### PR TITLE
feat(import-errors): Implement `report_on_import_errors`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - *(prepare-release)* Run `pre-commit` against the prepare release changes
 - *(ci)* Pre-commit needs to be setup and run in a few places
 
-## New Contributors
+### New Contributors
 
 - @s0undt3ch-gh-actions-automations[bot] made their first contribution
 - @dependabot[bot] made their first contribution

--- a/cliff.toml
+++ b/cliff.toml
@@ -38,7 +38,7 @@ body = """
 
 {%- if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
 
-  ## New Contributors
+  ### New Contributors
 {% endif -%}
 
 {%- for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}

--- a/cliff.toml
+++ b/cliff.toml
@@ -32,7 +32,8 @@ body = """
     {% for commit in commits | unique(attribute="message") %}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
-            {{ commit.message | upper_first }}\
+            {{ commit.message | upper_first }} \
+            ([`{{ commit.id | truncate(length=7, end="") }}`]({{ self::remote_url() }}/commit/{{ commit.id }}))\
     {% endfor %}
 {%- endfor %}\n
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ ignore = [
 "python/**/*.py" = [
   "D104",   # Missing docstring in public package
   "D107",   # Missing docstring in `__init__`
+  "PT",     # flake8-pytest-style (PT) - Disabled in production code, only enforced in tests
 ]
 "python/toolr/__main__.py" = [
   "F401",   #  `tools` imported but unused
@@ -191,6 +192,9 @@ ignore = [
 ]
 "tests/cli/**/*.py" = [
   "RUF013",   # PEP 484 prohibits implicit `Optional`
+]
+"tests/utils/**/*.py" = [
+  "PLC0415", # `import` should be at the top-level of a file
 ]
 "tests/support/coverage/*.py" = [
   "INP001",   # File `...` is part of an implicit namespace package. Add an `__init__.py`."

--- a/python/toolr/__init__.py
+++ b/python/toolr/__init__.py
@@ -9,6 +9,7 @@ except ImportError:
 
 from toolr._context import Context
 from toolr._registry import command_group
+from toolr.utils._imports import report_on_import_errors
 from toolr.utils._signature import arg
 
-__all__ = ["Context", "__version__", "arg", "command_group"]
+__all__ = ["Context", "__version__", "arg", "command_group", "report_on_import_errors"]

--- a/python/toolr/_registry.py
+++ b/python/toolr/_registry.py
@@ -149,9 +149,13 @@ class CommandRegistry(Struct, frozen=True):
                     else:
                         # Import the module which will trigger command registration
                         importlib.import_module(f"{package}.{item.name}")
-                except ImportError as exc:
+                except ModuleNotFoundError as exc:
+                    # If we're not debugging imports, we don't want to raise an error
                     if os.environ.get("TOOLR_DEBUG_IMPORTS", "0") == "1":
                         raise exc from None
+                except ImportError as exc:
+                    # This is likely something wrong with the environment, raise it to the user
+                    raise exc from None
 
         import_commands(tools_dir, "tools")
 

--- a/python/toolr/utils/_imports.py
+++ b/python/toolr/utils/_imports.py
@@ -1,0 +1,28 @@
+"""
+Imports related utilities.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+log = logging.getLogger(__name__)
+
+
+@contextmanager
+def report_on_import_errors(message: str) -> Iterator[None]:
+    """
+    Catch import errors and raise a CommandDependencyNotFoundError.
+    """
+    try:
+        yield
+    except ModuleNotFoundError as exc:
+        # Suppress the current frame (the yield line) from the traceback
+        # We just want to show the user the import error from the code that actually uses the command
+        if TYPE_CHECKING:
+            assert exc.__traceback__ is not None
+        exc.__traceback__ = exc.__traceback__.tb_next
+        log.warning(message, exc_info=exc)

--- a/tests/registry/test_discovery_errors.py
+++ b/tests/registry/test_discovery_errors.py
@@ -2,15 +2,28 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+from msgspec import Struct
 
 from toolr import Context
 from toolr import command_group
 from toolr._registry import CommandRegistry
+
+
+class ImportErrorSideEffect(Struct, frozen=True):
+    module_name: str
+
+    def __call__(self, module_name):
+        if module_name == self.module_name:
+            error_msg = "Simulated import error"
+            raise ImportError(error_msg)
+        # For other modules, use the real import
+        return importlib.import_module(module_name)  # pragma: no cover
 
 
 def test_discover_local_commands_with_debug_imports(tmp_path):
@@ -30,7 +43,7 @@ def test_discover_local_commands_with_debug_imports(tmp_path):
 
     # Should raise an error when TOOLR_DEBUG_IMPORTS is enabled
     with patch.dict(os.environ, {"TOOLR_DEBUG_IMPORTS": "1"}):
-        with pytest.raises(ImportError):
+        with pytest.raises(ModuleNotFoundError):
             registry._discover_local_commands()
 
 
@@ -83,9 +96,107 @@ def test_entry_points_discovery_with_error():
     # Mock entry points to return an entry point that will fail to load
     mock_entry_point = Mock()
     mock_entry_point.module = "nonexistent.module"
-    mock_entry_point.load.side_effect = ImportError("Module not found")
+    mock_entry_point.load.side_effect = ModuleNotFoundError("Module not found")
 
     with patch("importlib.metadata.entry_points", return_value=[mock_entry_point]):
         # Should raise an error when entry point loading fails
-        with pytest.raises(ImportError, match=r"Module not found"):
+        with pytest.raises(ModuleNotFoundError, match=r"Module not found"):
             registry._discover_entry_points_commands()
+
+
+def test_import_error_always_raised(tmp_path):
+    """Test that ImportError is always raised during command discovery."""
+    # Create a tools directory
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    tools_dir.joinpath("__init__.py").touch()
+
+    # Create a module that will cause an ImportError (not ModuleNotFoundError)
+    import_error_module = tools_dir / "import_error.py"
+    import_error_module.write_text(
+        "from toolr import command_group\ngroup = command_group('test', 'Test', 'Test commands')"
+    )
+
+    registry = CommandRegistry()
+    mock_parser = Mock()
+    mock_parser.repo_root = tmp_path
+    registry._set_parser(mock_parser)
+
+    # Mock importlib.import_module to raise ImportError for this specific module
+    with patch("importlib.import_module") as mock_import:
+        mock_import.side_effect = ImportErrorSideEffect(module_name="tools.import_error")
+
+        # Should raise an error - ImportError should always be raised
+        with pytest.raises(ImportError, match="Simulated import error"):
+            registry._discover_local_commands()
+
+
+def test_mixed_error_scenarios(tmp_path):
+    """Test mixed error scenarios to ensure proper differentiation."""
+    # Create a tools directory with multiple modules
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    tools_dir.joinpath("__init__.py").touch()
+
+    # Create a module that will cause a ModuleNotFoundError
+    missing_dep_module = tools_dir / "missing_dep.py"
+    missing_dep_module.write_text("import nonexistent_package")
+
+    # Create a module that will cause an ImportError
+    import_error_module = tools_dir / "import_error.py"
+    import_error_module.write_text(
+        "from toolr import command_group\ngroup = command_group('test', 'Test', 'Test commands')"
+    )
+
+    # Create a valid module
+    valid_module = tools_dir / "valid.py"
+    valid_module.write_text(
+        "from toolr import command_group\ngroup = command_group('valid', 'Valid', 'Valid commands')"
+    )
+
+    registry = CommandRegistry()
+    mock_parser = Mock()
+    mock_parser.repo_root = tmp_path
+    registry._set_parser(mock_parser)
+
+    # Mock importlib.import_module to raise ImportError for the import_error module
+    with patch("importlib.import_module") as mock_import:
+        mock_import.side_effect = ImportErrorSideEffect(module_name="tools.import_error")
+
+        # Should raise ImportError (not ModuleNotFoundError) because ImportError takes precedence
+        with pytest.raises(ImportError, match="Simulated import error"):
+            registry._discover_local_commands()
+
+
+def test_module_not_found_vs_import_error_differentiation(tmp_path):
+    """Test that the registry correctly differentiates between ModuleNotFoundError and ImportError."""
+    # Create a tools directory
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    tools_dir.joinpath("__init__.py").touch()
+
+    # Test 1: ModuleNotFoundError should be suppressed
+    missing_dep_module = tools_dir / "missing_dep.py"
+    missing_dep_module.write_text("import nonexistent_package")
+
+    registry = CommandRegistry()
+    mock_parser = Mock()
+    mock_parser.repo_root = tmp_path
+    registry._set_parser(mock_parser)
+
+    # Should not raise an error
+    registry._discover_local_commands()
+
+    # Test 2: ImportError should be raised
+    import_error_module = tools_dir / "import_error.py"
+    import_error_module.write_text(
+        "from toolr import command_group\ngroup = command_group('test', 'Test', 'Test commands')"
+    )
+
+    # Mock importlib.import_module to raise ImportError for the import_error module
+    with patch("importlib.import_module") as mock_import:
+        mock_import.side_effect = ImportErrorSideEffect(module_name="tools.import_error")
+
+        # Should raise ImportError
+        with pytest.raises(ImportError, match="Simulated import error"):
+            registry._discover_local_commands()

--- a/tests/utils/test_imports.py
+++ b/tests/utils/test_imports.py
@@ -1,0 +1,162 @@
+"""
+Tests for toolr.utils._imports module.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from toolr.utils._imports import report_on_import_errors
+
+
+def test_successful_import_no_error(caplog):
+    """Test that successful imports don't trigger any warnings."""
+    message = "Test import error message"
+
+    with caplog.at_level(logging.WARNING):
+        with report_on_import_errors(message):
+            # Simulate successful import
+            import sys
+
+            assert sys is not None
+
+    # No warnings should be logged
+    assert len(caplog.records) == 0
+
+
+def test_module_not_found_error_handling(caplog):
+    """Test that ModuleNotFoundError is caught and logged with warning."""
+    message = "Test import error message"
+
+    with caplog.at_level(logging.WARNING):
+        with report_on_import_errors(message):
+            # Simulate a module that doesn't exist
+            import nonexistent_module  # type: ignore[import-not-found]
+
+            # This assertion will never run and is only here to prevent ruff from removing the import
+            assert nonexistent_module is None  # pragma: no cover
+
+    # Should have one warning record
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "WARNING"
+    assert record.message == message
+    assert record.exc_info is not None
+    assert isinstance(record.exc_info[1], ModuleNotFoundError)
+
+
+def test_traceback_suppression(caplog):
+    """Test that the traceback is properly suppressed (tb_next is called)."""
+    message = "Test traceback suppression"
+
+    with caplog.at_level(logging.WARNING):
+        with report_on_import_errors(message):
+            import nonexistent_module
+
+            # This assertion will never run and is only here to prevent ruff from removing the import
+            assert nonexistent_module is None  # pragma: no cover
+
+    record = caplog.records[0]
+    exc_info = record.exc_info
+    assert exc_info is not None
+
+    # The exception should have its traceback modified
+    exc = exc_info[1]
+    assert isinstance(exc, ModuleNotFoundError)
+    # The traceback should be modified (tb_next called)
+    # We can't easily test the exact traceback content, but we can verify
+    # that the exception was processed
+
+
+def test_other_exceptions_not_caught():
+    """Test that exceptions other than ModuleNotFoundError are not caught."""
+    message = "Test other exception"
+    error_msg = "This should not be caught"
+
+    with pytest.raises(ValueError, match=error_msg):
+        with report_on_import_errors(message):
+            raise ValueError(error_msg)
+
+
+def test_custom_message_logged(caplog):
+    """Test that the custom message is logged correctly."""
+    custom_message = "Custom import error message for testing"
+
+    with caplog.at_level(logging.WARNING):
+        with report_on_import_errors(custom_message):
+            import nonexistent_module
+
+            # This assertion will never run and is only here to prevent ruff from removing the import
+            assert nonexistent_module is None  # pragma: no cover
+
+    record = caplog.records[0]
+    assert record.message == custom_message
+
+
+def test_nested_import_errors(caplog):
+    """Test handling of nested import errors."""
+    message = "Nested import error test"
+
+    def nested_import():
+        import nonexistent_module
+
+        # This assertion will never run and is only here to prevent ruff from removing the import
+        assert nonexistent_module is None  # pragma: no cover
+
+    with caplog.at_level(logging.WARNING):
+        with report_on_import_errors(message):
+            nested_import()
+
+    # Should still catch and log the error
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "WARNING"
+    assert record.message == message
+
+
+def test_multiple_import_errors_in_sequence(caplog):
+    """Test handling multiple import errors in sequence."""
+    message = "Multiple import errors test"
+
+    with caplog.at_level(logging.WARNING):
+        # First import error
+        with report_on_import_errors(message):
+            import nonexistent_module1  # type: ignore[import-not-found]
+
+            # This assertion will never run and is only here to prevent ruff from removing the import
+            assert nonexistent_module1 is None  # pragma: no cover
+
+    with caplog.at_level(logging.WARNING):
+        # Second import error
+        with report_on_import_errors(message):
+            import nonexistent_module2  # type: ignore[import-not-found]
+
+            # This assertion will never run and is only here to prevent ruff from removing the import
+            assert nonexistent_module2 is None  # pragma: no cover
+
+    # Each import error should be logged separately
+    assert len(caplog.records) == 2
+    for record in caplog.records:
+        assert record.levelname == "WARNING"
+        assert record.message == message
+
+
+def test_context_manager_as_decorator_pattern(caplog):
+    """Test using the context manager in a decorator-like pattern."""
+    message = "Decorator pattern test"
+
+    def function_with_import():
+        with report_on_import_errors(message):
+            import nonexistent_module
+
+            # This assertion will never run and is only here to prevent ruff from removing the import
+            assert nonexistent_module is None  # pragma: no cover
+
+    with caplog.at_level(logging.WARNING):
+        function_with_import()
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.message == message


### PR DESCRIPTION
This will allow handling import errors gracefully by providing a custom message to the user, which could be something along the lines of, "Please install X".

Fixes #66