### PR TITLE
fix(command): Command names from functions auto-naming

### DIFF
--- a/.codespell.words.ignore
+++ b/.codespell.words.ignore
@@ -1,0 +1,1 @@
+thirdparty

--- a/.gitignore
+++ b/.gitignore
@@ -230,9 +230,9 @@ tags
 
 # End of https://www.toptal.com/developers/gitignore/api/python,rust,vim,visualstudiocode
 
-# Ignore Setuptools VCS generated version file
-src/toolr/_version.py
-
 # Ignore the python-tools-scripts virtual environments
 .tools-venvs/
 .python-version
+
+# Ignore our own tools/ folder
+tools/

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,147 @@
+default: false
+
+# MD001/heading-increment : Heading levels should only increment by one level at a time : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md001.md
+MD001: true
+
+# MD003/heading-style : Heading style : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md003.md
+MD003:
+  style: "consistent"
+
+# MD004/ul-style : Unordered list style : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md004.md
+MD004:
+  style: "consistent"
+
+# MD005/list-indent : Inconsistent indentation for list items at the same level : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md005.md
+MD005: true
+
+# MD007/ul-indent : Unordered list indentation : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md007.md
+MD007:
+  indent: 4
+
+# MD009/no-trailing-spaces : Trailing spaces : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md009.md
+MD009: true
+
+# MD010/no-hard-tabs : Hard tabs : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md010.md
+MD010: true
+
+# MD011/no-reversed-links : Reversed link syntax : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md011.md
+MD011: true
+
+# MD012/no-multiple-blanks : Multiple consecutive blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md012.md
+MD012: true
+
+# MD014/commands-show-output : Dollar signs used before commands without showing output : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md014.md
+MD014: true
+
+# MD018/no-missing-space-atx : No space after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md018.md
+MD018: true
+
+# MD019/no-multiple-space-atx : Multiple spaces after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md019.md
+MD019: true
+
+# MD020/no-missing-space-closed-atx : No space inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md020.md
+MD020: true
+
+# MD021/no-multiple-space-closed-atx : Multiple spaces inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md021.md
+MD021: true
+
+# MD022/blanks-around-headings : Headings should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md022.md
+MD022: true
+
+# MD023/heading-start-left : Headings must start at the beginning of the line : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md023.md
+MD023: true
+
+# MD024/no-duplicate-heading : Multiple headings with the same content : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md024.md
+MD024:
+  siblings_only: true
+
+# MD025/single-title/single-h1 : Multiple top-level headings in the same document : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md025.md
+MD025: true
+
+# MD026/no-trailing-punctuation : Trailing punctuation in heading : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md026.md
+MD026: true
+
+# MD027/no-multiple-space-blockquote : Multiple spaces after blockquote symbol : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md027.md
+MD027: true
+
+# MD028/no-blanks-blockquote : Blank line inside blockquote : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md028.md
+MD028: true
+
+# MD029/ol-prefix : Ordered list item prefix : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md029.md
+MD029:
+  style: "ordered"
+
+# MD030/list-marker-space : Spaces after list markers : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md030.md
+MD030:
+  ul_single: 1
+  ol_single: 1
+  ul_multi: 1
+  ol_multi: 1
+
+# MD031/blanks-around-fences : Fenced code blocks should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md031.md
+MD031: true
+
+# MD032/blanks-around-lists : Lists should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md032.md
+MD032: true
+
+# MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md034.md
+MD034: true
+
+# MD035/hr-style : Horizontal rule style : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md035.md
+MD035: true
+
+# MD036/no-emphasis-as-heading : Emphasis used instead of a heading : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md036.md
+MD036: true
+
+# MD037/no-space-in-emphasis : Spaces inside emphasis markers : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md037.md
+MD037: true
+
+# MD038/no-space-in-code : Spaces inside code span elements : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md038.md
+MD038: true
+
+# MD039/no-space-in-links : Spaces inside link text : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md039.md
+MD039: true
+
+# MD040/fenced-code-language : Fenced code blocks should have a language specified : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md040.md
+MD040: true
+
+# MD042/no-empty-links : No empty links : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md042.md
+MD042: true
+
+# MD045/no-alt-text : Images should have alternate text (alt text) : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md045.md
+MD045: true
+
+# MD046/code-block-style : Code block style : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md046.md
+MD046:
+  style: "fenced"
+
+# MD047/single-trailing-newline : Files should end with a single newline character : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md047.md
+MD047: true
+
+# MD048/code-fence-style : Code fence style : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md048.md
+MD048:
+  style: "backtick"
+
+# MD049/emphasis-style : Emphasis style : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md049.md
+MD049:
+  style: "asterisk"
+
+# MD050/strong-style : Strong style : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md050.md
+MD050:
+  style: "consistent"
+
+# MD051/link-fragments : Link fragments should be valid : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md051.md
+MD051: true
+
+# MD053/link-image-reference-definitions : Link and image reference definitions should be needed : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md053.md
+MD053: true
+
+# MD054/link-image-style : Link and image style : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md054.md
+MD054: true
+
+# MD055/table-pipe-style : Table pipe style : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md055.md
+MD055:
+  style: "no_leading_or_trailing"
+
+# MD056/table-column-count : Table column count : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md056.md
+MD056: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,8 +66,18 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
+        args:
+          - --ignore-words=.codespell.words.ignore
         additional_dependencies:
           - tomli
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.18.1
+    hooks:
+      - id: markdownlint-cli2
+        args:
+          - --config=.markdownlint.yaml
+          - --fix
 
   - repo: local
     hooks:

--- a/README.md
+++ b/README.md
@@ -32,24 +32,31 @@ Organize commands into logical groups and subgroups using dot notation, providin
 
 Built-in support for rich text formatting and automatic help generation from docstrings and type annotations.
 
+### Third-Party Command Support
+
+Extend ToolR's functionality by installing packages that provide additional commands through Python entry points.
+
 ## Quick Start
 
 1. **Install ToolR**:
+
    ```bash
    python -m pip install toolr
    ```
 
 2. **Create a tools package** in your project root:
+
    ```bash
    mkdir tools
    touch tools/__init__.py
    ```
 
 3. **Write your first command** in `tools/example.py`:
+
    ```python
    from toolr import Context, command_group
 
-   group = registry.command_group("example", "Example Commands", "Example command group")
+   group = command_group("example", "Example Commands", "Example command group")
 
    @group.command
    def hello(ctx: Context, name: str = "World"):
@@ -62,6 +69,15 @@ Built-in support for rich text formatting and automatic help generation from doc
    ```
 
 4. **Run your command**:
+
    ```bash
    toolr example hello --name Alice
    ```
+
+## Advanced Usage
+
+### Third-Party Commands
+
+ToolR supports 3rd-party commands from installable Python packages. Create packages that extend ToolR's functionality by defining commands and registering them as entry points.
+
+See the [Advanced Topics section](https://s0undt3ch.github.io/ToolR/usage/#advanced-topics) in the documentation for detailed information about creating 3rd-party command packages.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img width="240px" src="imgs/toolr.png" alt="ToolR - AI Generated Logo"/>
+  <img width="240px" src="docs/imgs/toolr.png" alt="ToolR - AI Generated Logo"/>
 </h1>
 
 <h2 align="center">

--- a/docs/examples/files/function_name_conversion.py
+++ b/docs/examples/files/function_name_conversion.py
@@ -1,0 +1,49 @@
+"""Example demonstrating function name to command name conversion.
+
+This example shows how function names with underscores are automatically converted
+to command names with hyphens when using the @command decorator without specifying
+a name.
+"""
+
+from __future__ import annotations
+
+from toolr import Context
+from toolr import command_group
+
+# Create a command group
+tools = command_group(
+    "names",
+    "Examples for function name to command name conversion",
+    "Various examples for function name to command name conversion",
+)
+
+
+# Define commands using function names - they will be automatically converted
+@tools.command
+def simple_function(ctx: Context) -> None:  # -> simple-function
+    """A simple function."""
+
+
+@tools.command
+def function_with_underscores(ctx: Context) -> None:  # -> function-with-underscores
+    """A function with underscores in the name."""
+
+
+@tools.command
+def multiple_underscores_in_name(ctx: Context) -> None:  # -> multiple-underscores-in-name
+    """A function with multiple underscores."""
+
+
+@tools.command
+def _leading_underscore(ctx: Context) -> None:  # -> -leading-underscore
+    """A function with a leading underscore."""
+
+
+@tools.command
+def trailing_underscore_(ctx: Context) -> None:  # -> trailing-underscore-
+    """A function with a trailing underscore."""
+
+
+@tools.command
+def _both_underscores_(ctx: Context) -> None:  # -> -both-underscores-
+    """A function with both leading and trailing underscores."""

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,6 +1,5 @@
 Here's some basic usage examples to start off of.
 
-
 ## Simple Command
 
 The most basic command is a function with a context parameter:
@@ -10,6 +9,7 @@ The most basic command is a function with a context parameter:
 ```
 
 Run with:
+
 ```bash
 toolr greeting hello --name Alice
 # Output: Hello, Alice!
@@ -22,6 +22,7 @@ toolr greeting hello --name Alice
 ```
 
 Run with:
+
 ```bash
 toolr math add 5 3
 # Output: 5 + 3 = 8
@@ -34,6 +35,7 @@ toolr math add 5 3
 ```
 
 Run with:
+
 ```bash
 toolr example process --verbose --dry-run
 # Output: Verbose mode enabled
@@ -47,6 +49,7 @@ toolr example process --verbose --dry-run
 ```
 
 Run with:
+
 ```bash
 toolr files process-files file1.txt file2.txt file3.txt
 # Output: Processing file1.txt...
@@ -69,6 +72,42 @@ The `ctx` parameter provides access to useful utilities:
 ```
 
 Run with:
+
 ```bash
 toolr system info
+```
+
+## Function Name Conversion
+
+ToolR automatically converts Python function names with underscores to command names with hyphens:
+
+```python title="tools/function_names.py"
+--8<-- "docs/examples/files/function_name_conversion.py"
+```
+
+This example demonstrates how function names like `function_with_underscores` become command names like `function-with-underscores` in the CLI.
+
+```bash
+toolr names -h
+Usage: toolr names [-h] {simple-function,function-with-underscores,multiple-underscores-in-name,-leading-underscore,trailing-underscore-,-both-underscores-} ...
+
+Various examples for function name to command name conversion
+
+Options:
+  -h, --help            show this help message and exit
+
+Examples For Function Name To Command Name Conversion:
+  Various examples for function name to command name conversion
+
+  {simple-function,function-with-underscores,multiple-underscores-in-name,-leading-underscore,trailing-underscore-,-both-underscores-}
+    simple-function     A simple function.
+    function-with-underscores
+                        A function with underscores in the name.
+    multiple-underscores-in-name
+                        A function with multiple underscores.
+    -leading-underscore
+                        A function with a leading underscore.
+    trailing-underscore-
+                        A function with a trailing underscore.
+    -both-underscores-  A function with both leading and trailing underscores.
 ```

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -28,8 +28,10 @@ To verify the installation, run:
 ```bash
 toolr --help
 ```
+
 You should see the ToolR help output with available commands.
-```
+
+```console
 Usage: toolr [-h] [--version] [--timestamps | --no-timestamps] [--quiet | --debug] [--timeout SECONDS] [--no-output-timeout-secs SECONDS] {} ...
 
 In-project CLI tooling support
@@ -61,7 +63,6 @@ Commands:
 More information about ToolR can be found at https://github.com/s0undt3ch/toolr
 ```
 
-
 ## Development Installation
 
 For development or to use the latest version:
@@ -74,3 +75,15 @@ cd toolr
 # Install in development mode
 uv sync --dev
 ```
+
+## Third-Party Command Packages
+
+ToolR supports 3rd-party command packages that extend its functionality. These packages are automatically discovered when installed alongside ToolR.
+
+To install a 3rd-party command package:
+
+```bash
+python -m pip install <package-name>
+```
+
+The package's commands will be automatically available in the ToolR CLI. See the [Advanced Topics section](../usage/index.md#advanced-topics) for information about creating your own 3rd-party command packages.

--- a/docs/reference/toolr/testing.md
+++ b/docs/reference/toolr/testing.md
@@ -1,0 +1,3 @@
+# toolr.testing
+
+::: toolr.testing

--- a/docs/usage/files/example2.py
+++ b/docs/usage/files/example2.py
@@ -22,12 +22,12 @@ from typing import NoReturn
 
 from toolr import Context
 from toolr import arg
-from toolr import registry
+from toolr import command_group
 
-command_group = registry.command_group("example", title="Example", docstring=__doc__)
+group = command_group("example", title="Example", docstring=__doc__)
 
 
-@command_group.command
+@group.command
 def hello(ctx: Context) -> NoReturn:
     """
     Say hello.
@@ -37,7 +37,7 @@ def hello(ctx: Context) -> NoReturn:
     ctx.info("Hello, world!")
 
 
-@command_group.command("goodbye")
+@group.command("goodbye")
 def say_goodbye(ctx: Context, name: str | None = None) -> NoReturn:
     """
     Say goodbye.
@@ -50,7 +50,7 @@ def say_goodbye(ctx: Context, name: str | None = None) -> NoReturn:
     ctx.info(f"Goodbye, {name}!")
 
 
-@command_group.command
+@group.command
 def multiply(ctx: Context, a: int, b: int, verbose: bool = False) -> NoReturn:
     """
     Multiply two numbers.
@@ -74,7 +74,7 @@ class Operation(StrEnum):
     DIVIDE = "divide"
 
 
-@command_group.command
+@group.command
 def math(
     ctx: Context,
     a: int,
@@ -102,6 +102,9 @@ def math(
             value = a * b
             log_msg = f"{a} * {b} = {value}"
         case Operation.DIVIDE:
+            if b == 0:
+                ctx.error("Division by zero!")
+                return
             value = a / b
             log_msg = f"{a} / {b} = {value}"
         case _:
@@ -112,10 +115,12 @@ def math(
         ctx.info(value)
 
 
-@command_group.command
+@group.command
 def py_version(ctx: Context) -> NoReturn:
     """
-    Print the Python version.
+    Show Python version.
+
+    This command demonstrates how to run subprocess commands and capture their output.
     """
     python = shutil.which("python")
     ret = ctx.run(python, "--version", capture_output=True, stream_output=False)

--- a/mise.toml
+++ b/mise.toml
@@ -3,9 +3,10 @@ python = "3.11.12"
 actionlint = "latest"
 shellcheck = "latest"
 rust = { version = "stable" }
+uv = { version = "latest" }
 
 [env]
-'_'.python.venv = {path = ".venv", create = true, uv_create_args = ['--seed']}
+_.python.venv = { path = ".venv", create = true, uv_create_args = ['--seed'] }
 
 [settings]
 python.uv_venv_auto = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,8 @@ addopts = [
   "--strict-config",
   "--strict-markers",
 ]
-[tool.uv]
 
+[tool.uv]
 [dependency-groups]
 dev = [
     "attrs>=25.3.0",
@@ -92,6 +92,7 @@ dev = [
     "pytest>=8.3.5",
     "pytest-skip-markers>=1.5.2",
     "pytest-subtests>=0.14.2",
+    "3rd-party-pkg @ file://${PROJECT_ROOT}/tests/support/3rd-party-pkg",
 ]
 docs = [
     "markdown-include>=0.8.1",

--- a/python/toolr/__init__.py
+++ b/python/toolr/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 try:
     import importlib.metadata
 
@@ -10,16 +8,7 @@ except ImportError:
     __version__ = "0.0.0.not-installed"
 
 from toolr._context import Context
-from toolr._registry import registry
+from toolr._registry import command_group
 from toolr.utils._signature import arg
 
-if TYPE_CHECKING:
-    from toolr._registry import CommandRegistry
-
-    assert registry is not None
-    assert isinstance(registry, CommandRegistry)
-
-# Create a command group alias
-command_group = registry.command_group
-
-__all__ = ["Context", "__version__", "arg", "command_group", "registry"]
+__all__ = ["Context", "__version__", "arg", "command_group"]

--- a/python/toolr/__main__.py
+++ b/python/toolr/__main__.py
@@ -11,7 +11,7 @@ from multiprocessing import freeze_support
 from typing import NoReturn
 
 from toolr._parser import Parser
-from toolr._registry import registry
+from toolr._registry import CommandRegistry
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +33,7 @@ def main() -> NoReturn:  # type: ignore[misc]
             raise exc from None
 
     # Let's discover and build the command registry
+    registry = CommandRegistry()
     registry.discover_and_build(parser)
 
     parser.parse_args()

--- a/python/toolr/_registry.py
+++ b/python/toolr/_registry.py
@@ -6,7 +6,7 @@ import os
 import pkgutil
 from argparse import _SubParsersAction
 from collections.abc import Callable
-from operator import itemgetter
+from operator import attrgetter
 from pathlib import Path
 from types import FunctionType
 from typing import TYPE_CHECKING
@@ -35,10 +35,9 @@ class CommandGroup(Struct, frozen=True):
     name: str
     title: str
     description: str
-    registry: CommandRegistry
     long_description: str | None = None
     parent: str | None = None
-    _subparsers: _SubParsersAction | None = None
+    _commands: list[tuple[str, Callable[..., Any]]] = field(default_factory=list)
 
     @property
     def full_name(self) -> str:
@@ -71,7 +70,7 @@ class CommandGroup(Struct, frozen=True):
             assert isinstance(name, str)
 
         def decorator(func: F) -> F:
-            self.registry._pending_commands.append((self.full_name, name, func))  # noqa: SLF001
+            self._commands.append((name, func))
             return func
 
         return decorator
@@ -86,15 +85,13 @@ class CommandGroup(Struct, frozen=True):
     ) -> CommandGroup:
         """Create a nested command group within this group.
 
-        This is a wrapper around the [CommandRegistry.command_group][toolr._registry.CommandRegistry.command_group]
-        method that passes this group's full name as the parent.
-
-        See [command_group][toolr._registry.CommandRegistry.command_group] for more details.
+        This is a wrapper around the [command_group][toolr._registry.command_group] function
+        that sets the parent to this group's full name.
 
         Returns:
             A CommandGroup instance
         """
-        return self.registry.command_group(
+        return command_group(
             name,
             title,
             description=description,
@@ -107,8 +104,6 @@ class CommandGroup(Struct, frozen=True):
 class CommandRegistry(Struct, frozen=True):
     """Registry for CLI commands and their subcommands."""
 
-    _command_groups: dict[str, CommandGroup] = field(default_factory=dict)
-    _pending_commands: list[tuple[str, str, Callable[..., Any]]] = field(default_factory=list)
     _built: bool = False
     _parser: Parser | None = None
 
@@ -128,6 +123,11 @@ class CommandRegistry(Struct, frozen=True):
         structs.force_setattr(self, "_parser", parser)
 
     def _discover_commands(self) -> None:
+        """Discover both project local as well as 3rd party commands."""
+        self._discover_local_commands()
+        self._discover_entry_points_commands()
+
+    def _discover_local_commands(self) -> None:
         """Recursively discover and import command modules from tools/."""
         tools_dir = self.parser.repo_root / "tools"
         if not tools_dir.is_dir():
@@ -149,63 +149,11 @@ class CommandRegistry(Struct, frozen=True):
 
         import_commands(tools_dir, "tools")
 
-    def command_group(
-        self,
-        name: str,
-        title: str,
-        description: str | None = None,
-        long_description: str | None = None,
-        docstring: str | None = None,
-        parent: str | None = None,
-    ) -> CommandGroup:
-        """Register a new command group.
-
-        If you pass ``docstring``, you won't be allowed to pass ``description`` or ``long_description``.
-        Those will be parsed by [docstring-parser](https://pypi.org/project/docstring-parser/).
-        The first line of the docstring will be used as the description, the rest will be used as the long description.
-
-        Args:
-            name: Name of the command group
-            title: Title for the command group
-            description: Description for the command group
-            long_description: Long description for the command group
-            docstring: Docstring for the command group
-            parent: Optional parent command path using dot notation (e.g. "tools.docker.build")
-
-        Returns:
-            A CommandGroup instance
-
-        """
-        if parent is None:
-            parent = "tools"
-
-        if docstring is not None:
-            if description is not None or long_description is not None:
-                err_msg = "You can't pass both docstring and description or long_description"
-                raise ValueError(err_msg)
-            parsed_docstring = parse_docstring(docstring)
-            description = parsed_docstring.short_description
-            long_description = parsed_docstring.long_description
-        elif description is None:
-            err_msg = "You must at least pass either the 'docstring' or 'description' argument"
-            raise ValueError(err_msg)
-
-        if TYPE_CHECKING:
-            assert description is not None
-
-        # Create the command group
-        group = CommandGroup(
-            name=name,
-            title=title,
-            description=description,
-            registry=self,
-            parent=parent,
-            long_description=long_description,
-        )
-
-        # Store the command group for later parser building
-        self._command_groups[group.full_name] = group
-        return group
+    def _discover_entry_points_commands(self) -> None:
+        """Discover and import command modules from entry points."""
+        for entry_point in importlib.metadata.entry_points(group="toolr.tools"):
+            log.debug("Importing commands from entry point %s", entry_point.module)
+            entry_point.load()
 
     def _build_parsers(self) -> None:
         """Build the argument parsers from the registered command groups and commands."""
@@ -215,10 +163,9 @@ class CommandRegistry(Struct, frozen=True):
         # Create a hierarchy of subparsers based on the dot notation paths
         parser_hierarchy: dict[str, _SubParsersAction] = {}
 
-        for full_name, group in sorted(self._command_groups.items()):
-            # Sanity check
-            assert group.full_name == full_name  # noqa: S101
+        collector = get_command_group_list()
 
+        for group in sorted(collector, key=attrgetter("full_name")):
             if group.parent == "tools":
                 # Top-level command group
                 parent_subparsers = self.parser.subparsers
@@ -250,37 +197,25 @@ class CommandRegistry(Struct, frozen=True):
             subparsers_description = cast(
                 "str", Markdown(group.long_description or group.description, style="argparse.text")
             )
+            group_full_name = group.full_name
             subparsers = group_parser.add_subparsers(
                 title=group.title,
                 description=subparsers_description,
-                dest=f"{full_name.replace('.', '_')}_command",
+                dest=f"{group_full_name.replace('.', '_')}_command",
             )
 
-            parser_hierarchy[full_name] = subparsers
+            parser_hierarchy[group_full_name] = subparsers
 
-            # Store reference in the group object
-            structs.force_setattr(group, "_subparsers", subparsers)
-
-        # Now add all the pending commands to their respective groups
-        for group_path, command_name, func in sorted(self._pending_commands, key=itemgetter(0)):
-            if group_path not in parser_hierarchy:
-                # This shouldn't happen with our sorting and because we also check
-                # for this when building the subparsers.
-                err_msg = (
-                    f"Command group '{group_path}' for command '{command_name}' does not exist. Please check your code."
+            # Now add all the pending commands to their respective groups
+            for command_name, func in group._commands:  # noqa: SLF001
+                signature = get_signature(func)
+                cmd_parser = subparsers.add_parser(
+                    command_name,
+                    help=signature.short_description,
+                    description=signature.long_description,
+                    formatter_class=self.parser.formatter_class,
                 )
-                raise ValueError(err_msg)
-
-            signature = get_signature(func)
-
-            subparsers = parser_hierarchy[group_path]
-            cmd_parser = subparsers.add_parser(
-                command_name,
-                help=signature.short_description,
-                description=signature.long_description,
-                formatter_class=self.parser.formatter_class,
-            )
-            signature.setup_parser(cmd_parser)
+                signature.setup_parser(cmd_parser)
 
         structs.force_setattr(self, "_built", True)  # noqa: FBT003
 
@@ -292,5 +227,75 @@ class CommandRegistry(Struct, frozen=True):
         self._build_parsers()
 
 
-# Global registry instance
-registry = CommandRegistry()
+def get_command_group_list() -> list[CommandGroup]:
+    """Get the list of collected command groups.
+
+    This function acts as a singleton for the list of collected command groups.
+
+    Returns:
+        A list of CommandGroup instances
+    """
+    try:
+        collector = get_command_group_list.__command_groups__  # type: ignore[attr-defined]
+    except AttributeError:
+        command_groups: list[CommandGroup] = []
+        collector = get_command_group_list.__command_groups__ = command_groups  # type: ignore[attr-defined]
+    return collector
+
+
+def command_group(
+    name: str,
+    title: str,
+    description: str | None = None,
+    long_description: str | None = None,
+    docstring: str | None = None,
+    parent: str | None = None,
+) -> CommandGroup:
+    """Register a new command group.
+
+    If you pass ``docstring``, you won't be allowed to pass ``description`` or ``long_description``.
+    Those will be parsed by [docstring-parser](https://pypi.org/project/docstring-parser/).
+    The first line of the docstring will be used as the description, the rest will be used as the long description.
+
+    Args:
+        name: Name of the command group
+        title: Title for the command group
+        description: Description for the command group
+        long_description: Long description for the command group
+        docstring: Docstring for the command group
+        parent: Optional parent command path using dot notation (e.g. "tools.docker.build")
+
+    Returns:
+        A CommandGroup instance
+
+    """
+    if parent is None:
+        parent = "tools"
+
+    if docstring is not None:
+        if description is not None or long_description is not None:
+            err_msg = "You can't pass both docstring and description or long_description"
+            raise ValueError(err_msg)
+        parsed_docstring = parse_docstring(docstring)
+        description = parsed_docstring.short_description
+        long_description = parsed_docstring.long_description
+    elif description is None:
+        err_msg = "You must at least pass either the 'docstring' or 'description' argument"
+        raise ValueError(err_msg)
+
+    if TYPE_CHECKING:
+        assert description is not None
+
+    # Create the command group
+    group = CommandGroup(
+        name=name,
+        title=title,
+        description=description,
+        parent=parent,
+        long_description=long_description,
+    )
+
+    collector = get_command_group_list()
+    collector.append(group)
+
+    return group

--- a/python/toolr/_registry.py
+++ b/python/toolr/_registry.py
@@ -65,7 +65,7 @@ class CommandGroup(Struct, frozen=True):
         if isinstance(name, FunctionType):
             # If we were not passed a name in the decorator call, we're being called with a function
             # and we need to use the function name as the command name
-            return self.command(name.__name__)(name)
+            return self.command(name.__name__.replace("_", "-"))(name)
 
         if TYPE_CHECKING:
             assert isinstance(name, str)

--- a/python/toolr/testing.py
+++ b/python/toolr/testing.py
@@ -1,32 +1,41 @@
+"""
+Utilities for testing ToolR and supported commands.
+"""
+
 from __future__ import annotations
 
 import sys
 from pathlib import Path
 from types import ModuleType
+from typing import Self
 from unittest.mock import _patch
 from unittest.mock import patch
 
-import pytest
 from attrs import define
 from attrs import field
 
 from toolr._parser import Parser
+from toolr._registry import CommandGroup
 from toolr._registry import CommandRegistry
 
 
 @define(slots=True, frozen=True)
-class RegistryTestCase:
-    test_case_dir: Path
+class CommandsTester:
+    """
+    Helper class to simplify testing command discovery.
+    """
+
+    search_path: Path
     parser: Parser = field(init=False, repr=False)
     registry: CommandRegistry = field(init=False, repr=False)
     sys_path: list[str] = field(init=False, repr=False)
     sys_modules: dict[str, ModuleType] = field(init=False, repr=False)
-    registry_patcher: _patch = field(init=False, repr=False)
+    command_group_collector: list[CommandGroup] = field(init=False, repr=False, factory=list)
     command_group_patcher: _patch = field(init=False, repr=False)
 
     @parser.default
     def _default_parser(self) -> Parser:
-        return Parser(repo_root=self.test_case_dir)
+        return Parser(repo_root=self.search_path)
 
     @registry.default
     def _default_registry(self) -> CommandRegistry:
@@ -38,32 +47,33 @@ class RegistryTestCase:
 
     @sys_modules.default
     def _default_sys_modules(self) -> dict[str, ModuleType]:
-        return sys.modules.copy()
-
-    @registry_patcher.default
-    def _default_registry_patcher(self) -> _patch:
-        return patch("toolr.registry", self.registry)
+        # Copy sys.modules but exclude our testing thirdparty package
+        return {name: sys.modules[name] for name in sys.modules if not name.startswith(("tools.", "thirdparty"))}
 
     @command_group_patcher.default
     def _default_command_group_patcher(self) -> _patch:
-        return patch("toolr.command_group", self.registry.command_group)
+        return patch("toolr._registry.get_command_group_list", return_value=self.command_group_collector)
 
-    def __enter__(self):
-        self.registry_patcher.start()
+    def collected_command_groups(self) -> dict[str, CommandGroup]:
+        """
+        Get the collected command groups.
+        """
+        return {group.full_name: group for group in self.command_group_collector}
+
+    def __enter__(self) -> Self:
+        """
+        Enter the context manager.
+        """
         self.command_group_patcher.start()
-        sys.path.insert(0, str(self.test_case_dir))
+        sys.path.insert(0, str(self.search_path))
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.registry_patcher.stop()
+    def __exit__(self, *args: object) -> None:
+        """
+        Exit the context manager.
+        """
         self.command_group_patcher.stop()
+        self.command_group_collector.clear()
         sys.path[:] = self.sys_path
         sys.modules.clear()
         sys.modules.update(self.sys_modules)
-
-
-@pytest.fixture
-def registry(tmp_path: Path) -> CommandRegistry:
-    """Create a registry with a parser."""
-    parser = Parser(repo_root=tmp_path)
-    return CommandRegistry(_parser=parser)

--- a/tests/cli/test_boolean_arguments.py
+++ b/tests/cli/test_boolean_arguments.py
@@ -97,25 +97,34 @@ def test_boolean_flag_with_true_default(cli_parser):
     assert isinstance(args.quiet, bool)
 
 
-def test_multiple_boolean_flags(cli_parser):
+def test_multiple_boolean_flags(cli_parser, capfd):
     """Test multiple boolean flags."""
     # Test all flags
     args = cli_parser.parse_args(["test", "multiple-flags", "--verbose", "--quiet", "--debug"])
     assert args.verbose is True
     assert args.quiet is True
     assert args.debug is True
+    out, err = capfd.readouterr()
+    assert not err
+    assert not out
 
     # Test some flags
     args = cli_parser.parse_args(["test", "multiple-flags", "--verbose", "--debug"])
     assert args.verbose is True
     assert args.quiet is False
     assert args.debug is True
+    out, err = capfd.readouterr()
+    assert "CLI parsed options Namespace" in err
+    assert not out
 
     # Test no flags
     args = cli_parser.parse_args(["test", "multiple-flags"])
     assert args.verbose is False
     assert args.quiet is False
     assert args.debug is False
+    out, err = capfd.readouterr()
+    assert "Tools executing" in err
+    assert not out
 
 
 @pytest.mark.parametrize("alias", ["--verbose", "--verb", "-v"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from toolr.testing import CommandsTester
+
+
+@pytest.fixture
+def commands_tester(tmp_path: Path) -> Iterator[CommandsTester]:
+    """Create a commands tester."""
+    commands_tester = CommandsTester(search_path=tmp_path)
+    with commands_tester:
+        commands_tester.registry.discover_and_build()
+        yield commands_tester

--- a/tests/parser/test_parser_errors.py
+++ b/tests/parser/test_parser_errors.py
@@ -1,0 +1,50 @@
+"""Tests for parser error cases."""
+
+from __future__ import annotations
+
+import pytest
+from msgspec import structs
+
+from toolr._parser import Parser
+
+
+def test_parser_run_without_parse_args():
+    """Test that run() raises error when parse_args() wasn't called."""
+    parser = Parser()
+
+    with pytest.raises(RuntimeError, match="parser.parse_args\\(\\) was not called"):
+        parser.run()
+
+
+def test_parser_parse_args_no_command(capfd):
+    """Test parse_args when no command is provided."""
+    parser = Parser()
+
+    # Parse args with no command
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+    out, err = capfd.readouterr()
+    assert "error: the following arguments are required: command" in err
+    assert not out
+
+
+def test_parser_getattr_proxy():
+    """Test that __getattr__ proxies unknown attributes to parser."""
+    parser = Parser()
+
+    # Test that unknown attributes are proxied to the underlying parser
+    # The parser should have a 'prog' attribute
+    assert hasattr(parser, "prog")
+    assert parser.prog == "toolr"
+
+
+def test_parser_getattr_options():
+    """Test that __getattr__ doesn't proxy 'options' attribute."""
+    parser = Parser()
+
+    # Set options directly using force_setattr
+    structs.force_setattr(parser, "options", "test_options")
+
+    # Should return the direct attribute, not proxy
+    assert parser.options == "test_options"

--- a/tests/registry/cases/mixed/tools/deployment.py
+++ b/tests/registry/cases/mixed/tools/deployment.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from toolr import Context
-from toolr import registry
+from toolr import command_group
 
 # Create main deployment group
-deployment_group = registry.command_group("deployment", "Deployment Tools", "Application deployment and management")
+deployment_group = command_group("deployment", "Deployment Tools", "Application deployment and management")
 
 
 # Simple commands directly on the deployment group

--- a/tests/registry/cases/mixed/tools/utils.py
+++ b/tests/registry/cases/mixed/tools/utils.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from toolr import Context
-from toolr import registry
+from toolr import command_group
 
 # Create a simple utilities group
-utils_group = registry.command_group("utils", "Utilities", "General utility commands")
+utils_group = command_group("utils", "Utilities", "General utility commands")
 
 
 @utils_group.command("clean")

--- a/tests/registry/cases/nested/tools/docker/__init__.py
+++ b/tests/registry/cases/nested/tools/docker/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from toolr import registry
+from toolr import command_group
 
 # Create the main docker command group
-docker_group = registry.command_group("docker", "Docker Commands", "Docker container and image management tools")
+docker_group = command_group("docker", "Docker Commands", "Docker container and image management tools")

--- a/tests/registry/cases/simple/tools/docker.py
+++ b/tests/registry/cases/simple/tools/docker.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from toolr import Context
-from toolr import registry
+from toolr import command_group
 
 # Create a simple command group
-docker_group = registry.command_group("docker", "Docker Commands", "Docker-related tools")
+docker_group = command_group("docker", "Docker Commands", "Docker-related tools")
 
 
 @docker_group.command("build")

--- a/tests/registry/test_command_group_errors.py
+++ b/tests/registry/test_command_group_errors.py
@@ -1,0 +1,43 @@
+"""Tests for command group error cases."""
+
+from __future__ import annotations
+
+import pytest
+
+from toolr import command_group
+
+
+def test_command_group_without_description_or_docstring():
+    """Test command_group error when neither description nor docstring provided."""
+    with pytest.raises(ValueError, match="You must at least pass either the 'docstring' or 'description' argument"):
+        command_group("test", "Test Group")
+
+
+def test_command_group_with_both_docstring_and_description():
+    """Test command_group error when both docstring and description provided."""
+    with pytest.raises(ValueError, match="You can't pass both docstring and description or long_description"):
+        command_group("test", "Test Group", description="Description", docstring="Docstring")
+
+
+def test_command_group_with_docstring_parsing():
+    """Test command_group with docstring parsing."""
+    group = command_group(
+        "docstring_test", "Docstring Test", docstring="Short description.\n\nLong description with more details."
+    )
+
+    assert group.description == "Short description."
+    assert group.long_description == "Long description with more details."
+
+
+def test_command_group_full_name_with_parent():
+    """Test CommandGroup full_name property with parent."""
+    group = command_group("child", "Child Group", "A child group", parent="tools.parent")
+
+    assert group.full_name == "tools.parent.child"
+
+
+def test_command_group_full_name_without_parent():
+    """Test CommandGroup full_name property without parent."""
+    group = command_group("test", "Test Group", "A test group")
+
+    assert group.full_name == "tools.test"

--- a/tests/registry/test_discovery.py
+++ b/tests/registry/test_discovery.py
@@ -3,48 +3,46 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
-from toolr import Context
-
-from .conftest import RegistryTestCase
+from toolr.testing import CommandsTester
 
 CASES_PATH = Path(__file__).parent / "cases"
 
 
-def test_discover_commands_no_tools_dir(tmp_path):
+def test_discover_commands_no_tools_dir(tmp_path: Path):
     """Test discovery when tools directory doesn't exist."""
-    with RegistryTestCase(tmp_path) as test_case:
-        registry = test_case.registry
+    with patch("importlib.metadata.entry_points", return_value=[]):
+        with CommandsTester(search_path=tmp_path) as commands_tester:
+            command_groups = commands_tester.collected_command_groups()
 
-        # Should not raise an error
-        registry._discover_commands()
-
-        # Should have no command groups or pending commands
-        assert len(registry._command_groups) == 0
-        assert len(registry._pending_commands) == 0
+    # Should not raise an error
+    assert not command_groups
 
 
 def test_discover_simple_case():
     """Test discovery with the simple test case."""
     # Point to our test case directory
     test_case_dir = CASES_PATH / "simple"
-    with RegistryTestCase(test_case_dir) as test_case:
-        registry = test_case.registry
+    with CommandsTester(test_case_dir) as tester:
+        registry = tester.registry
 
         # Run discovery
         registry._discover_commands()
 
         # Should have discovered command groups
-        assert len(registry._command_groups) >= 2  # docker and git groups
-        assert "tools.docker" in registry._command_groups
-        assert "tools.git" in registry._command_groups
+        command_groups = tester.collected_command_groups()
+        assert len(command_groups) >= 2  # docker and git groups
+        assert "tools.docker" in command_groups
+        assert "tools.git" in command_groups
 
         # Should have pending commands
-        assert len(registry._pending_commands) >= 4  # 2 docker + 2 git commands
+        assert len(command_groups["tools.git"]._commands) == 2
+        assert len(command_groups["tools.docker"]._commands) == 2
 
         # Check specific command groups
-        docker_group = registry._command_groups["tools.docker"]
-        git_group = registry._command_groups["tools.git"]
+        docker_group = command_groups["tools.docker"]
+        git_group = command_groups["tools.git"]
 
         assert docker_group.title == "Docker Commands"
         assert git_group.title == "Git Commands"
@@ -53,22 +51,23 @@ def test_discover_simple_case():
 def test_discover_nested_case():
     """Test discovery with nested command groups."""
     test_case_dir = CASES_PATH / "nested"
-    with RegistryTestCase(test_case_dir) as test_case:
-        registry = test_case.registry
+    with CommandsTester(test_case_dir) as tester:
+        registry = tester.registry
 
         # Run discovery
         registry._discover_commands()
 
         # Should have discovered nested command groups
-        assert "tools.docker" in registry._command_groups
-        assert "tools.docker.build" in registry._command_groups
-        assert "tools.docker.compose" in registry._command_groups
+        command_groups = tester.collected_command_groups()
+        assert "tools.docker" in command_groups
+        assert "tools.docker.build" in command_groups
+        assert "tools.docker.compose" in command_groups
 
         # Check nested group relationships
-        docker_group = registry._command_groups["tools.docker"]
+        docker_group = command_groups["tools.docker"]
         assert docker_group
-        build_group = registry._command_groups["tools.docker.build"]
-        compose_group = registry._command_groups["tools.docker.compose"]
+        build_group = command_groups["tools.docker.build"]
+        compose_group = command_groups["tools.docker.compose"]
 
         assert build_group.parent == "tools.docker"
         assert compose_group.parent == "tools.docker"
@@ -79,202 +78,21 @@ def test_discover_nested_case():
 def test_discover_mixed_case():
     """Test discovery with mixed command structures."""
     test_case_dir = CASES_PATH / "mixed"
-    with RegistryTestCase(test_case_dir) as test_case:
-        registry = test_case.registry
+    with CommandsTester(test_case_dir) as tester:
+        registry = tester.registry
 
         # Run discovery
         registry._discover_commands()
 
         # Should have top-level groups
-        assert "tools.deployment" in registry._command_groups
-        assert "tools.utils" in registry._command_groups
+        command_groups = tester.collected_command_groups()
+        assert "tools.deployment" in command_groups
+        assert "tools.utils" in command_groups
 
         # Should have nested groups
-        assert "tools.deployment.k8s" in registry._command_groups
-        assert "tools.deployment.aws" in registry._command_groups
+        assert "tools.deployment.k8s" in command_groups
+        assert "tools.deployment.aws" in command_groups
 
         # Check that we have both top-level and nested commands
-        deployment_commands = [
-            full_name for (full_name, _, _) in registry._pending_commands if full_name == "tools.deployment"
-        ]
-        k8s_commands = [
-            full_name for (full_name, _, _) in registry._pending_commands if full_name == "tools.deployment.k8s"
-        ]
-
-        assert len(deployment_commands) >= 2  # status, rollback
-        assert len(k8s_commands) >= 2  # deploy, scale
-
-
-def test_build_parsers_empty_registry(registry):
-    """Test building parsers with an empty registry."""
-    # Verify initial state
-    assert not registry._built
-    assert len(registry._command_groups) == 0
-    assert len(registry._pending_commands) == 0
-
-    # Building parsers should complete without errors
-    registry._build_parsers()
-
-    # Should be marked as built
-    assert registry._built
-    # Should still have no command groups or pending commands
-    assert len(registry._command_groups) == 0
-    assert len(registry._pending_commands) == 0
-
-
-def test_build_simple_command_group(registry):
-    """Test building parsers for a simple command group."""
-
-    # Create a simple command group with a command
-    group = registry.command_group("test", "Test", "Test description")
-
-    @group.command("hello")
-    def hello_cmd(ctx: Context):
-        """Say hello."""
-
-    # Verify initial state
-    assert not registry._built
-    assert len(registry._command_groups) == 1
-    assert len(registry._pending_commands) == 1
-    assert "tools.test" in registry._command_groups
-
-    # Building parsers should complete without errors
-    registry._build_parsers()
-
-    # Should be marked as built
-    assert registry._built
-    # Command groups and commands should still be registered
-    assert len(registry._command_groups) == 1
-    assert len(registry._pending_commands) == 1
-    # Verify the command group details
-    test_group = registry._command_groups["tools.test"]
-    assert test_group.name == "test"
-    assert test_group.title == "Test"
-    assert test_group.description == "Test description"
-
-
-def test_build_nested_command_groups(registry):
-    """Test building parsers for nested command groups."""
-
-    # Create nested command groups
-    parent = registry.command_group("parent", "Parent", "Parent desc")
-    child = parent.command_group("child", "Child", "Child desc")
-
-    @parent.command("parent_cmd")
-    def parent_cmd(ctx: Context):
-        """Parent command."""
-
-    @child.command("child_cmd")
-    def child_cmd(ctx: Context):
-        """Child command."""
-
-    # Verify initial state
-    assert not registry._built
-    assert len(registry._command_groups) == 2  # parent and child
-    assert len(registry._pending_commands) == 2  # parent_cmd and child_cmd
-    assert "tools.parent" in registry._command_groups
-    assert "tools.parent.child" in registry._command_groups
-
-    # Building parsers should complete without errors
-    registry._build_parsers()
-
-    # Should be marked as built
-    assert registry._built
-    # Verify nested structure is maintained
-    parent_group = registry._command_groups["tools.parent"]
-    child_group = registry._command_groups["tools.parent.child"]
-    assert parent_group.name == "parent"
-    assert child_group.name == "child"
-    assert child_group.parent == "tools.parent"
-    assert child_group.full_name == "tools.parent.child"
-
-
-def test_build_parsers_called_once(registry):
-    """Test that _build_parsers can be called multiple times safely."""
-
-    group = registry.command_group("test", "Test", "Test desc")
-
-    @group.command("cmd")
-    def test_cmd(ctx: Context):
-        """Test command."""
-
-    # Verify initial state
-    assert not registry._built
-    assert len(registry._command_groups) == 1
-    assert len(registry._pending_commands) == 1
-
-    # Call build_parsers first time
-    registry._build_parsers()
-    assert registry._built
-
-    # State should remain the same after first build
-    first_build_groups = len(registry._command_groups)
-    first_build_commands = len(registry._pending_commands)
-
-    # Call build_parsers second time
-    registry._build_parsers()
-
-    # Should still be built and state should be unchanged
-    assert registry._built
-    assert len(registry._command_groups) == first_build_groups
-    assert len(registry._pending_commands) == first_build_commands
-
-
-def test_discover_and_build_integration():
-    """Test the full discover_and_build integration."""
-    # Use the simple test case for real integration testing
-    test_case_dir = CASES_PATH / "simple"
-    with RegistryTestCase(test_case_dir) as test_case:
-        registry = test_case.registry
-
-        # Verify initial state
-        assert not registry._built
-        assert len(registry._command_groups) == 0
-        assert len(registry._pending_commands) == 0
-
-        # Run full discover and build
-        registry.discover_and_build()
-
-        # Should be marked as built
-        assert registry._built
-
-        # Should have discovered command groups from the test case
-        assert len(registry._command_groups) >= 2  # docker and git groups
-        assert "tools.docker" in registry._command_groups
-        assert "tools.git" in registry._command_groups
-
-        # Should have discovered commands
-        assert len(registry._pending_commands) >= 4  # 2 docker + 2 git commands
-
-
-def test_discover_and_build_with_manual_groups(registry):
-    """Test discover_and_build works with manually created groups."""
-
-    # Create some command groups manually before discovery
-    group1 = registry.command_group("group1", "Group 1", "Description 1")
-    group2 = registry.command_group("group2", "Group 2", "Description 2")
-
-    @group1.command("cmd1")
-    def cmd1(ctx: Context):
-        """Command 1."""
-
-    @group2.command("cmd2")
-    def cmd2(ctx: Context):
-        """Command 2."""
-
-    # Verify initial state
-    assert not registry._built
-    assert len(registry._command_groups) == 2
-    assert len(registry._pending_commands) == 2
-
-    # Run discover_and_build (will discover nothing from empty tmp_path)
-    registry.discover_and_build()
-
-    # Should be marked as built
-    assert registry._built
-
-    # Should still have our manually created command groups
-    assert "tools.group1" in registry._command_groups
-    assert "tools.group2" in registry._command_groups
-    assert len(registry._command_groups) == 2
-    assert len(registry._pending_commands) == 2
+        assert len(command_groups["tools.deployment"]._commands) == 2  # status, rollback
+        assert len(command_groups["tools.deployment.k8s"]._commands) >= 2  # deploy, scale

--- a/tests/registry/test_discovery.py
+++ b/tests/registry/test_discovery.py
@@ -131,7 +131,6 @@ def test_build_simple_command_group(registry):
     @group.command("hello")
     def hello_cmd(ctx: Context):
         """Say hello."""
-        return "hello"
 
     # Verify initial state
     assert not registry._built
@@ -164,12 +163,10 @@ def test_build_nested_command_groups(registry):
     @parent.command("parent_cmd")
     def parent_cmd(ctx: Context):
         """Parent command."""
-        return "parent"
 
     @child.command("child_cmd")
     def child_cmd(ctx: Context):
         """Child command."""
-        return "child"
 
     # Verify initial state
     assert not registry._built
@@ -200,7 +197,6 @@ def test_build_parsers_called_once(registry):
     @group.command("cmd")
     def test_cmd(ctx: Context):
         """Test command."""
-        return "test"
 
     # Verify initial state
     assert not registry._built
@@ -261,12 +257,10 @@ def test_discover_and_build_with_manual_groups(registry):
     @group1.command("cmd1")
     def cmd1(ctx: Context):
         """Command 1."""
-        return "cmd1"
 
     @group2.command("cmd2")
     def cmd2(ctx: Context):
         """Command 2."""
-        return "cmd2"
 
     # Verify initial state
     assert not registry._built

--- a/tests/registry/test_discovery_errors.py
+++ b/tests/registry/test_discovery_errors.py
@@ -1,0 +1,89 @@
+"""Tests for discovery error cases."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from toolr import Context
+from toolr import command_group
+from toolr._registry import CommandRegistry
+
+
+def test_discover_local_commands_with_debug_imports(tmp_path):
+    """Test local command discovery with TOOLR_DEBUG_IMPORTS enabled."""
+    # Create a tools directory with a problematic module
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+
+    # Create a module that will cause an import error
+    problematic_module = tools_dir / "problematic.py"
+    problematic_module.write_text("import nonexistent_module")
+
+    registry = CommandRegistry()
+    mock_parser = Mock()
+    mock_parser.repo_root = tmp_path
+    registry._set_parser(mock_parser)
+
+    # Should raise an error when TOOLR_DEBUG_IMPORTS is enabled
+    with patch.dict(os.environ, {"TOOLR_DEBUG_IMPORTS": "1"}):
+        with pytest.raises(ImportError):
+            registry._discover_local_commands()
+
+
+def test_discover_local_commands_no_tools_dir(tmp_path):
+    """Test local command discovery when tools directory doesn't exist."""
+    registry = CommandRegistry()
+    mock_parser = Mock()
+    mock_parser.repo_root = tmp_path
+    registry._set_parser(mock_parser)
+
+    # Should not raise an error when tools directory doesn't exist
+    registry._discover_local_commands()
+
+
+def test_command_decorator_with_function():
+    """Test command decorator when called with a function directly."""
+    group = command_group("test", "Test Group", "A test group")
+
+    def test_command(ctx: Context) -> None:
+        """Test command."""
+
+    # Test the overload where command is called with a function
+    decorated = group.command(test_command)
+
+    # Should return the function and register it
+    assert decorated is test_command
+    assert len(group._commands) == 1
+    assert group._commands[0][0] == "test-command"  # Function name with underscores replaced
+
+
+def test_entry_points_discovery_empty():
+    """Test entry point discovery when no entry points exist."""
+    registry = CommandRegistry()
+    mock_parser = Mock()
+    registry._set_parser(mock_parser)
+
+    with patch("importlib.metadata.entry_points", return_value=[]):
+        # Should not raise an error
+        registry._discover_entry_points_commands()
+
+
+def test_entry_points_discovery_with_error():
+    """Test entry point discovery with import errors."""
+    registry = CommandRegistry()
+    mock_parser = Mock()
+    registry._set_parser(mock_parser)
+
+    # Mock entry points to return an entry point that will fail to load
+    mock_entry_point = Mock()
+    mock_entry_point.module = "nonexistent.module"
+    mock_entry_point.load.side_effect = ImportError("Module not found")
+
+    with patch("importlib.metadata.entry_points", return_value=[mock_entry_point]):
+        # Should raise an error when entry point loading fails
+        with pytest.raises(ImportError, match="Module not found"):
+            registry._discover_entry_points_commands()

--- a/tests/registry/test_entry_points.py
+++ b/tests/registry/test_entry_points.py
@@ -1,0 +1,36 @@
+"""Tests for 3rd-party package entry point discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from toolr._registry import CommandRegistry
+from toolr.testing import CommandsTester
+
+
+def test_3rd_party_commands(commands_tester: CommandsTester):
+    """Test that 3rd-party commands are discovered via entry points."""
+    command_groups = commands_tester.collected_command_groups()
+    assert "tools.third-party" in command_groups
+    assert "tools.utils" in command_groups
+
+    third_party_commands = [cmd[0] for cmd in command_groups["tools.third-party"]._commands]
+    utils_commands = [cmd[0] for cmd in command_groups["tools.utils"]._commands]
+    assert "hello" in third_party_commands
+    assert "version" in third_party_commands
+    assert "echo" in utils_commands
+    assert "info" in utils_commands
+
+
+def test_entry_point_discovery_mechanism(tmp_path: Path):
+    """Test that entry point discovery mechanism works."""
+
+    registry = CommandRegistry()
+
+    # Create a mock parser
+    mock_parser = type("MockParser", (), {"repo_root": tmp_path})()
+    registry._set_parser(mock_parser)
+
+    # Test that entry point discovery doesn't raise errors
+    # This tests the basic mechanism without requiring actual entry points
+    registry._discover_entry_points_commands()

--- a/tests/registry/test_integration.py
+++ b/tests/registry/test_integration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from toolr._context import Context
 from toolr._parser import Parser
 from toolr._registry import CommandRegistry
 
@@ -24,12 +25,12 @@ def test_complete_workflow_example(registry):
 
     # Add some direct commands to docker group
     @docker_group.command("version")
-    def docker_version(args):
+    def docker_version(ctx: Context):
         """Show Docker version."""
         return "Docker version 20.10.7"
 
     @docker_group.command("info")
-    def docker_info(args):
+    def docker_info(ctx: Context):
         """Show Docker system info."""
         return "Docker system info"
 
@@ -39,23 +40,23 @@ def test_complete_workflow_example(registry):
 
     # Add commands to build group
     @build_group.command("image")
-    def build_image(args):
+    def build_image(ctx: Context):
         """Build an image."""
         return "Building Docker image"
 
     @build_group.command("cache")
-    def build_cache(args):
+    def build_cache(ctx: Context):
         """Manage build cache."""
         return "Managing build cache"
 
     # Add commands to compose group
     @compose_group.command("up")
-    def compose_up(args):
+    def compose_up(ctx: Context):
         """Start services."""
         return "Starting services"
 
     @compose_group.command("down")
-    def compose_down(args):
+    def compose_down(ctx: Context):
         """Stop services."""
         return "Stopping services"
 
@@ -63,7 +64,7 @@ def test_complete_workflow_example(registry):
     advanced_group = build_group.command_group("advanced", "Advanced Build", "Advanced build features")
 
     @advanced_group.command("multi-stage")
-    def multi_stage_build(args):
+    def multi_stage_build(ctx: Context):
         """Multi-stage build."""
         return "Multi-stage build"
 
@@ -94,12 +95,12 @@ def test_real_world_tool_structure(registry):
     dev_group = registry.command_group("dev", "Development", "Development workflow tools")
 
     @dev_group.command("setup")
-    def dev_setup(args):
+    def dev_setup(ctx: Context):
         """Set up development environment."""
         return "Setting up dev environment"
 
     @dev_group.command("clean")
-    def dev_clean(args):
+    def dev_clean(ctx: Context):
         """Clean development artifacts."""
         return "Cleaning dev artifacts"
 
@@ -107,17 +108,17 @@ def test_real_world_tool_structure(registry):
     test_group = dev_group.command_group("test", "Testing", "Test execution and management")
 
     @test_group.command("unit")
-    def test_unit(args):
+    def test_unit(ctx: Context):
         """Run unit tests."""
         return "Running unit tests"
 
     @test_group.command("integration")
-    def test_integration(args):
+    def test_integration(ctx: Context):
         """Run integration tests."""
         return "Running integration tests"
 
     @test_group.command("e2e")
-    def test_e2e(args):
+    def test_e2e(ctx: Context):
         """Run end-to-end tests."""
         return "Running e2e tests"
 
@@ -125,12 +126,12 @@ def test_real_world_tool_structure(registry):
     coverage_group = test_group.command_group("coverage", "Coverage", "Test coverage tools")
 
     @coverage_group.command("report")
-    def coverage_report(args):
+    def coverage_report(ctx: Context):
         """Generate coverage report."""
         return "Generating coverage report"
 
     @coverage_group.command("html")
-    def coverage_html(args):
+    def coverage_html(ctx: Context):
         """Generate HTML coverage report."""
         return "Generating HTML coverage"
 
@@ -138,7 +139,7 @@ def test_real_world_tool_structure(registry):
     ci_group = registry.command_group("ci", "CI/CD", "Continuous integration and deployment")
 
     @ci_group.command("validate")
-    def ci_validate(args):
+    def ci_validate(ctx: Context):
         """Validate CI configuration."""
         return "Validating CI config"
 
@@ -146,12 +147,12 @@ def test_real_world_tool_structure(registry):
     deploy_group = ci_group.command_group("deploy", "Deploy", "Deployment operations")
 
     @deploy_group.command("staging")
-    def deploy_staging(args):
+    def deploy_staging(ctx: Context):
         """Deploy to staging."""
         return "Deploying to staging"
 
     @deploy_group.command("production")
-    def deploy_production(args):
+    def deploy_production(ctx: Context):
         """Deploy to production."""
         return "Deploying to production"
 
@@ -209,12 +210,12 @@ def test_multiple_registries_isolation(tmp_path):
     group2 = registry2.command_group("test2", "Test 2", "Test registry 2")
 
     @group1.command("cmd1")
-    def cmd1(args):
+    def cmd1(ctx: Context):
         """Command 1."""
         return "cmd1"
 
     @group2.command("cmd2")
-    def cmd2(args):
+    def cmd2(ctx: Context):
         """Command 2."""
         return "cmd2"
 

--- a/tests/registry/test_integration.py
+++ b/tests/registry/test_integration.py
@@ -2,26 +2,14 @@
 
 from __future__ import annotations
 
-import pytest
-
-from toolr._context import Context
-from toolr._parser import Parser
-from toolr._registry import CommandRegistry
-
-from .conftest import RegistryTestCase
+from toolr import Context
+from toolr import command_group
 
 
-@pytest.fixture
-def registry(tmp_path):
-    """Create a fresh registry with a real parser for each test."""
-    with RegistryTestCase(tmp_path) as _registry_test_case:
-        yield _registry_test_case.registry
-
-
-def test_complete_workflow_example(registry):
+def test_complete_workflow_example(commands_tester):
     """Test a complete workflow demonstrating the registry usage."""
     # Simulate building a Docker tooling hierarchy
-    docker_group = registry.command_group("docker", "Docker Tools", "Docker container management")
+    docker_group = command_group("docker", "Docker Tools", "Docker container management")
 
     # Add some direct commands to docker group
     @docker_group.command("version")
@@ -69,14 +57,18 @@ def test_complete_workflow_example(registry):
         return "Multi-stage build"
 
     # Verify the structure was created correctly
-    assert len(registry._command_groups) == 4
-    assert "tools.docker" in registry._command_groups
-    assert "tools.docker.build" in registry._command_groups
-    assert "tools.docker.compose" in registry._command_groups
-    assert "tools.docker.build.advanced" in registry._command_groups
+    command_groups = commands_tester.collected_command_groups()
+    assert len(command_groups) == 4
+    assert "tools.docker" in command_groups
+    assert "tools.docker.build" in command_groups
+    assert "tools.docker.compose" in command_groups
+    assert "tools.docker.build.advanced" in command_groups
 
     # Verify command registration
-    assert len(registry._pending_commands) == 7
+    assert len(command_groups["tools.docker"]._commands) == 2
+    assert len(command_groups["tools.docker.build"]._commands) == 2
+    assert len(command_groups["tools.docker.compose"]._commands) == 2
+    assert len(command_groups["tools.docker.build.advanced"]._commands) == 1
 
     # Verify group relationships
     assert docker_group.full_name == "tools.docker"
@@ -89,10 +81,10 @@ def test_complete_workflow_example(registry):
     assert advanced_group.parent == "tools.docker.build"
 
 
-def test_real_world_tool_structure(registry):
+def test_real_world_tool_structure(commands_tester):
     """Test a realistic tool structure like you might see in a real project."""
     # Development tools
-    dev_group = registry.command_group("dev", "Development", "Development workflow tools")
+    dev_group = command_group("dev", "Development", "Development workflow tools")
 
     @dev_group.command("setup")
     def dev_setup(ctx: Context):
@@ -129,7 +121,7 @@ def test_real_world_tool_structure(registry):
         """Generate HTML coverage report."""
 
     # CI/CD tools
-    ci_group = registry.command_group("ci", "CI/CD", "Continuous integration and deployment")
+    ci_group = command_group("ci", "CI/CD", "Continuous integration and deployment")
 
     @ci_group.command("validate")
     def ci_validate(ctx: Context):
@@ -147,75 +139,41 @@ def test_real_world_tool_structure(registry):
         """Deploy to production."""
 
     # Verify the complex structure
+    command_groups = commands_tester.collected_command_groups()
     expected_groups = ["tools.dev", "tools.dev.test", "tools.dev.test.coverage", "tools.ci", "tools.ci.deploy"]
 
     for group_name in expected_groups:
-        assert group_name in registry._command_groups
-        group = registry._command_groups[group_name]
+        assert group_name in command_groups
+        group = command_groups[group_name]
         assert group.full_name == group_name
 
     # Verify we have all the expected commands
-    assert len(registry._pending_commands) == 10
+    assert len(command_groups["tools.dev.test.coverage"]._commands) == 2
 
     # Test specific command paths
-    coverage_commands = [
-        (full_name, cmd) for (full_name, cmd, _) in registry._pending_commands if full_name == "tools.dev.test.coverage"
-    ]
-    assert len(coverage_commands) == 2
-    assert any(cmd == "report" for (_, cmd) in coverage_commands)
-    assert any(cmd == "html" for (_, cmd) in coverage_commands)
+    coverage_commands_group = command_groups["tools.dev.test.coverage"]
+    assert len(coverage_commands_group._commands) == 2
+    assert any(cmd[0] == "report" for cmd in coverage_commands_group._commands)
+    assert any(cmd[0] == "html" for cmd in coverage_commands_group._commands)
 
 
-def test_command_group_hierarchy_storage(registry):
+def test_command_group_hierarchy_storage(commands_tester):
     """Test that command groups are properly stored in hierarchical structure."""
     # Create a hierarchy (avoid naming conflict with 'tools' prefix)
-    app = registry.command_group("app", "Application", "Application tools")
+    app = command_group("app", "Application", "Application tools")
     docker = app.command_group("docker", "Docker", "Docker tools")
     build = docker.command_group("build", "Build", "Build tools")
     advanced = build.command_group("advanced", "Advanced", "Advanced build")
 
     # Test that groups are stored at correct paths
-    assert registry._command_groups["tools.app"] == app
-    assert registry._command_groups["tools.app.docker"] == docker
-    assert registry._command_groups["tools.app.docker.build"] == build
-    assert registry._command_groups["tools.app.docker.build.advanced"] == advanced
+    command_groups = commands_tester.collected_command_groups()
+    assert command_groups["tools.app"] == app
+    assert command_groups["tools.app.docker"] == docker
+    assert command_groups["tools.app.docker.build"] == build
+    assert command_groups["tools.app.docker.build.advanced"] == advanced
 
     # Test that non-existent paths are not in the registry
-    assert "nonexistent" not in registry._command_groups
-    assert "tools.nonexistent" not in registry._command_groups
-    assert "tools.app.docker.nonexistent" not in registry._command_groups
-    assert "tools.app.docker.build.advanced.nonexistent" not in registry._command_groups
-
-
-def test_multiple_registries_isolation(tmp_path):
-    """Test that multiple registry instances are properly isolated."""
-
-    parser1 = Parser(repo_root=tmp_path / "registry1")
-    parser2 = Parser(repo_root=tmp_path / "registry2")
-    registry1 = CommandRegistry(_parser=parser1)
-    registry2 = CommandRegistry(_parser=parser2)
-
-    # Create different structures in each registry
-    group1 = registry1.command_group("test1", "Test 1", "Test registry 1")
-    group2 = registry2.command_group("test2", "Test 2", "Test registry 2")
-
-    @group1.command("cmd1")
-    def cmd1(ctx: Context):
-        """Command 1."""
-
-    @group2.command("cmd2")
-    def cmd2(ctx: Context):
-        """Command 2."""
-
-    # Verify isolation
-    assert len(registry1._command_groups) == 1
-    assert len(registry2._command_groups) == 1
-    assert "tools.test1" in registry1._command_groups
-    assert "tools.test2" in registry2._command_groups
-    assert "tools.test1" not in registry2._command_groups
-    assert "tools.test2" not in registry1._command_groups
-
-    assert len(registry1._pending_commands) == 1
-    assert len(registry2._pending_commands) == 1
-    assert registry1._pending_commands[0][1] == "cmd1"
-    assert registry2._pending_commands[0][1] == "cmd2"
+    assert "nonexistent" not in command_groups
+    assert "tools.nonexistent" not in command_groups
+    assert "tools.app.docker.nonexistent" not in command_groups
+    assert "tools.app.docker.build.advanced.nonexistent" not in command_groups

--- a/tests/registry/test_integration.py
+++ b/tests/registry/test_integration.py
@@ -97,12 +97,10 @@ def test_real_world_tool_structure(registry):
     @dev_group.command("setup")
     def dev_setup(ctx: Context):
         """Set up development environment."""
-        return "Setting up dev environment"
 
     @dev_group.command("clean")
     def dev_clean(ctx: Context):
         """Clean development artifacts."""
-        return "Cleaning dev artifacts"
 
     # Testing tools
     test_group = dev_group.command_group("test", "Testing", "Test execution and management")
@@ -110,17 +108,14 @@ def test_real_world_tool_structure(registry):
     @test_group.command("unit")
     def test_unit(ctx: Context):
         """Run unit tests."""
-        return "Running unit tests"
 
     @test_group.command("integration")
     def test_integration(ctx: Context):
         """Run integration tests."""
-        return "Running integration tests"
 
     @test_group.command("e2e")
     def test_e2e(ctx: Context):
         """Run end-to-end tests."""
-        return "Running e2e tests"
 
     # Coverage tools under testing
     coverage_group = test_group.command_group("coverage", "Coverage", "Test coverage tools")
@@ -128,19 +123,16 @@ def test_real_world_tool_structure(registry):
     @coverage_group.command("report")
     def coverage_report(ctx: Context):
         """Generate coverage report."""
-        return "Generating coverage report"
 
     @coverage_group.command("html")
     def coverage_html(ctx: Context):
         """Generate HTML coverage report."""
-        return "Generating HTML coverage"
 
     # CI/CD tools
     ci_group = registry.command_group("ci", "CI/CD", "Continuous integration and deployment")
 
     @ci_group.command("validate")
     def ci_validate(ctx: Context):
-        """Validate CI configuration."""
         return "Validating CI config"
 
     # Deployment under CI
@@ -149,12 +141,10 @@ def test_real_world_tool_structure(registry):
     @deploy_group.command("staging")
     def deploy_staging(ctx: Context):
         """Deploy to staging."""
-        return "Deploying to staging"
 
     @deploy_group.command("production")
     def deploy_production(ctx: Context):
         """Deploy to production."""
-        return "Deploying to production"
 
     # Verify the complex structure
     expected_groups = ["tools.dev", "tools.dev.test", "tools.dev.test.coverage", "tools.ci", "tools.ci.deploy"]
@@ -212,12 +202,10 @@ def test_multiple_registries_isolation(tmp_path):
     @group1.command("cmd1")
     def cmd1(ctx: Context):
         """Command 1."""
-        return "cmd1"
 
     @group2.command("cmd2")
     def cmd2(ctx: Context):
         """Command 2."""
-        return "cmd2"
 
     # Verify isolation
     assert len(registry1._command_groups) == 1

--- a/tests/registry/test_registry_basic.py
+++ b/tests/registry/test_registry_basic.py
@@ -2,21 +2,14 @@
 
 from __future__ import annotations
 
-from toolr._context import Context
+from toolr import Context
+from toolr import command_group
 from toolr._registry import CommandGroup
 
 
-def test_create_registry(registry):
-    """Test creating a new registry instance."""
-    assert registry is not None
-    assert registry._command_groups == {}
-    assert registry._pending_commands == []
-    assert not registry._built
-
-
-def test_create_simple_command_group(registry):
+def test_create_simple_command_group(commands_tester):
     """Test creating a simple command group."""
-    group = registry.command_group("test", "Test Commands", "Test command description")
+    group = command_group("test", "Test Commands", "Test command description")
 
     assert isinstance(group, CommandGroup)
     assert group.name == "test"
@@ -24,13 +17,14 @@ def test_create_simple_command_group(registry):
     assert group.description == "Test command description"
     assert group.parent == "tools"  # Default parent is now "tools"
     assert group.full_name == "tools.test"
-    assert registry._command_groups["tools.test"] == group
+    command_groups = commands_tester.collected_command_groups()
+    assert command_groups["tools.test"] == group
 
 
-def test_create_nested_command_group(registry):
+def test_create_nested_command_group(commands_tester):
     """Test creating nested command groups."""
     # Create parent group (gets tools. prefix automatically)
-    parent_group = registry.command_group("parent", "Parent Commands", "Parent description")
+    parent_group = command_group("parent", "Parent Commands", "Parent description")
 
     # Create child group
     child_group = parent_group.command_group("child", "Child Commands", "Child description")
@@ -38,39 +32,42 @@ def test_create_nested_command_group(registry):
     assert child_group.name == "child"
     assert child_group.parent == "tools.parent"
     assert child_group.full_name == "tools.parent.child"
-    assert registry._command_groups["tools.parent.child"] == child_group
+    command_groups = commands_tester.collected_command_groups()
+    assert command_groups["tools.parent.child"] == child_group
 
 
-def test_deeply_nested_command_groups(registry):
+def test_deeply_nested_command_groups(commands_tester):
     """Test creating deeply nested command groups."""
     # Create hierarchy: tools.parent -> tools.parent.child -> tools.parent.child.grandchild
-    parent = registry.command_group("parent", "Parent", "Parent desc")
+    parent = command_group("parent", "Parent", "Parent desc")
     child = parent.command_group("child", "Child", "Child desc")
     grandchild = child.command_group("grandchild", "Grandchild", "Grandchild desc")
 
     assert grandchild.full_name == "tools.parent.child.grandchild"
-    assert registry._command_groups["tools.parent.child.grandchild"] == grandchild
+    command_groups = commands_tester.collected_command_groups()
+    assert command_groups["tools.parent.child.grandchild"] == grandchild
 
 
-def test_command_registration(registry):
+def test_command_registration(commands_tester):
     """Test registering commands on a command group."""
-    group = registry.command_group("test", "Test Commands", "Test description")
+    group = command_group("test", "Test Commands", "Test description")
 
     @group.command("hello")
     def hello_cmd(ctx: Context):
         """Say hello."""
 
     # Check that the command was registered
-    assert len(registry._pending_commands) == 1
-    full_name, name, func = registry._pending_commands[0]
-    assert full_name == "tools.test"
+    command_groups = commands_tester.collected_command_groups()
+    tools_test_group = command_groups["tools.test"]
+    assert len(tools_test_group._commands) == 1
+    name, func = tools_test_group._commands[0]
     assert name == "hello"
     assert func == hello_cmd
 
 
-def test_multiple_commands_same_group(registry):
+def test_multiple_commands_same_group(commands_tester):
     """Test registering multiple commands on the same group."""
-    group = registry.command_group("test", "Test Commands", "Test description")
+    group = command_group("test", "Test Commands", "Test description")
 
     @group.command("cmd1")
     def cmd1(ctx: Context):
@@ -80,20 +77,20 @@ def test_multiple_commands_same_group(registry):
     def cmd2(ctx: Context):
         """Command 2."""
 
-    assert len(registry._pending_commands) == 2
-    full_name, name, func = registry._pending_commands[0]
-    assert full_name == "tools.test"
+    command_groups = commands_tester.collected_command_groups()
+    assert len(command_groups["tools.test"]._commands) == 2
+    tools_test_group = command_groups["tools.test"]
+    name, func = tools_test_group._commands[0]
     assert name == "cmd1"
     assert func == cmd1
-    full_name, name, func = registry._pending_commands[1]
-    assert full_name == "tools.test"
+    name, func = tools_test_group._commands[1]
     assert name == "cmd2"
     assert func == cmd2
 
 
-def test_commands_on_nested_groups(registry):
+def test_commands_on_nested_groups(commands_tester):
     """Test registering commands on nested groups."""
-    parent = registry.command_group("parent", "Parent", "Parent desc")
+    parent = command_group("parent", "Parent", "Parent desc")
     child = parent.command_group("child", "Child", "Child desc")
 
     @parent.command("parent_cmd")
@@ -104,33 +101,32 @@ def test_commands_on_nested_groups(registry):
     def child_cmd(ctx: Context):
         """Child command."""
 
-    assert len(registry._pending_commands) == 2
+    command_groups = commands_tester.collected_command_groups()
+    assert len(command_groups["tools.parent"]._commands) == 1
+    assert len(command_groups["tools.parent.child"]._commands) == 1
 
-    # Find the commands by their group paths
-    parent_cmd_info = next(cmd for cmd in registry._pending_commands if cmd[0] == "tools.parent")
-    child_cmd_info = next(cmd for cmd in registry._pending_commands if cmd[0] == "tools.parent.child")
-
-    assert parent_cmd_info[1] == "parent_cmd"
-    assert child_cmd_info[1] == "child_cmd"
+    assert command_groups["tools.parent"]._commands[0][0] == "parent_cmd"
+    assert command_groups["tools.parent.child"]._commands[0][0] == "child_cmd"
 
 
-def test_command_group_storage(registry):
+def test_command_group_storage(commands_tester):
     """Test that command groups are properly stored in the registry."""
-    group1 = registry.command_group("test1", "Test 1", "Test 1 desc")
-    group2 = registry.command_group("test2", "Test 2", "Test 2 desc")
+    group1 = command_group("test1", "Test 1", "Test 1 desc")
+    group2 = command_group("test2", "Test 2", "Test 2 desc")
     nested = group1.command_group("nested", "Nested", "Nested desc")
 
     # Verify groups are stored with correct paths
-    assert registry._command_groups["tools.test1"] == group1
-    assert registry._command_groups["tools.test2"] == group2
-    assert registry._command_groups["tools.test1.nested"] == nested
-    assert "nonexistent" not in registry._command_groups
+    command_groups = commands_tester.collected_command_groups()
+    assert command_groups["tools.test1"] == group1
+    assert command_groups["tools.test2"] == group2
+    assert command_groups["tools.test1.nested"] == nested
+    assert "nonexistent" not in command_groups
 
 
-def test_command_group_hierarchy(registry):
+def test_command_group_hierarchy(commands_tester):
     """Test that command groups properly maintain hierarchy."""
     # All top-level groups get "tools" as parent automatically
-    parent_group = registry.command_group("parent", "Parent", "Parent desc")
+    parent_group = command_group("parent", "Parent", "Parent desc")
     assert parent_group.parent == "tools"
 
     # Nested groups get their parent's full name as parent
@@ -142,10 +138,10 @@ def test_command_group_hierarchy(registry):
     assert grandchild_group.parent == "tools.parent.child"
 
 
-def test_command_group_full_name(registry):
+def test_command_group_full_name(commands_tester):
     """Test that full_name property works correctly."""
     # Top-level group gets tools. prefix
-    group1 = registry.command_group("top", "Top", "Top desc")
+    group1 = command_group("top", "Top", "Top desc")
     assert group1.full_name == "tools.top"
 
     # Nested group
@@ -157,9 +153,9 @@ def test_command_group_full_name(registry):
     assert group3.full_name == "tools.top.sub.deep"
 
 
-def test_command_decorator_returns_function(registry):
+def test_command_decorator_returns_function(commands_tester):
     """Test that the command decorator returns the original function."""
-    group = registry.command_group("test", "Test", "Test desc")
+    group = command_group("test", "Test", "Test desc")
 
     @group.command("test_cmd")
     def original_function(ctx: Context):
@@ -170,9 +166,9 @@ def test_command_decorator_returns_function(registry):
     assert original_function(None) == "test"
 
 
-def test_function_name_to_command_name_conversion(registry):
+def test_function_name_to_command_name_conversion(commands_tester):
     """Test that function names are converted to command names using hyphens."""
-    group = registry.command_group("test", "Test", "Test desc")
+    group = command_group("test", "Test", "Test desc")
 
     @group.command
     def simple_function(ctx: Context):
@@ -203,10 +199,11 @@ def test_function_name_to_command_name_conversion(registry):
         """Function with both leading and trailing underscores."""
 
     # Check that the commands were registered with the correct names
-    assert len(registry._pending_commands) == 7
+    command_groups = commands_tester.collected_command_groups()
+    assert len(command_groups["tools.test"]._commands) == 7
 
     # Find each command and verify the name conversion
-    command_map = {cmd[1]: cmd[2] for cmd in registry._pending_commands if cmd[0] == "tools.test"}
+    command_map = {cmd[0]: cmd[1] for cmd in command_groups["tools.test"]._commands}
 
     assert "simple-function" in command_map
     assert command_map["simple-function"] == simple_function

--- a/tests/registry/test_registry_basic.py
+++ b/tests/registry/test_registry_basic.py
@@ -59,7 +59,6 @@ def test_command_registration(registry):
     @group.command("hello")
     def hello_cmd(ctx: Context):
         """Say hello."""
-        return "hello"
 
     # Check that the command was registered
     assert len(registry._pending_commands) == 1
@@ -76,12 +75,10 @@ def test_multiple_commands_same_group(registry):
     @group.command("cmd1")
     def cmd1(ctx: Context):
         """Command 1."""
-        return "cmd1"
 
     @group.command("cmd2")
     def cmd2(ctx: Context):
         """Command 2."""
-        return "cmd2"
 
     assert len(registry._pending_commands) == 2
     full_name, name, func = registry._pending_commands[0]
@@ -102,12 +99,10 @@ def test_commands_on_nested_groups(registry):
     @parent.command("parent_cmd")
     def parent_cmd(ctx: Context):
         """Parent command."""
-        return "parent"
 
     @child.command("child_cmd")
     def child_cmd(ctx: Context):
         """Child command."""
-        return "child"
 
     assert len(registry._pending_commands) == 2
 

--- a/tests/registry/test_registry_errors.py
+++ b/tests/registry/test_registry_errors.py
@@ -1,0 +1,45 @@
+"""Tests for registry error cases."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from toolr import command_group
+from toolr._registry import CommandRegistry
+from toolr.testing import CommandsTester
+
+
+def test_registry_parser_not_set_error():
+    """Test error when accessing parser before it's set."""
+    registry = CommandRegistry()
+
+    with pytest.raises(RuntimeError, match="The parser is not set"):
+        _ = registry.parser
+
+
+def test_registry_set_parser_twice_error():
+    """Test error when setting parser twice."""
+    registry = CommandRegistry()
+    mock_parser1 = Mock()
+    mock_parser2 = Mock()
+
+    registry._set_parser(mock_parser1)
+
+    with pytest.raises(RuntimeError, match="A parser has already been set"):
+        registry._set_parser(mock_parser2)
+
+
+def test_build_parsers_missing_parent_group(tmp_path: Path):
+    """Test parser building with missing parent command group."""
+    with CommandsTester(search_path=tmp_path) as tester:
+        # Create a command group with a non-existent parent
+        command_group("child", "Child Group", "A child group", parent="nonexistent.parent")
+
+        # Should raise an error when building parsers
+        with pytest.raises(
+            ValueError, match="Parent command group 'nonexistent.parent' for command 'child' does not exist"
+        ):
+            tester.registry._build_parsers()

--- a/tests/support/3rd-party-pkg/README.md
+++ b/tests/support/3rd-party-pkg/README.md
@@ -1,0 +1,28 @@
+# 3rd-party-pkg
+
+A test package for ToolR entry point discovery.
+
+## Installation
+
+This package is used for testing purposes. The test suite takes care of installing it.
+
+## Available Commands
+
+### Third Party Tools
+
+- `hello` - Say hello to someone
+- `version` - Show the version of the 3rd-party package
+
+### Utility Commands
+
+- `echo` - Echo a message multiple times
+- `info` - Show information about the 3rd-party package
+
+## Usage
+
+After installation, the commands will be available through ToolR:
+
+```bash
+toolr third-party hello --name "Alice"
+toolr utils echo --message "Hello World" --repeat 3
+```

--- a/tests/support/3rd-party-pkg/pyproject.toml
+++ b/tests/support/3rd-party-pkg/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "3rd-party-pkg"
+version = "1.0.0"
+description = "Test package for entry point discovery"
+authors = [
+    {name = "Test Author", email = "test@example.com"}
+]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "toolr",
+]
+
+[project.entry-points."toolr.tools"]
+commands = "thirdparty.commands"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/tests/support/3rd-party-pkg/thirdparty/__init__.py
+++ b/tests/support/3rd-party-pkg/thirdparty/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/support/3rd-party-pkg/thirdparty/commands.py
+++ b/tests/support/3rd-party-pkg/thirdparty/commands.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from toolr import Context
+from toolr import command_group
+
+third_party_group = command_group("third-party", "Third Party Tools", "Tools from third-party packages")
+
+
+@third_party_group.command("hello")
+def hello_command(ctx: Context, name: str = "World") -> None:
+    """Say hello to someone.
+
+    Args:
+        ctx: The execution context
+        name: Name to greet (default: World)
+    """
+    ctx.console.print(f"Hello, {name} from 3rd-party package!")
+
+
+@third_party_group.command("version")
+def version_command(ctx: Context) -> None:
+    """Show the version of the 3rd-party package.
+
+    Args:
+        ctx: The execution context
+    """
+    ctx.console.print("3rd-party package version 1.0.0")
+
+
+utils_group = command_group("utils", "Utility Commands", "General utility commands")
+
+
+@utils_group.command("echo")
+def echo_command(ctx: Context, message: str, repeat: int = 1) -> None:
+    """Echo a message multiple times.
+
+    Args:
+        ctx: The execution context
+        message: Message to echo
+        repeat: Number of times to repeat the message (default: 1)
+    """
+    for i in range(repeat):
+        ctx.console.print(f"[{i + 1}] {message}")
+
+
+@utils_group.command("info")
+def info_command(ctx: Context) -> None:
+    """Show information about the 3rd-party package.
+
+    Args:
+        ctx: The execution context
+    """
+    ctx.console.print("3rd-party package information:")
+    ctx.console.print("- Name: 3rd-party-pkg")
+    ctx.console.print("- Version: 1.0.0")
+    ctx.console.print("- Description: Test package for entry point discovery")
+    ctx.console.print("- Author: Test Author")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,25 +31,15 @@ def dummy_parser():
 
 
 @pytest.fixture
-def dummy_registry():
-    """Create a dummy registry that doesn't have side effects."""
-
-    class DummyRegistry:
-        def discover_and_build(self, parser):
-            pass
-
-    return DummyRegistry()
-
-
-@pytest.fixture
-def registry(dummy_registry):
-    with patch.object(main_module, "registry", dummy_registry):
-        yield dummy_registry
-
-
-@pytest.fixture
-def parser(dummy_parser, registry):
-    with patch.object(main_module, "Parser", dummy_parser):
+def parser(dummy_parser):
+    with (
+        # Make sure our command groups list is empty
+        patch("toolr._registry.get_command_group_list", return_value=[]),
+        # Make sure we don't load any entry points
+        patch("importlib.metadata.entry_points", return_value=[]),
+        # Use our dummy parser
+        patch.object(main_module, "Parser", dummy_parser),
+    ):
         yield parser
 
 

--- a/tests/utils/signature/test_get_signature.py
+++ b/tests/utils/signature/test_get_signature.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 import pytest
 
-from toolr._context import Context
+from toolr import Context
 from toolr._exc import SignatureError
 from toolr.utils._signature import Arg
 from toolr.utils._signature import KwArg

--- a/tests/utils/signature/test_integration.py
+++ b/tests/utils/signature/test_integration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import enum
 from typing import Annotated
 
-from toolr._context import Context
+from toolr import Context
 from toolr.utils._signature import Arg
 from toolr.utils._signature import KwArg
 from toolr.utils._signature import arg

--- a/tests/utils/signature/test_signature.py
+++ b/tests/utils/signature/test_signature.py
@@ -8,7 +8,7 @@ from argparse import Namespace
 
 import pytest
 
-from toolr._context import Context
+from toolr import Context
 from toolr.utils._signature import Arg
 from toolr.utils._signature import KwArg
 from toolr.utils._signature import Signature

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,21 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version < '3.13'",
 ]
+
+[[package]]
+name = "3rd-party-pkg"
+version = "1.0.0"
+source = { directory = "tests/support/3rd-party-pkg" }
+dependencies = [
+    { name = "toolr" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "toolr" }]
 
 [[package]]
 name = "annotated-types"
@@ -856,6 +867,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "3rd-party-pkg" },
     { name = "attrs" },
     { name = "coverage" },
     { name = "pytest" },
@@ -879,6 +891,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "3rd-party-pkg", directory = "tests/support/3rd-party-pkg" },
     { name = "attrs", specifier = ">=25.3.0" },
     { name = "coverage", specifier = ">=7.8.0" },
     { name = "pytest", specifier = ">=8.3.5" },


### PR DESCRIPTION
When not passing a name to the command decorator, the name is extracted from the function name, however, underscores are converted to dashes so that less keystrokes are required to type the command name in the CLI.

Keep in mind that you can name the command whatever you want, you just have to pass a string to the command decorator.

```python
group = registry.command_group("test", "Test", "Test desc")

@group.command
def foo_bar(ctx: Context): ...  # -> Command will be 'foo-bar'

@group.command("the-name-that-i-want")
def random_function_name(ctx: Context): ...  # -> Command will be 'the-name-that-i-want'
```

Fixes #15