### PR TITLE
fix(docs): use descriptive link text in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,8 +17,8 @@ We take security vulnerabilities seriously and appreciate your efforts to respon
 
 If you discover a security vulnerability, please report it by:
 
-1. **GitHub Security Advisory**: Use GitHub's private vulnerability reporting feature that can be
-found [here](https://github.com/s0undt3ch/toolr/security/advisories/new).
+1. **GitHub Security Advisory**: Use GitHub's
+[private vulnerability reporting feature](https://github.com/s0undt3ch/toolr/security/advisories/new).
 
 ### What to Include
 


### PR DESCRIPTION
## Summary

- rumdl's `MD059` (link text should be descriptive) flagged the `[here](...)` link in `SECURITY.md`.
- Replaced with a descriptive `[private vulnerability reporting feature](...)` link.

## Test plan

- [x] `rumdl check SECURITY.md` reports clean
- [x] Pre-commit hooks pass on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude --resume aad12397-cbb5-49a7-9ed9-fbbdb12c65d2_