### PR TITLE
fix(signature): Match KwArg before Arg in Signature.__call__

### DIFF
--- a/python/toolr/utils/_signature.py
+++ b/python/toolr/utils/_signature.py
@@ -147,12 +147,16 @@ class Signature(Struct, Generic[F], frozen=True):
         kwargs: dict[str, Any] = {}
         for argument in self.arguments:
             argument_value = getattr(options, argument.name)
+            # KwArg and VarArg both subclass Arg, so the more specific subclasses
+            # must be matched first; otherwise KwArg values land in ``args`` and
+            # ``bind_partial`` fails for any function that uses a ``*,`` keyword-only
+            # separator.
             if isinstance(argument, VarArg):
                 args.extend(argument_value)
-            elif isinstance(argument, Arg):
-                args.append(argument_value)
             elif isinstance(argument, KwArg):
                 kwargs[argument.name] = argument_value
+            elif isinstance(argument, Arg):
+                args.append(argument_value)
             else:  # pragma: no cover
                 err_msg = f"Unknown argument type: {argument}"
                 raise TypeError(err_msg)

--- a/tests/utils/signature/test_integration.py
+++ b/tests/utils/signature/test_integration.py
@@ -169,3 +169,54 @@ def test_signature_call_spreads_var_positional_values():
     signature(mock_ctx, options)
 
     assert captured["items"] == ("a", "b", "c")
+
+
+def test_signature_call_routes_kwargs_with_keyword_only_separator():
+    """End-to-end: ``KwArg`` values must be routed via ``kwargs`` so a user
+    function with ``*,`` keyword-only parameters can be invoked.
+
+    Regression test: ``KwArg`` subclasses ``Arg``, so the ``isinstance(_, Arg)``
+    branch in ``Signature.__call__`` matched first and ``KwArg`` values were
+    appended to the positional ``args`` list. That worked when every parameter
+    was POSITIONAL_OR_KEYWORD (because the values still lined up positionally
+    after the prepended ``ctx``), but it broke as soon as the user function
+    used a ``*,`` separator: ``inspect.Signature.bind_partial`` raised
+    ``TypeError: too many positional arguments``.
+    """
+    captured: dict[str, object] = {}
+
+    def test_func(
+        ctx: Context,
+        target: str,
+        *,
+        verbose: bool = False,
+        retries: int = 3,
+    ) -> None:
+        """Function with a keyword-only separator and KwArgs after it.
+
+        Args:
+            target: The target to act on.
+            verbose: Whether to be verbose.
+            retries: Number of retries.
+        """
+        captured["target"] = target
+        captured["verbose"] = verbose
+        captured["retries"] = retries
+
+    signature = get_signature(test_func)
+
+    options = Namespace()
+    options.target = "alpha"
+    options.verbose = True
+    options.retries = 7
+
+    mock_ctx = Context(
+        repo_root=None,
+        parser=None,
+        verbosity=None,
+        _console_stderr=None,
+        _console_stdout=None,
+    )
+    signature(mock_ctx, options)
+
+    assert captured == {"target": "alpha", "verbose": True, "retries": 7}


### PR DESCRIPTION
## Summary

`KwArg` and `VarArg` both subclass `Arg`, so the `isinstance(argument, Arg)` branch in `Signature.__call__` matched first and `KwArg` values were appended to the positional `args` list instead of going through `kwargs`. That happened to work for functions where every parameter was `POSITIONAL_OR_KEYWORD` (the values still lined up positionally after `ctx` was prepended in `self.func(ctx, *bound.args, **bound.kwargs)`), but it broke the moment the user function introduced a `*,` keyword-only separator:

```python
@group.command
def cmd(
    ctx: Context,
    target: str,
    *,
    verbose: bool = False,
    retries: int = 3,
) -> None: ...
# TypeError: too many positional arguments
```

## Changes

- Reorder the `isinstance` checks in `Signature.__call__` so the more specific subclasses (`VarArg`, `KwArg`) are matched before the `Arg` base class, with a short comment explaining why the order matters.
- Adds a regression test in `tests/utils/signature/test_integration.py` driving the full `get_signature` → `Signature.__call__` path with a `*,`-separated function and asserting that the user function receives the right positional and keyword values.

## Test plan

- [x] `uv run pytest -q tests/` — 327 passed (was 326).
- [x] `uv run ruff check` / `ruff format --check` — clean.

_claude --resume 2c0bc011-aabd-4efe-bfaf-1018ea79e556_