### PR TITLE
fix(signature): Return VarArg for *args (VAR_POSITIONAL) parameters

### DIFF
--- a/python/toolr/utils/_signature.py
+++ b/python/toolr/utils/_signature.py
@@ -461,7 +461,8 @@ def _parse_parameter(  # noqa: PLR0915
         assert isinstance(aliases, list)
 
     if positional:
-        return Arg(
+        positional_cls: type[Arg] = VarArg if param.kind == Parameter.VAR_POSITIONAL else Arg
+        return positional_cls(
             name=param_name,
             type=actual_type,
             description=description,

--- a/tests/utils/signature/test_get_signature.py
+++ b/tests/utils/signature/test_get_signature.py
@@ -11,6 +11,7 @@ from toolr import Context
 from toolr._exc import SignatureError
 from toolr.utils._signature import Arg
 from toolr.utils._signature import KwArg
+from toolr.utils._signature import VarArg
 from toolr.utils._signature import arg
 from toolr.utils._signature import get_signature
 
@@ -243,3 +244,46 @@ def test_get_signature_union_second_type_not_none():
 
     with pytest.raises(SignatureError, match=r"The second type of Arg 'value' must be None"):
         get_signature(test_func)
+
+
+def test_get_signature_var_positional_returns_vararg():
+    """get_signature must return a VarArg for *args-style (VAR_POSITIONAL) parameters.
+
+    Regression test: previously _parse_parameter set the local ``klass`` to ``VarArg``
+    for VAR_POSITIONAL parameters but the final return statement unconditionally built
+    an ``Arg``. That meant ``Signature.__call__`` never took the VarArg ``.extend``
+    branch, and values arrived in the user function nested inside a single-element
+    list instead of being spread.
+    """
+
+    def test_func(ctx: Context, *items: str) -> None:
+        """Test function with variable positional arguments.
+
+        Args:
+            items: The items.
+        """
+
+    signature = get_signature(test_func)
+    assert len(signature.arguments) == 1
+    assert signature.arguments[0].name == "items"
+    assert signature.arguments[0].nargs == "*"
+    assert isinstance(signature.arguments[0], VarArg)
+
+
+def test_get_signature_var_positional_with_other_args():
+    """VAR_POSITIONAL must remain a VarArg even when preceded by regular positionals."""
+
+    def test_func(ctx: Context, first: str, *rest: str) -> None:
+        """Test function with a positional and trailing varargs.
+
+        Args:
+            first: The first arg.
+            rest: The remaining args.
+        """
+
+    signature = get_signature(test_func)
+    assert len(signature.arguments) == 2
+    assert isinstance(signature.arguments[0], Arg)
+    assert not isinstance(signature.arguments[0], VarArg)
+    assert isinstance(signature.arguments[1], VarArg)
+    assert signature.arguments[1].nargs == "*"

--- a/tests/utils/signature/test_integration.py
+++ b/tests/utils/signature/test_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import enum
+from argparse import Namespace
 from typing import Annotated
 
 import pytest
@@ -133,3 +134,38 @@ def test_mutually_exclusive_groups_error_handling():
     # This should raise an error because positional arguments can't be in mutually exclusive groups
     with pytest.raises(SignatureError, match="Positional parameter 'name' cannot be in a mutually exclusive group"):
         get_signature(func)
+
+
+def test_signature_call_spreads_var_positional_values():
+    """End-to-end: ``*args`` values are spread into the user function, not nested.
+
+    Regression test for the bug where ``_parse_parameter`` returned a plain ``Arg``
+    for VAR_POSITIONAL parameters. That caused ``Signature.__call__`` to take the
+    ``Arg.append`` branch and the user function received the list as a single
+    positional argument rather than spread varargs.
+    """
+    captured: dict[str, object] = {}
+
+    def test_func(ctx: Context, *items: str) -> None:
+        """Function with varargs.
+
+        Args:
+            items: Items.
+        """
+        captured["items"] = items
+
+    signature = get_signature(test_func)
+
+    options = Namespace()
+    options.items = ["a", "b", "c"]
+
+    mock_ctx = Context(
+        repo_root=None,
+        parser=None,
+        verbosity=None,
+        _console_stderr=None,
+        _console_stdout=None,
+    )
+    signature(mock_ctx, options)
+
+    assert captured["items"] == ("a", "b", "c")


### PR DESCRIPTION
## Summary

`_parse_parameter` in `python/toolr/utils/_signature.py` correctly selected `VarArg` for the local `klass` variable when the parameter was `VAR_POSITIONAL`, but the final positional return statement unconditionally built an `Arg`, ignoring `klass`. As a result, `*args`-style parameters never went through the `VarArg.extend` branch in `Signature.__call__` — values arrived in the user function nested inside a single-element list instead of being spread.

```python
def cmd(ctx: Context, *items: str) -> None: ...
# Called with items=["a", "b", "c"]
# Before: items == (["a", "b", "c"],)
# After:  items == ("a", "b", "c")
```

The existing `Signature.__call__` tests in `tests/utils/signature/test_signature.py` constructed `VarArg` instances directly and so never exercised the path through `get_signature`, which is why this slipped through.

## Changes

- `_parse_parameter` now picks `VarArg` vs `Arg` based on `param.kind == Parameter.VAR_POSITIONAL` when building the return value, rather than always returning `Arg` for positionals.
- Adds two regression tests in `tests/utils/signature/test_get_signature.py` covering the class returned by `get_signature` for `*args` parameters (alone and alongside a regular positional).
- Adds an end-to-end integration test in `tests/utils/signature/test_integration.py` that drives the full `get_signature` → `Signature.__call__` path and asserts the user function receives spread varargs.

## Test plan

- [x] `uv run pytest -q tests/` — 329 passed (was 326).
- [x] `uv run ruff check` / `ruff format --check` — clean.

_claude --resume 2c0bc011-aabd-4efe-bfaf-1018ea79e556_