### PR TITLE
fix(docs): Bump pymdown-extensions to 10.21.2 for pygments 2.20.0 compat

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -721,15 +721,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.17.2"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/6d/af5378dbdb379fddd9a277f8b9888c027db480cde70028669ebd009d642a/pymdown_extensions-10.17.2.tar.gz", hash = "sha256:26bb3d7688e651606260c90fb46409fbda70bf9fdc3623c7868643a1aeee4713", size = 847344, upload-time = "2025-11-26T15:43:57.004Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/78/b93cb80bd673bdc9f6ede63d8eb5b4646366953df15667eb3603be57a2b1/pymdown_extensions-10.17.2-py3-none-any.whl", hash = "sha256:bffae79a2e8b9e44aef0d813583a8fea63457b7a23643a43988055b7b79b4992", size = 266556, upload-time = "2025-11-26T15:43:55.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `Publish Docs` has been broken on `main` since #171 (pygments 2.19.2 → 2.20.0).
- pygments 2.20.0 stopped tolerating `filename=None` in `HtmlFormatter`; it now passes the option straight into `html.escape()`, which crashes with `AttributeError: 'NoneType' object has no attribute 'replace'`.
- pymdown-extensions 10.17.2 passes exactly that (`pymdownx/highlight.py:410`) when a fenced code block has no `title` attribute.
- Upstream fixed this in [pymdown-extensions 10.21.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.21.2): *"FIX: Highlight: Latest Pygments versions cannot handle a 'filename' for code block titles of `None`."*

This bumps pymdown-extensions in `uv.lock` only — it's a transitive dep via `mkdocs-material`, no need to surface it in `pyproject.toml`.

## Test plan

- [x] `uv run --group docs mkdocs build` succeeds locally.
- [x] Verified the fix still holds when pygments 2.20.0 is force-installed on top of pymdown-extensions 10.21.2 — so dependabot bumping pygments later won't re-break this.
- [ ] CI `Publish Docs` job passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude --resume 61d4200c-80a2-4b05-8b04-caea12beb436_