### PR TITLE
CI: migrate off deprecated codecov/test-results-action

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -227,8 +227,12 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        # codecov/test-results-action is deprecated in favour of running
+        # codecov-action a second time with report_type: test_results.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           # Use OpenID Connect for secure authentication (no token needed)
           use_oidc: true
+          report_type: test_results
+          files: junit-${{ matrix.python-version }}-${{ inputs.os }}.xml
           flags: ${{ inputs.os }},${{ matrix.python-version }}

--- a/.github/workflows/_test_distribution.yml
+++ b/.github/workflows/_test_distribution.yml
@@ -81,8 +81,12 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        # codecov/test-results-action is deprecated in favour of running
+        # codecov-action a second time with report_type: test_results.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           # Use OpenID Connect for secure authentication (no token needed)
           use_oidc: true
+          report_type: test_results
+          files: junit-dist-${{ inputs.os }}.xml
           flags: ${{ inputs.os }}


### PR DESCRIPTION
## Summary
- `codecov/test-results-action@v1` is being deprecated by Codecov in favour of running `codecov/codecov-action` a second time with `report_type: test_results`.
- Both `_test.yml` and `_test_distribution.yml` now invoke `codecov-action@v6` twice — once for coverage, once for the JUnit XML produced by pytest — with the JUnit path passed explicitly via the `files` input.
- OIDC auth and the existing `flags` (OS / Python version) are preserved.

## Test plan
- [ ] CI runs the Codecov upload steps without the deprecation warning.
- [ ] Test results show up on Codecov for both standard and distribution test jobs.