### PR TITLE
feat(argparse): built-in argparse scanner + DispatchCommand dispatcher contract

### DIFF
--- a/crates/toolr-core/src/argparse/attach.rs
+++ b/crates/toolr-core/src/argparse/attach.rs
@@ -1,0 +1,1 @@
+//! Attachment validation + grafting — implemented in Task 12.

--- a/crates/toolr-core/src/argparse/attach.rs
+++ b/crates/toolr-core/src/argparse/attach.rs
@@ -1,1 +1,169 @@
-//! Attachment validation + grafting — implemented in Task 12.
+//! Graft scanned commands under parent dispatchers, with validation.
+
+use std::collections::HashMap;
+
+use thiserror::Error;
+
+use crate::argparse::config::ArgparseBlock;
+use crate::manifest::Command;
+
+#[derive(Debug, Error)]
+pub enum AttachError {
+    #[error("source {block:?} attaches to unknown parent {parent:?}{hint}")]
+    UnknownParent {
+        block: String,
+        parent: String,
+        hint: String,
+    },
+    #[error("parent {parent:?} has no DispatchCommand-annotated keyword parameter")]
+    NotADispatcher { parent: String },
+    #[error(
+        "child name collision on parent {parent:?}: {name:?} is provided by both {a:?} and {b:?}"
+    )]
+    Collision {
+        parent: String,
+        name: String,
+        a: String,
+        b: String,
+    },
+}
+
+pub fn validate_attachments(
+    blocks: &[ArgparseBlock],
+    parents: &HashMap<String, (String, String)>,
+) -> Result<(), AttachError> {
+    let known: std::collections::BTreeSet<&str> = parents.keys().map(|s| s.as_str()).collect();
+    for block in blocks {
+        for attachment in &block.attach {
+            if !parents.contains_key(&attachment.parent) {
+                let hint = closest_parent_hint(&attachment.parent, &known);
+                return Err(AttachError::UnknownParent {
+                    block: block.name.clone(),
+                    parent: attachment.parent.clone(),
+                    hint,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_no_collisions(
+    children_by_parent: &HashMap<String, Vec<Command>>,
+) -> Result<(), AttachError> {
+    for (parent, children) in children_by_parent {
+        let mut seen: HashMap<&str, &str> = HashMap::new();
+        for child in children {
+            let source = child.dispatched_from.as_deref().unwrap_or("?");
+            if let Some(prev_source) = seen.get(child.name.as_str()) {
+                if *prev_source != source {
+                    return Err(AttachError::Collision {
+                        parent: parent.clone(),
+                        name: child.name.clone(),
+                        a: (*prev_source).into(),
+                        b: source.into(),
+                    });
+                }
+            }
+            seen.insert(&child.name, source);
+        }
+    }
+    Ok(())
+}
+
+fn closest_parent_hint(
+    target: &str,
+    candidates: &std::collections::BTreeSet<&str>,
+) -> String {
+    let mut best: Option<(usize, &str)> = None;
+    for candidate in candidates {
+        let dist = edit_distance(target, candidate);
+        if best.is_none_or(|(d, _)| dist < d) {
+            best = Some((dist, candidate));
+        }
+    }
+    match best {
+        Some((d, name)) if d <= 3 => format!(" (did you mean {name:?}?)"),
+        _ => String::new(),
+    }
+}
+
+fn edit_distance(a: &str, b: &str) -> usize {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    let mut prev = (0..=b.len()).collect::<Vec<_>>();
+    let mut cur = vec![0usize; b.len() + 1];
+    for i in 1..=a.len() {
+        cur[0] = i;
+        for j in 1..=b.len() {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            cur[j] = (prev[j] + 1).min(cur[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::argparse::config::Attachment;
+    use crate::manifest::Origin;
+
+    fn parents_with_django() -> HashMap<String, (String, String)> {
+        let mut m = HashMap::new();
+        m.insert(
+            "django".into(),
+            ("tools.dispatcher".into(), "django".into()),
+        );
+        m
+    }
+
+    fn block(name: &str, parent: &str) -> ArgparseBlock {
+        ArgparseBlock {
+            name: name.into(),
+            scan_paths: vec![],
+            common_args: vec![],
+            attach: vec![Attachment {
+                parent: parent.into(),
+            }],
+        }
+    }
+
+    #[test]
+    fn unknown_parent_with_hint() {
+        let err = validate_attachments(&[block("django", "djnago")], &parents_with_django())
+            .unwrap_err();
+        match err {
+            AttachError::UnknownParent { hint, .. } => {
+                assert!(
+                    hint.contains("django"),
+                    "hint did not surface the close match: {hint:?}"
+                );
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn collision_is_detected() {
+        let cmd = |source: &str| Command {
+            name: "migrate".into(),
+            group: "django".into(),
+            module: "tools.dispatcher".into(),
+            function: "django".into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: Some(source.into()),
+        };
+        let children: HashMap<String, Vec<Command>> =
+            HashMap::from([("django".into(), vec![cmd("a"), cmd("b")])]);
+        let err = validate_no_collisions(&children).unwrap_err();
+        match err {
+            AttachError::Collision { name, .. } => assert_eq!(name, "migrate"),
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+}

--- a/crates/toolr-core/src/argparse/attach.rs
+++ b/crates/toolr-core/src/argparse/attach.rs
@@ -5,7 +5,8 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 use crate::argparse::config::ArgparseBlock;
-use crate::manifest::Command;
+use crate::argparse::scan::ScannedCommand;
+use crate::manifest::{Command, Origin};
 
 #[derive(Debug, Error)]
 pub enum AttachError {
@@ -88,6 +89,40 @@ fn closest_parent_hint(
     }
 }
 
+pub fn graft_children(
+    block: &ArgparseBlock,
+    scanned: &[ScannedCommand],
+    parents: &HashMap<String, (String, String)>,
+) -> Result<HashMap<String, Vec<Command>>, AttachError> {
+    let mut out: HashMap<String, Vec<Command>> = HashMap::new();
+    for attachment in &block.attach {
+        let (module, function) =
+            parents
+                .get(&attachment.parent)
+                .ok_or_else(|| AttachError::UnknownParent {
+                    block: block.name.clone(),
+                    parent: attachment.parent.clone(),
+                    hint: String::new(),
+                })?;
+        let entries = out.entry(attachment.parent.clone()).or_default();
+        for sc in scanned {
+            entries.push(Command {
+                name: sc.name.clone(),
+                group: attachment.parent.clone(),
+                module: module.clone(),
+                function: function.clone(),
+                summary: sc.summary.clone(),
+                description: sc.description.clone(),
+                arguments: sc.arguments.clone(),
+                imports: vec![],
+                origin: Origin::Static,
+                dispatched_from: Some(format!("argparse:{}", block.name)),
+            });
+        }
+    }
+    Ok(out)
+}
+
 fn edit_distance(a: &str, b: &str) -> usize {
     let (a, b) = (a.as_bytes(), b.as_bytes());
     let mut prev = (0..=b.len()).collect::<Vec<_>>();
@@ -165,5 +200,34 @@ mod tests {
             AttachError::Collision { name, .. } => assert_eq!(name, "migrate"),
             other => panic!("unexpected error variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn graft_emits_one_child_per_scanned_with_dispatched_from() {
+        let block = ArgparseBlock {
+            name: "django".into(),
+            scan_paths: vec![],
+            common_args: vec![],
+            attach: vec![Attachment {
+                parent: "django".into(),
+            }],
+        };
+        let scanned = vec![ScannedCommand {
+            name: "migrate".into(),
+            summary: "Migrate".into(),
+            description: "".into(),
+            arguments: vec![],
+            warnings: vec![],
+        }];
+        let children = graft_children(&block, &scanned, &parents_with_django()).unwrap();
+        assert_eq!(children.len(), 1);
+        let django_children = children.get("django").unwrap();
+        assert_eq!(django_children[0].name, "migrate");
+        assert_eq!(
+            django_children[0].dispatched_from.as_deref(),
+            Some("argparse:django")
+        );
+        assert_eq!(django_children[0].module, "tools.dispatcher");
+        assert_eq!(django_children[0].function, "django");
     }
 }

--- a/crates/toolr-core/src/argparse/attach.rs
+++ b/crates/toolr-core/src/argparse/attach.rs
@@ -117,6 +117,7 @@ pub fn graft_children(
                 imports: vec![],
                 origin: Origin::Static,
                 dispatched_from: Some(format!("argparse:{}", block.name)),
+                is_dispatcher: false,
             });
         }
     }
@@ -192,6 +193,7 @@ mod tests {
             imports: vec![],
             origin: Origin::Static,
             dispatched_from: Some(source.into()),
+            is_dispatcher: false,
         };
         let children: HashMap<String, Vec<Command>> =
             HashMap::from([("django".into(), vec![cmd("a"), cmd("b")])]);

--- a/crates/toolr-core/src/argparse/config.rs
+++ b/crates/toolr-core/src/argparse/config.rs
@@ -1,0 +1,135 @@
+//! Parse `[tool.toolr.argparse.*]` blocks from `tools/pyproject.toml`.
+
+use std::path::Path;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::manifest::ArgumentKind;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ArgparseBlock {
+    /// Block key under `[tool.toolr.argparse.<name>]`. Set by the parser
+    /// from the table key, not from a field on the table.
+    #[serde(skip_deserializing, default)]
+    pub name: String,
+    #[serde(default)]
+    pub scan_paths: Vec<String>,
+    #[serde(default)]
+    pub common_args: Vec<CommonArg>,
+    #[serde(default)]
+    pub attach: Vec<Attachment>,
+}
+
+impl ArgparseBlock {
+    pub fn attachments(&self) -> &[Attachment] {
+        &self.attach
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct CommonArg {
+    pub name: String,
+    pub kind: ArgumentKind,
+    #[serde(default)]
+    pub help: String,
+    #[serde(default)]
+    pub default: Option<String>,
+    #[serde(default)]
+    pub choices: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Attachment {
+    pub parent: String,
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("failed to parse tool.toolr.argparse: {0}")]
+    Toml(#[from] toml::de::Error),
+    #[error("failed to read {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Public: parse blocks from a raw TOML string. Convenient for tests.
+pub fn parse_blocks(toml_text: &str) -> Result<Vec<ArgparseBlock>, ConfigError> {
+    #[derive(Deserialize)]
+    struct Root {
+        #[serde(default)]
+        tool: Tool,
+    }
+    #[derive(Default, Deserialize)]
+    struct Tool {
+        #[serde(default)]
+        toolr: Toolr,
+    }
+    #[derive(Default, Deserialize)]
+    struct Toolr {
+        #[serde(default)]
+        argparse: std::collections::BTreeMap<String, ArgparseBlock>,
+    }
+    let root: Root = toml::from_str(toml_text)?;
+    Ok(root
+        .tool
+        .toolr
+        .argparse
+        .into_iter()
+        .map(|(name, mut block)| {
+            block.name = name;
+            block
+        })
+        .collect())
+}
+
+/// Public: read `pyproject.toml` from disk and parse.
+pub fn parse_blocks_from_pyproject(
+    pyproject: &Path,
+) -> Result<Vec<ArgparseBlock>, ConfigError> {
+    let text = std::fs::read_to_string(pyproject).map_err(|source| ConfigError::Io {
+        path: pyproject.display().to_string(),
+        source,
+    })?;
+    parse_blocks(&text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_one_block_two_attachments() {
+        let toml_text = r#"
+            [tool.toolr.argparse.django]
+            scan_paths = ["apps/*/management/commands/*.py"]
+            common_args = [
+              { name = "verbosity", kind = "optional", default = "1" },
+            ]
+
+            [[tool.toolr.argparse.django.attach]]
+            parent = "django"
+
+            [[tool.toolr.argparse.django.attach]]
+            parent = "jenkins.job"
+        "#;
+        let blocks = parse_blocks(toml_text).unwrap();
+        assert_eq!(blocks.len(), 1);
+        let block = &blocks[0];
+        assert_eq!(block.name, "django");
+        assert_eq!(block.scan_paths, vec!["apps/*/management/commands/*.py"]);
+        assert_eq!(block.common_args.len(), 1);
+        assert_eq!(
+            block.attachments().iter().map(|a| a.parent.as_str()).collect::<Vec<_>>(),
+            vec!["django", "jenkins.job"],
+        );
+    }
+
+    #[test]
+    fn empty_table_returns_empty() {
+        assert!(parse_blocks("[project]\nname = 'x'\n").unwrap().is_empty());
+    }
+}

--- a/crates/toolr-core/src/argparse/mod.rs
+++ b/crates/toolr-core/src/argparse/mod.rs
@@ -2,7 +2,7 @@
 //! `[tool.toolr.argparse.*]` and grafts their `parser.add_argument`
 //! calls as manifest children of user-declared dispatcher commands.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use thiserror::Error;
@@ -25,42 +25,61 @@ pub enum ArgparseError {
     Attach(#[from] attach::AttachError),
 }
 
+/// Outcome of running the argparse pipeline for a project.
+#[derive(Debug, Clone, Default)]
+pub struct GraftResult {
+    /// `{parent_dotted_name -> [grafted child Command]}`.
+    pub children_by_parent: HashMap<String, Vec<Command>>,
+    /// Dotted names of parents that received at least one grafted
+    /// child. The caller flips `is_dispatcher = true` on each.
+    pub dispatchers: HashSet<String>,
+}
+
 /// Run the full argparse pipeline for a project: read pyproject,
 /// scan files, validate attachments, graft children, detect
-/// collisions. Returns `{parent_dotted_name: [child Commands]}`.
+/// collisions. Returns a [`GraftResult`] mapping each parent dotted
+/// name to its grafted children and recording which parents received
+/// any children (so the caller can flip `is_dispatcher`).
 ///
 /// `parents` maps every potential dispatcher's dotted name to
 /// `(module, function)`. The static parser populates this from the
 /// freshly-walked registry before calling `run_for_project`.
 ///
-/// Returns an empty map when no `tools/pyproject.toml` exists or
-/// when it has no `[tool.toolr.argparse.*]` blocks.
+/// Returns an empty [`GraftResult`] when no `tools/pyproject.toml`
+/// exists or when it has no `[tool.toolr.argparse.*]` blocks.
 pub fn run_for_project(
     project_root: &Path,
     parents: &HashMap<String, (String, String)>,
-) -> Result<HashMap<String, Vec<Command>>, ArgparseError> {
+) -> Result<GraftResult, ArgparseError> {
     let pyproject = project_root.join("tools").join("pyproject.toml");
     if !pyproject.exists() {
-        return Ok(HashMap::new());
+        return Ok(GraftResult::default());
     }
     let blocks = config::parse_blocks_from_pyproject(&pyproject)?;
     if blocks.is_empty() {
-        return Ok(HashMap::new());
+        return Ok(GraftResult::default());
     }
     attach::validate_attachments(&blocks, parents)?;
 
     let mut out: HashMap<String, Vec<Command>> = HashMap::new();
+    let mut dispatchers: HashSet<String> = HashSet::new();
     for block in &blocks {
         let scanned: Vec<scan::ScannedCommand> = scan::scan_block_paths(project_root, &block.scan_paths)?
             .into_iter()
             .map(|s| scan::with_common_args(s, &block.common_args))
             .collect();
         for (parent, children) in attach::graft_children(block, &scanned, parents)? {
+            if !children.is_empty() {
+                dispatchers.insert(parent.clone());
+            }
             out.entry(parent).or_default().extend(children);
         }
     }
     attach::validate_no_collisions(&out)?;
-    Ok(out)
+    Ok(GraftResult {
+        children_by_parent: out,
+        dispatchers,
+    })
 }
 
 #[cfg(test)]
@@ -99,12 +118,15 @@ mod tests {
         );
 
         let result = run_for_project(project.path(), &parents).unwrap();
-        let django_children = result.get("django").unwrap();
+        let django_children = result.children_by_parent.get("django").unwrap();
         assert_eq!(django_children.len(), 1);
         assert_eq!(django_children[0].name, "sync");
         assert_eq!(
             django_children[0].dispatched_from.as_deref(),
             Some("argparse:django"),
         );
+
+        // `django` received grafted children, so it's in `dispatchers`.
+        assert!(result.dispatchers.contains("django"));
     }
 }

--- a/crates/toolr-core/src/argparse/mod.rs
+++ b/crates/toolr-core/src/argparse/mod.rs
@@ -2,8 +2,109 @@
 //! `[tool.toolr.argparse.*]` and grafts their `parser.add_argument`
 //! calls as manifest children of user-declared dispatcher commands.
 
+use std::collections::HashMap;
+use std::path::Path;
+
+use thiserror::Error;
+
+use crate::manifest::Command;
+
 pub mod attach;
 pub mod config;
 pub mod scan;
 
 pub use config::{ArgparseBlock, Attachment, parse_blocks, parse_blocks_from_pyproject};
+
+#[derive(Debug, Error)]
+pub enum ArgparseError {
+    #[error(transparent)]
+    Config(#[from] config::ConfigError),
+    #[error(transparent)]
+    Scan(#[from] scan::ScanError),
+    #[error(transparent)]
+    Attach(#[from] attach::AttachError),
+}
+
+/// Run the full argparse pipeline for a project: read pyproject,
+/// scan files, validate attachments, graft children, detect
+/// collisions. Returns `{parent_dotted_name: [child Commands]}`.
+///
+/// `parents` maps every potential dispatcher's dotted name to
+/// `(module, function)`. The static parser populates this from the
+/// freshly-walked registry before calling `run_for_project`.
+///
+/// Returns an empty map when no `tools/pyproject.toml` exists or
+/// when it has no `[tool.toolr.argparse.*]` blocks.
+pub fn run_for_project(
+    project_root: &Path,
+    parents: &HashMap<String, (String, String)>,
+) -> Result<HashMap<String, Vec<Command>>, ArgparseError> {
+    let pyproject = project_root.join("tools").join("pyproject.toml");
+    if !pyproject.exists() {
+        return Ok(HashMap::new());
+    }
+    let blocks = config::parse_blocks_from_pyproject(&pyproject)?;
+    if blocks.is_empty() {
+        return Ok(HashMap::new());
+    }
+    attach::validate_attachments(&blocks, parents)?;
+
+    let mut out: HashMap<String, Vec<Command>> = HashMap::new();
+    for block in &blocks {
+        let scanned: Vec<scan::ScannedCommand> = scan::scan_block_paths(project_root, &block.scan_paths)?
+            .into_iter()
+            .map(|s| scan::with_common_args(s, &block.common_args))
+            .collect();
+        for (parent, children) in attach::graft_children(block, &scanned, parents)? {
+            out.entry(parent).or_default().extend(children);
+        }
+    }
+    attach::validate_no_collisions(&out)?;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn run_for_project_returns_grafted_children() {
+        let project = tempfile::tempdir().unwrap();
+        let tools = project.path().join("tools");
+        std::fs::create_dir_all(&tools).unwrap();
+        let cmds = project.path().join("apps/billing/management/commands");
+        std::fs::create_dir_all(&cmds).unwrap();
+        std::fs::write(
+            cmds.join("sync.py"),
+            "def add_arguments(self, parser):\n    parser.add_argument('--force', action='store_true')\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tools.join("pyproject.toml"),
+            r#"
+                [tool.toolr.argparse.django]
+                scan_paths = ["apps/*/management/commands/*.py"]
+
+                [[tool.toolr.argparse.django.attach]]
+                parent = "django"
+            "#,
+        )
+        .unwrap();
+
+        let mut parents = HashMap::new();
+        parents.insert(
+            "django".to_string(),
+            ("tools.dispatcher".to_string(), "django".to_string()),
+        );
+
+        let result = run_for_project(project.path(), &parents).unwrap();
+        let django_children = result.get("django").unwrap();
+        assert_eq!(django_children.len(), 1);
+        assert_eq!(django_children[0].name, "sync");
+        assert_eq!(
+            django_children[0].dispatched_from.as_deref(),
+            Some("argparse:django"),
+        );
+    }
+}

--- a/crates/toolr-core/src/argparse/mod.rs
+++ b/crates/toolr-core/src/argparse/mod.rs
@@ -1,0 +1,9 @@
+//! Built-in argparse scanner: AST-walks Python files declared in
+//! `[tool.toolr.argparse.*]` and grafts their `parser.add_argument`
+//! calls as manifest children of user-declared dispatcher commands.
+
+pub mod attach;
+pub mod config;
+pub mod scan;
+
+pub use config::{ArgparseBlock, Attachment, parse_blocks, parse_blocks_from_pyproject};

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -1,1 +1,463 @@
-//! Argparse AST scanner — implemented in Task 9.
+//! Walk a Python file's AST and extract `<x>.add_argument(...)` calls.
+
+use ruff_python_ast::{Expr, ExprCall, ModModule, Stmt};
+use ruff_python_parser as parser;
+use thiserror::Error;
+
+#[allow(unused_imports)] // Used by Task 11 (with_common_args helper).
+use crate::argparse::config::CommonArg;
+use crate::manifest::{ArgMetadata, Argument, ArgumentKind};
+
+#[derive(Debug, Error)]
+pub enum ScanError {
+    #[error("failed to parse {path}: {message}")]
+    Parse { path: String, message: String },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ScannedCommand {
+    pub name: String,        // filename stem
+    pub summary: String,     // first paragraph of module docstring
+    pub description: String, // rest of module docstring
+    pub arguments: Vec<Argument>,
+    pub warnings: Vec<String>,
+}
+
+/// argparse keyword arguments we recognise — the signature-shape filter
+/// requires every kwarg present on a candidate call to be in this set.
+/// Other names mean the call is some unrelated `.add_argument(...)` and
+/// we silently skip it.
+const ARGPARSE_KWARGS: &[&str] = &[
+    "action", "nargs", "const", "default", "type", "choices", "required", "help", "metavar",
+    "dest", "version",
+];
+
+/// Parse `source_text` (Python) and return a `ScannedCommand`.
+/// `command_name` is what the caller wants to label this file's discovered
+/// command as (typically the filename stem).
+pub fn scan_source(command_name: &str, source_text: &str) -> Result<ScannedCommand, ScanError> {
+    let parsed = parser::parse_module(source_text).map_err(|e| ScanError::Parse {
+        path: command_name.to_string(),
+        message: e.to_string(),
+    })?;
+    let module = parsed.into_syntax();
+    let (summary, description) = split_docstring(&module_docstring(&module));
+
+    let mut out = ScannedCommand {
+        name: command_name.to_string(),
+        summary,
+        description,
+        arguments: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    for stmt in &module.body {
+        visit_stmt(stmt, &mut out);
+    }
+
+    Ok(out)
+}
+
+/// Recursively walk statements looking for `Expr::Call` whose `.func` is
+/// `<anything>.add_argument`. Function/class bodies are descended into.
+fn visit_stmt(stmt: &Stmt, out: &mut ScannedCommand) {
+    match stmt {
+        Stmt::FunctionDef(f) => {
+            for s in &f.body {
+                visit_stmt(s, out);
+            }
+        }
+        Stmt::ClassDef(c) => {
+            for s in &c.body {
+                visit_stmt(s, out);
+            }
+        }
+        Stmt::If(i) => {
+            for s in &i.body {
+                visit_stmt(s, out);
+            }
+            for clause in &i.elif_else_clauses {
+                for s in &clause.body {
+                    visit_stmt(s, out);
+                }
+            }
+        }
+        Stmt::For(f) => {
+            for s in &f.body {
+                visit_stmt(s, out);
+            }
+            for s in &f.orelse {
+                visit_stmt(s, out);
+            }
+        }
+        Stmt::While(w) => {
+            for s in &w.body {
+                visit_stmt(s, out);
+            }
+            for s in &w.orelse {
+                visit_stmt(s, out);
+            }
+        }
+        Stmt::With(w) => {
+            for s in &w.body {
+                visit_stmt(s, out);
+            }
+        }
+        Stmt::Try(t) => {
+            for s in &t.body {
+                visit_stmt(s, out);
+            }
+            for h in &t.handlers {
+                let ruff_python_ast::ExceptHandler::ExceptHandler(h) = h;
+                for s in &h.body {
+                    visit_stmt(s, out);
+                }
+            }
+            for s in &t.orelse {
+                visit_stmt(s, out);
+            }
+            for s in &t.finalbody {
+                visit_stmt(s, out);
+            }
+        }
+        Stmt::Expr(e) => visit_expr(&e.value, out),
+        _ => {}
+    }
+}
+
+/// Walk an expression looking for `.add_argument(...)` calls. We only
+/// need to inspect Calls — argparse usage is always a method call.
+fn visit_expr(expr: &Expr, out: &mut ScannedCommand) {
+    if let Expr::Call(call) = expr {
+        if let Some(arg) = try_extract_argument(call, &mut out.warnings) {
+            out.arguments.push(arg);
+        }
+    }
+}
+
+/// If `call` matches the argparse `add_argument` signature shape, build
+/// the corresponding `Argument`. Returns `None` (silently) when the
+/// shape doesn't match — this is how we tell argparse calls apart from
+/// unrelated `.add_argument(...)` calls on other objects.
+fn try_extract_argument(call: &ExprCall, warnings: &mut Vec<String>) -> Option<Argument> {
+    // (1) Function must be `<anything>.add_argument`.
+    let Expr::Attribute(attr) = call.func.as_ref() else {
+        return None;
+    };
+    if attr.attr.as_str() != "add_argument" {
+        return None;
+    }
+
+    // (2) Must have at least one positional, and every positional must
+    //     be a string literal.
+    let positionals = &call.arguments.args;
+    if positionals.is_empty() {
+        return None;
+    }
+    let mut pos_strs: Vec<String> = Vec::with_capacity(positionals.len());
+    for p in positionals.iter() {
+        let Expr::StringLiteral(s) = p else {
+            return None;
+        };
+        pos_strs.push(s.value.to_str().to_string());
+    }
+
+    // (3) Every kwarg name must be in the argparse-known set.
+    for kw in &call.arguments.keywords {
+        let Some(name) = kw.arg.as_ref().map(|n| n.as_str()) else {
+            // `**kwargs` splat — unknown name, treat as non-argparse.
+            return None;
+        };
+        if !ARGPARSE_KWARGS.contains(&name) {
+            return None;
+        }
+    }
+
+    // Shape check passed — classify and extract.
+    Some(build_argument(&pos_strs, call, warnings))
+}
+
+/// Build the `Argument` from a confirmed argparse `add_argument` call.
+fn build_argument(positionals: &[String], call: &ExprCall, warnings: &mut Vec<String>) -> Argument {
+    // Pick the canonical name: for keyword-style args, prefer the
+    // longest `--foo`; for positional, the sole positional string.
+    let is_keyword_style = positionals.iter().any(|s| s.starts_with('-'));
+    let (name, name_for_warning) = if is_keyword_style {
+        let longest = positionals
+            .iter()
+            .filter(|s| s.starts_with("--"))
+            .max_by_key(|s| s.len())
+            .or_else(|| positionals.iter().find(|s| s.starts_with('-')))
+            .expect("we know at least one positional starts with '-'");
+        let stripped = longest.trim_start_matches('-').to_string();
+        (stripped, longest.clone())
+    } else {
+        let n = positionals[0].clone();
+        (n.clone(), n)
+    };
+
+    // Collect kwargs by name (string-encoded best-effort).
+    let mut action: Option<String> = None;
+    let mut default: Option<String> = None;
+    let mut help_text = String::new();
+    let mut choices: Vec<String> = Vec::new();
+    let mut type_annotation: Option<String> = None;
+    let mut metavar: Option<String> = None;
+    for kw in &call.arguments.keywords {
+        let Some(kw_name) = kw.arg.as_ref().map(|n| n.as_str()) else {
+            continue;
+        };
+        match kw_name {
+            "action" => action = literal_str(&kw.value),
+            "default" => default = literal_to_string(&kw.value),
+            "help" => {
+                if let Some(s) = literal_str(&kw.value) {
+                    help_text = s;
+                }
+            }
+            "choices" => {
+                if let Some(list) = literal_str_list(&kw.value) {
+                    choices = list;
+                }
+            }
+            "type" => {
+                let resolved = resolve_type_kwarg(&kw.value);
+                match resolved {
+                    Some(t) => type_annotation = Some(t),
+                    None => {
+                        let raw = type_kwarg_repr(&kw.value);
+                        warnings.push(format!(
+                            "argparse: {name_for_warning}: unresolvable type={raw}"
+                        ));
+                    }
+                }
+            }
+            "metavar" => metavar = literal_str(&kw.value),
+            _ => {}
+        }
+    }
+
+    let kind = classify_kind(is_keyword_style, action.as_deref());
+
+    let mut metadata = ArgMetadata::default();
+    if let Some(mv) = metavar {
+        metadata.metavar = Some(mv);
+    }
+
+    Argument {
+        name,
+        kind,
+        help: help_text,
+        default,
+        type_annotation,
+        resolved_type: None,
+        allowed_values: choices,
+        path_constraints: None,
+        metadata,
+    }
+}
+
+fn classify_kind(is_keyword_style: bool, action: Option<&str>) -> ArgumentKind {
+    if !is_keyword_style {
+        return ArgumentKind::Positional;
+    }
+    match action {
+        Some("store_true") | Some("store_false") => ArgumentKind::Flag,
+        Some("append") => ArgumentKind::Repeated,
+        _ => ArgumentKind::Optional,
+    }
+}
+
+/// Returns the type name if `expr` is one of the literal type-builtin
+/// names that argparse recognises and we know how to render.
+fn resolve_type_kwarg(expr: &Expr) -> Option<String> {
+    let Expr::Name(n) = expr else { return None };
+    let id = n.id.as_str();
+    matches!(id, "int" | "float" | "str" | "bool").then(|| id.to_string())
+}
+
+/// Best-effort textual rendering of an unresolved `type=...` value for
+/// the warning message.
+fn type_kwarg_repr(expr: &Expr) -> String {
+    match expr {
+        Expr::Name(n) => n.id.as_str().to_string(),
+        Expr::Attribute(a) => {
+            let prefix = type_kwarg_repr(&a.value);
+            format!("{prefix}.{}", a.attr)
+        }
+        _ => "<expr>".to_string(),
+    }
+}
+
+fn literal_str(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::StringLiteral(s) => Some(s.value.to_str().to_string()),
+        _ => None,
+    }
+}
+
+fn literal_str_list(expr: &Expr) -> Option<Vec<String>> {
+    let elts = match expr {
+        Expr::List(l) => &l.elts,
+        Expr::Tuple(t) => &t.elts,
+        _ => return None,
+    };
+    let mut out = Vec::with_capacity(elts.len());
+    for e in elts {
+        out.push(literal_str(e)?);
+    }
+    Some(out)
+}
+
+/// Render a literal default value as a string. Booleans/ints/floats/strs
+/// all map cleanly; non-literal expressions yield `None` (the caller
+/// treats this as "no default").
+fn literal_to_string(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::StringLiteral(s) => Some(s.value.to_str().to_string()),
+        Expr::NumberLiteral(n) => match &n.value {
+            ruff_python_ast::Number::Int(i) => Some(i.to_string()),
+            ruff_python_ast::Number::Float(f) => Some(f.to_string()),
+            ruff_python_ast::Number::Complex { real, imag } => Some(format!("({real}+{imag}j)")),
+        },
+        Expr::BooleanLiteral(b) => Some(if b.value { "true" } else { "false" }.to_string()),
+        Expr::NoneLiteral(_) => None,
+        _ => None,
+    }
+}
+
+/// Grab the module's leading string-literal as the raw docstring.
+fn module_docstring(module: &ModModule) -> String {
+    let Some(Stmt::Expr(e)) = module.body.first() else {
+        return String::new();
+    };
+    let Expr::StringLiteral(s) = e.value.as_ref() else {
+        return String::new();
+    };
+    s.value.to_str().to_string()
+}
+
+/// Split a docstring into (summary, description). The summary is the
+/// first paragraph (everything before the first blank line); the
+/// description is everything after it, with leading blank lines
+/// stripped.
+fn split_docstring(raw: &str) -> (String, String) {
+    let trimmed = raw.trim_start_matches('\n');
+    let mut summary = String::new();
+    let mut rest_start = None;
+    for (idx, line) in trimmed.lines().enumerate() {
+        if line.trim().is_empty() {
+            rest_start = Some(idx + 1);
+            break;
+        }
+        if !summary.is_empty() {
+            summary.push(' ');
+        }
+        summary.push_str(line.trim());
+    }
+    let description = match rest_start {
+        Some(start) => trimmed
+            .lines()
+            .skip(start)
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string(),
+        None => String::new(),
+    };
+    (summary, description)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_positional_optional_flag_and_repeated() {
+        let source = r#"
+"""Migrate the database.
+
+Handles schema migrations and rolling back.
+"""
+def add_arguments(self, parser):
+    parser.add_argument('app_label')
+    parser.add_argument('--database', default='default', help='Target DB')
+    parser.add_argument('--check', action='store_true', help='Dry run')
+    parser.add_argument('--exclude', action='append')
+"#;
+        let scanned = scan_source("migrate", source).unwrap();
+        assert_eq!(scanned.name, "migrate");
+        assert_eq!(scanned.summary, "Migrate the database.");
+        assert!(scanned.description.contains("Handles schema migrations"));
+
+        let names: Vec<_> = scanned.arguments.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["app_label", "database", "check", "exclude"]);
+
+        assert_eq!(scanned.arguments[0].kind, ArgumentKind::Positional);
+        assert_eq!(scanned.arguments[1].kind, ArgumentKind::Optional);
+        assert_eq!(scanned.arguments[1].default.as_deref(), Some("default"));
+        assert_eq!(scanned.arguments[2].kind, ArgumentKind::Flag);
+        assert_eq!(scanned.arguments[3].kind, ArgumentKind::Repeated);
+    }
+
+    #[test]
+    fn empty_file_yields_command_with_no_args() {
+        let scanned = scan_source("empty", "").unwrap();
+        assert!(scanned.arguments.is_empty());
+        assert_eq!(scanned.name, "empty");
+    }
+
+    #[test]
+    fn unresolvable_type_emits_warning_and_no_type_annotation() {
+        let source = r#"
+def add_arguments(self, parser):
+    parser.add_argument('--count', type=parse_count)
+"#;
+        let scanned = scan_source("x", source).unwrap();
+        assert_eq!(scanned.arguments.len(), 1);
+        assert_eq!(scanned.arguments[0].type_annotation, None);
+        assert!(scanned.warnings.iter().any(|w| w.contains("type=")));
+    }
+
+    #[test]
+    fn matches_any_receiver_name() {
+        // Django-style (`parser`), nested attribute (`self.parser`), and
+        // a custom name should all be picked up — receiver is not checked.
+        let source = r#"
+def add_arguments(self, parser):
+    parser.add_argument('a')
+    self.parser.add_argument('--b', action='store_true')
+    sub_parser.add_argument('c')
+"#;
+        let scanned = scan_source("x", source).unwrap();
+        let names: Vec<_> = scanned.arguments.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn skips_calls_whose_positional_is_not_a_string_literal() {
+        // First positional is an int — not an argparse name/flag, skip.
+        let source = "def f(): mylist.add_argument(42, default='x')";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(scanned.arguments.is_empty());
+        assert!(scanned.warnings.is_empty(), "skipping non-argparse calls should not warn");
+    }
+
+    #[test]
+    fn skips_calls_with_unknown_kwarg() {
+        // `frobnicate` is not in the argparse kwarg set; this is some other
+        // method named `add_argument`. Skip silently.
+        let source = "def f(): widget.add_argument('--x', frobnicate=True)";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(scanned.arguments.is_empty());
+        assert!(scanned.warnings.is_empty());
+    }
+
+    #[test]
+    fn skips_calls_with_no_positional_arguments() {
+        let source = "def f(): widget.add_argument(action='store_true')";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(scanned.arguments.is_empty());
+        assert!(scanned.warnings.is_empty());
+    }
+}

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -4,7 +4,6 @@ use ruff_python_ast::{Expr, ExprCall, ModModule, Stmt};
 use ruff_python_parser as parser;
 use thiserror::Error;
 
-#[allow(unused_imports)] // Used by Task 11 (with_common_args helper).
 use crate::argparse::config::CommonArg;
 use crate::manifest::{ArgMetadata, Argument, ArgumentKind};
 
@@ -441,6 +440,31 @@ pub fn scan_block_paths(
     Ok(out)
 }
 
+/// Append `common` args to `scanned`, skipping any whose `name` collides
+/// with an existing argument. The file's own argument always wins on
+/// collision.
+pub fn with_common_args(mut scanned: ScannedCommand, common: &[CommonArg]) -> ScannedCommand {
+    let existing: std::collections::HashSet<&str> =
+        scanned.arguments.iter().map(|a| a.name.as_str()).collect();
+    let extras: Vec<Argument> = common
+        .iter()
+        .filter(|c| !existing.contains(c.name.as_str()))
+        .map(|c| Argument {
+            name: c.name.clone(),
+            kind: c.kind,
+            help: c.help.clone(),
+            default: c.default.clone(),
+            type_annotation: None,
+            resolved_type: None,
+            allowed_values: c.choices.clone().unwrap_or_default(),
+            path_constraints: None,
+            metadata: Default::default(),
+        })
+        .collect();
+    scanned.arguments.extend(extras);
+    scanned
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -532,6 +556,49 @@ def add_arguments(self, parser):
         let scanned = scan_source("x", source).unwrap();
         assert!(scanned.arguments.is_empty());
         assert!(scanned.warnings.is_empty());
+    }
+
+    #[test]
+    fn common_args_are_appended_when_not_shadowed() {
+        let scanned = ScannedCommand {
+            name: "migrate".into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![Argument {
+                name: "verbosity".into(),
+                kind: ArgumentKind::Optional,
+                help: "local".into(),
+                default: Some("2".into()),
+                type_annotation: None,
+                resolved_type: None,
+                allowed_values: vec![],
+                path_constraints: None,
+                metadata: Default::default(),
+            }],
+            warnings: vec![],
+        };
+        let common = vec![
+            CommonArg {
+                name: "verbosity".into(),
+                kind: ArgumentKind::Optional,
+                help: "common".into(),
+                default: Some("0".into()),
+                choices: None,
+            },
+            CommonArg {
+                name: "traceback".into(),
+                kind: ArgumentKind::Flag,
+                help: "tb".into(),
+                default: None,
+                choices: None,
+            },
+        ];
+        let merged = with_common_args(scanned, &common);
+        let names: Vec<_> = merged.arguments.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["verbosity", "traceback"]);
+        // The local "verbosity" wins.
+        assert_eq!(merged.arguments[0].help, "local");
+        assert_eq!(merged.arguments[0].default.as_deref(), Some("2"));
     }
 
     #[test]

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -368,6 +368,79 @@ fn split_docstring(raw: &str) -> (String, String) {
     (summary, description)
 }
 
+use std::path::Path;
+
+/// Expand every glob in `scan_paths` against `root`, scan each match,
+/// and return one `ScannedCommand` per file. Files that failed to parse
+/// become placeholder `ScannedCommand`s (no arguments) with the failure
+/// recorded in their `warnings` field — the rest of the build continues.
+pub fn scan_block_paths(
+    root: &Path,
+    scan_paths: &[String],
+) -> Result<Vec<ScannedCommand>, ScanError> {
+    let mut all_paths: Vec<std::path::PathBuf> = Vec::new();
+    for pattern in scan_paths {
+        let abs = root.join(pattern);
+        // Bad glob pattern is a hard error so the user finds their typo.
+        let pattern_str = abs.to_str().ok_or_else(|| ScanError::Parse {
+            path: pattern.clone(),
+            message: "non-utf8 path in scan_paths".into(),
+        })?;
+        for path in glob::glob(pattern_str)
+            .map_err(|e| ScanError::Parse {
+                path: pattern.clone(),
+                message: e.to_string(),
+            })?
+            .flatten()
+        {
+            if path.is_file() {
+                all_paths.push(path);
+            }
+        }
+    }
+    all_paths.sort();
+    all_paths.dedup();
+
+    let mut out = Vec::with_capacity(all_paths.len());
+    for path in all_paths {
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        let text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(err) => {
+                let mut placeholder = ScannedCommand {
+                    name: stem.clone(),
+                    ..Default::default()
+                };
+                placeholder
+                    .warnings
+                    .push(format!("failed to read {}: {}", path.display(), err));
+                out.push(placeholder);
+                continue;
+            }
+        };
+        match scan_source(&stem, &text) {
+            Ok(cmd) => out.push(cmd),
+            Err(ScanError::Parse { message, .. }) => {
+                let mut placeholder = ScannedCommand {
+                    name: stem,
+                    ..Default::default()
+                };
+                placeholder.warnings.push(format!(
+                    "failed to parse {}: {}",
+                    path.display(),
+                    message
+                ));
+                out.push(placeholder);
+            }
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -459,5 +532,29 @@ def add_arguments(self, parser):
         let scanned = scan_source("x", source).unwrap();
         assert!(scanned.arguments.is_empty());
         assert!(scanned.warnings.is_empty());
+    }
+
+    #[test]
+    fn scan_paths_expands_globs_and_skips_unparsable() {
+        let project = tempfile::tempdir().unwrap();
+        let cmds = project.path().join("apps/x/management/commands");
+        std::fs::create_dir_all(&cmds).unwrap();
+        std::fs::write(cmds.join("migrate.py"), "def add_arguments(self, parser):\n    parser.add_argument('app_label')\n").unwrap();
+        std::fs::write(cmds.join("runserver.py"), "def add_arguments(self, parser):\n    parser.add_argument('--insecure', action='store_true')\n").unwrap();
+        std::fs::write(cmds.join("broken.py"), "def add_arguments(self, parser:\n").unwrap(); // syntax error
+
+        let scanned = scan_block_paths(
+            project.path(),
+            &["apps/*/management/commands/*.py".to_string()],
+        ).unwrap();
+
+        // Expect migrate + runserver scanned successfully, broken recorded as a warning placeholder.
+        let names: std::collections::BTreeSet<_> = scanned.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains("migrate"));
+        assert!(names.contains("runserver"));
+        // The broken file should still produce a ScannedCommand placeholder with the
+        // failure recorded in its `warnings` field — confirm at least one ScannedCommand
+        // carries a warning mentioning "broken".
+        assert!(scanned.iter().any(|s| s.warnings.iter().any(|w| w.contains("broken"))));
     }
 }

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -1,0 +1,1 @@
+//! Argparse AST scanner — implemented in Task 9.

--- a/crates/toolr-core/src/complete/tests.rs
+++ b/crates/toolr-core/src/complete/tests.rs
@@ -45,6 +45,7 @@ fn fixture() -> Manifest {
                 }],
                 imports: vec![],
                 origin: Origin::Static,
+                dispatched_from: None,
             },
             Command {
                 name: "deploy".into(),
@@ -66,6 +67,7 @@ fn fixture() -> Manifest {
                 }],
                 imports: vec![],
                 origin: Origin::Static,
+                dispatched_from: None,
             },
             Command {
                 name: "load".into(),
@@ -87,6 +89,7 @@ fn fixture() -> Manifest {
                 }],
                 imports: vec![],
                 origin: Origin::Static,
+                dispatched_from: None,
             },
         ],
     }
@@ -196,6 +199,7 @@ fn nested_fixture() -> Manifest {
                 arguments: vec![],
                 imports: vec![],
                 origin: Origin::Static,
+                dispatched_from: None,
             },
             Command {
                 name: "start".into(),
@@ -207,6 +211,7 @@ fn nested_fixture() -> Manifest {
                 arguments: vec![],
                 imports: vec![],
                 origin: Origin::Static,
+                dispatched_from: None,
             },
         ],
     }
@@ -327,6 +332,7 @@ fn preserves_dynamic_entries_from_cache_when_reparsing() {
         arguments: vec![],
         imports: vec![],
         origin: Origin::Dynamic,
+        dispatched_from: None,
     });
     seeded.groups.push(crate::manifest::Group {
         name: "dyn-group".into(),

--- a/crates/toolr-core/src/complete/tests.rs
+++ b/crates/toolr-core/src/complete/tests.rs
@@ -46,6 +46,7 @@ fn fixture() -> Manifest {
                 imports: vec![],
                 origin: Origin::Static,
                 dispatched_from: None,
+                is_dispatcher: false,
             },
             Command {
                 name: "deploy".into(),
@@ -68,6 +69,7 @@ fn fixture() -> Manifest {
                 imports: vec![],
                 origin: Origin::Static,
                 dispatched_from: None,
+                is_dispatcher: false,
             },
             Command {
                 name: "load".into(),
@@ -90,6 +92,7 @@ fn fixture() -> Manifest {
                 imports: vec![],
                 origin: Origin::Static,
                 dispatched_from: None,
+                is_dispatcher: false,
             },
         ],
     }
@@ -200,6 +203,7 @@ fn nested_fixture() -> Manifest {
                 imports: vec![],
                 origin: Origin::Static,
                 dispatched_from: None,
+                is_dispatcher: false,
             },
             Command {
                 name: "start".into(),
@@ -212,6 +216,7 @@ fn nested_fixture() -> Manifest {
                 imports: vec![],
                 origin: Origin::Static,
                 dispatched_from: None,
+                is_dispatcher: false,
             },
         ],
     }
@@ -333,6 +338,7 @@ fn preserves_dynamic_entries_from_cache_when_reparsing() {
         imports: vec![],
         origin: Origin::Dynamic,
         dispatched_from: None,
+        is_dispatcher: false,
     });
     seeded.groups.push(crate::manifest::Group {
         name: "dyn-group".into(),

--- a/crates/toolr-core/src/dynamic/merge.rs
+++ b/crates/toolr-core/src/dynamic/merge.rs
@@ -54,6 +54,7 @@ mod tests {
             arguments: vec![],
             imports: vec![],
             origin,
+            dispatched_from: None,
         }
     }
 

--- a/crates/toolr-core/src/dynamic/merge.rs
+++ b/crates/toolr-core/src/dynamic/merge.rs
@@ -55,6 +55,7 @@ mod tests {
             imports: vec![],
             origin,
             dispatched_from: None,
+            is_dispatcher: false,
         }
     }
 

--- a/crates/toolr-core/src/dynamic/tests.rs
+++ b/crates/toolr-core/src/dynamic/tests.rs
@@ -21,6 +21,7 @@ fn sample_payload() -> DynamicPayload {
             arguments: vec![],
             imports: vec![],
             origin: Origin::Dynamic,
+            dispatched_from: None,
         }],
         warnings: vec![],
     }

--- a/crates/toolr-core/src/dynamic/tests.rs
+++ b/crates/toolr-core/src/dynamic/tests.rs
@@ -22,6 +22,7 @@ fn sample_payload() -> DynamicPayload {
             imports: vec![],
             origin: Origin::Dynamic,
             dispatched_from: None,
+            is_dispatcher: false,
         }],
         warnings: vec![],
     }

--- a/crates/toolr-core/src/execute/mod.rs
+++ b/crates/toolr-core/src/execute/mod.rs
@@ -9,5 +9,8 @@ pub mod tempfile;
 pub use python::{PythonError, resolve_python};
 pub use signals::wait_with_signals;
 pub use spawn::{StderrCapture, spawn_runner, spawn_runner_capturing_stderr};
-pub use spec::{ContextSpec, ExecutionSpec, RUNNER_SCHEMA_VERSION};
+pub use spec::{
+    ArgSchemaSpec, CommandSchemaSpec, ContextSpec, DispatchSpec, ExecutionSpec,
+    RUNNER_SCHEMA_VERSION,
+};
 pub use tempfile::write_spec_to_tempfile;

--- a/crates/toolr-core/src/execute/spec.rs
+++ b/crates/toolr-core/src/execute/spec.rs
@@ -51,6 +51,71 @@ pub struct ExecutionSpec {
     /// without per-arg type juggling on the Rust side.
     pub args: BTreeMap<String, serde_json::Value>,
     pub context: ContextSpec,
+    /// Set when the matched command is a dispatched leaf — the runner
+    /// must construct a `DispatchCommand` from this payload and call
+    /// `toolr._runner.invoke_dispatcher` instead of running `args` as
+    /// a regular command call. `module` / `function` point at the
+    /// parent dispatcher function; `args` carries the parent's own
+    /// kwargs (typically empty); this struct carries the leaf's name,
+    /// its packed args, and the schema needed by `DispatchCommand`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispatch: Option<DispatchSpec>,
+}
+
+/// Dispatch payload conveyed to the Python runner.
+///
+/// Mirrors the keyword arguments of `toolr._runner.invoke_dispatcher`:
+/// `command` → `child_name`, `command_args` → `child_args`,
+/// `schema` → `child_schema`. The serialised `schema` shape mirrors
+/// `toolr.sources.CommandSchema` so `msgspec.convert` reconstructs the
+/// Python frozen struct one-shot.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DispatchSpec {
+    /// Leaf command name (e.g. `"migrate"`).
+    pub command: String,
+    /// Leaf's argument values, keyed by name. Same shape and encoding
+    /// as `ExecutionSpec::args` for a normal command call — flags are
+    /// JSON bools, counts are numbers, missing optionals are absent.
+    pub command_args: BTreeMap<String, serde_json::Value>,
+    /// Wire-shape of `toolr.sources.CommandSchema` for the leaf.
+    pub schema: CommandSchemaSpec,
+}
+
+/// Wire-shape for `toolr.sources.CommandSchema`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommandSchemaSpec {
+    pub name: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub description: String,
+    pub arguments: Vec<ArgSchemaSpec>,
+}
+
+/// Wire-shape for `toolr.sources.ArgSchema`.
+///
+/// Field order and default-skipping rules match the Python frozen
+/// struct so `msgspec.convert` reconstructs it field-for-field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArgSchemaSpec {
+    pub name: String,
+    /// One of `"positional" | "optional" | "flag" | "repeated"`.
+    pub kind: String,
+    #[serde(default)]
+    pub help: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub choices: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metavar: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_annotation: Option<String>,
+    /// `"*" | "+" | "?"` or an integer; serde encodes whichever variant.
+    /// Always `None` from the current Rust scanner — argparse-equivalent
+    /// nargs information isn't tracked yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nargs: Option<serde_json::Value>,
 }
 
 impl ExecutionSpec {
@@ -80,6 +145,7 @@ impl ExecutionSpec {
                 default_timeout_secs: None,
                 default_no_output_timeout_secs: None,
             },
+            dispatch: None,
         }
     }
 }

--- a/crates/toolr-core/src/execute/tempfile.rs
+++ b/crates/toolr-core/src/execute/tempfile.rs
@@ -45,6 +45,7 @@ mod tests {
                 default_timeout_secs: None,
                 default_no_output_timeout_secs: None,
             },
+            dispatch: None,
         }
     }
 

--- a/crates/toolr-core/src/lib.rs
+++ b/crates/toolr-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_local_definitions)]
 
+pub mod argparse;
 pub mod cache;
 mod command;
 pub mod complete;

--- a/crates/toolr-core/src/manifest/model.rs
+++ b/crates/toolr-core/src/manifest/model.rs
@@ -84,6 +84,14 @@ pub struct Command {
     /// regular command call. `None` for normal commands.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dispatched_from: Option<String>,
+    /// True when this command hosts grafted children as its own
+    /// subcommands. Set by `argparse::run_for_project` on the parent
+    /// dispatcher entry whenever a `[[tool.toolr.argparse.*.attach]]`
+    /// directs children at it. Read by the CLI builder to decide
+    /// whether to build the command as a flat leaf or as a parent
+    /// that owns children.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_dispatcher: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/toolr-core/src/manifest/model.rs
+++ b/crates/toolr-core/src/manifest/model.rs
@@ -77,6 +77,13 @@ pub struct Command {
     pub imports: Vec<String>,
     /// Where this command entry came from.
     pub origin: Origin,
+    /// Source identifier (e.g. `"argparse:django"`) when this command
+    /// was grafted from an external source. The runtime treats commands
+    /// with this set as dispatched leaves: the parent's `target` is
+    /// invoked with a constructed `DispatchCommand` payload, not as a
+    /// regular command call. `None` for normal commands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispatched_from: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/toolr-core/src/manifest/tests.rs
+++ b/crates/toolr-core/src/manifest/tests.rs
@@ -22,6 +22,7 @@ fn sample_manifest() -> Manifest {
             arguments: vec![],
             imports: vec!["packaging".into()],
             origin: Origin::Static,
+            dispatched_from: None,
         }],
     }
 }
@@ -79,4 +80,35 @@ fn load_returns_io_error_when_missing() {
     let tmp = TempDir::new().unwrap();
     let err = load_manifest(&tmp.path().join("absent.json")).expect_err("should be missing");
     assert!(matches!(err, ManifestError::Io(_)));
+}
+
+mod dispatched_from_tests {
+    use super::*;
+
+    fn cmd_with(dispatched_from: Option<String>) -> Command {
+        Command {
+            name: "migrate".into(),
+            group: "django".into(),
+            module: "tools.django_dispatcher".into(),
+            function: "django".into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from,
+        }
+    }
+
+    #[test]
+    fn command_serializes_dispatched_from_when_present() {
+        let json = serde_json::to_string(&cmd_with(Some("argparse:django".into()))).unwrap();
+        assert!(json.contains(r#""dispatched_from":"argparse:django""#));
+    }
+
+    #[test]
+    fn command_omits_dispatched_from_when_none() {
+        let json = serde_json::to_string(&cmd_with(None)).unwrap();
+        assert!(!json.contains("dispatched_from"));
+    }
 }

--- a/crates/toolr-core/src/manifest/tests.rs
+++ b/crates/toolr-core/src/manifest/tests.rs
@@ -23,6 +23,7 @@ fn sample_manifest() -> Manifest {
             imports: vec!["packaging".into()],
             origin: Origin::Static,
             dispatched_from: None,
+            is_dispatcher: false,
         }],
     }
 }
@@ -97,6 +98,7 @@ mod dispatched_from_tests {
             imports: vec![],
             origin: Origin::Static,
             dispatched_from,
+            is_dispatcher: false,
         }
     }
 
@@ -110,5 +112,38 @@ mod dispatched_from_tests {
     fn command_omits_dispatched_from_when_none() {
         let json = serde_json::to_string(&cmd_with(None)).unwrap();
         assert!(!json.contains("dispatched_from"));
+    }
+}
+
+#[cfg(test)]
+mod is_dispatcher_tests {
+    use super::*;
+
+    fn cmd_with(is_dispatcher: bool) -> Command {
+        Command {
+            name: "job".into(),
+            group: "jenkins".into(),
+            module: "tools.jenkins".into(),
+            function: "job".into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: None,
+            is_dispatcher,
+        }
+    }
+
+    #[test]
+    fn command_serializes_is_dispatcher_when_true() {
+        let json = serde_json::to_string(&cmd_with(true)).unwrap();
+        assert!(json.contains(r#""is_dispatcher":true"#));
+    }
+
+    #[test]
+    fn command_omits_is_dispatcher_when_false() {
+        let json = serde_json::to_string(&cmd_with(false)).unwrap();
+        assert!(!json.contains("is_dispatcher"));
     }
 }

--- a/crates/toolr-core/src/parser/build.rs
+++ b/crates/toolr-core/src/parser/build.rs
@@ -152,27 +152,42 @@ fn build_static_manifest_inner(tools_dir: &Path) -> std::result::Result<Manifest
     let parents: std::collections::HashMap<String, (String, String)> = manifest
         .commands
         .iter()
-        .map(|c| {
-            let leaf = c.group.rsplit('.').next().unwrap_or(c.group.as_str());
-            let dotted = if !c.group.is_empty() && c.name == leaf {
-                c.group.clone()
-            } else if c.group.is_empty() {
-                c.name.clone()
-            } else {
-                format!("{}.{}", c.group, c.name)
-            };
-            (dotted, (c.module.clone(), c.function.clone()))
-        })
+        .map(|c| (dotted_name(c), (c.module.clone(), c.function.clone())))
         .collect();
 
     let project_root = tools_dir.parent().unwrap_or(tools_dir);
     let grafted = crate::argparse::run_for_project(project_root, &parents)
         .map_err(BuildError::Argparse)?;
-    for (_parent, mut children) in grafted {
+
+    // Splice grafted children into the manifest.
+    for (_parent, mut children) in grafted.children_by_parent {
         manifest.commands.append(&mut children);
     }
 
+    // Flip the dispatcher flag on each parent that received children.
+    for cmd in manifest.commands.iter_mut() {
+        if grafted.dispatchers.contains(&dotted_name(cmd)) {
+            cmd.is_dispatcher = true;
+        }
+    }
+
     Ok(manifest)
+}
+
+/// Compute the dotted name a command is addressable by from the CLI
+/// (mirrors the dispatcher's `command_group(name)` + `def <name>(...)`
+/// pattern). A command whose `name` matches the leaf segment of its
+/// `group` is addressable as the group path itself; otherwise it's
+/// `"<group>.<name>"` (or just `name` when the group is empty).
+fn dotted_name(cmd: &crate::manifest::Command) -> String {
+    let leaf = cmd.group.rsplit('.').next().unwrap_or(cmd.group.as_str());
+    if !cmd.group.is_empty() && cmd.name == leaf {
+        cmd.group.clone()
+    } else if cmd.group.is_empty() {
+        cmd.name.clone()
+    } else {
+        format!("{}.{}", cmd.group, cmd.name)
+    }
 }
 
 /// Like `build_static_manifest`, but also globs `tools_venv` for
@@ -552,6 +567,10 @@ parent = "django"
             .unwrap();
         assert_eq!(migrate.module, django.module);
         assert_eq!(migrate.function, django.function);
+        assert!(
+            django.is_dispatcher,
+            "expected dispatcher flag set on django",
+        );
     }
 
     /// A dispatcher command with both a real CLI flag (`cpu`) and a

--- a/crates/toolr-core/src/parser/build.rs
+++ b/crates/toolr-core/src/parser/build.rs
@@ -8,7 +8,7 @@ use walkdir::WalkDir;
 
 use crate::hash::hash_tools_dir;
 use crate::manifest::{Manifest, SCHEMA_VERSION};
-use crate::parser::types::{TypeImports, TypeResolutionError};
+use crate::parser::types::{SourcesImports, TypeImports, TypeResolutionError};
 use crate::parser::{
     commands::extract_commands,
     groups::extract_groups,
@@ -69,12 +69,14 @@ fn build_static_manifest_inner(tools_dir: &Path) -> std::result::Result<Manifest
         let module_doc = module_docstring(&module);
         let bindings = extract_groups(&module, &module_doc, &global_vars);
         let type_imports = TypeImports::from_module(&module);
+        let sources_imports = SourcesImports::from_module(&module);
         let commands = extract_commands(
             &module,
             &module_path,
             &bindings,
             &enums,
             &type_imports,
+            &sources_imports,
             &aliases,
             &sections,
             &global_vars,
@@ -550,6 +552,41 @@ parent = "django"
             .unwrap();
         assert_eq!(migrate.module, django.module);
         assert_eq!(migrate.function, django.function);
+    }
+
+    /// A dispatcher command with both a real CLI flag (`cpu`) and a
+    /// `DispatchCommand`-annotated injection kwarg builds cleanly: the
+    /// CLI flag lands on the manifest, the injection kwarg is dropped
+    /// rather than rejected as "unsupported type `DispatchCommand`".
+    #[test]
+    fn dispatcher_with_real_flags_and_injection_kwarg_builds() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "tools/dispatcher.py",
+            r#""""Django dispatcher."""
+from toolr.sources import DispatchCommand
+
+group = command_group("django", "Django")
+
+@group.command
+def django(ctx, *, cpu: str = "1", dispatched: DispatchCommand) -> int:
+    """Dispatch."""
+    return 0
+"#,
+        );
+        let manifest = build_static_manifest(&tmp.path().join("tools")).unwrap();
+        let django = manifest
+            .commands
+            .iter()
+            .find(|c| c.name == "django")
+            .expect("django command present");
+        let arg_names: Vec<&str> = django.arguments.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(
+            arg_names,
+            vec!["cpu"],
+            "expected dispatcher arguments to keep `cpu` and drop `dispatched`",
+        );
     }
 
     /// Bare `@command` (no `group=` kwarg) is a build error pointing

--- a/crates/toolr-core/src/parser/build.rs
+++ b/crates/toolr-core/src/parser/build.rs
@@ -132,13 +132,45 @@ fn build_static_manifest_inner(tools_dir: &Path) -> std::result::Result<Manifest
     }
 
     let static_hash = hash_tools_dir(tools_dir).map_err(BuildError::Build)?;
-    Ok(Manifest {
+    let mut manifest = Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash,
         dynamic_hash: String::new(),
         groups: all_groups,
         commands: all_commands,
-    })
+    };
+
+    // Run the user's argparse scanner ([tool.toolr.argparse.*] in
+    // tools/pyproject.toml) so its grafted children land in the same
+    // static manifest layer alongside the user's @command-decorated
+    // commands. The dotted-name derivation mirrors the CLI invocation
+    // path: a dispatcher whose name matches its group's leaf segment
+    // (`command_group("django")` + `def django(...)`) is addressable
+    // as `"django"`; any other command is `"<group>.<name>"`.
+    let parents: std::collections::HashMap<String, (String, String)> = manifest
+        .commands
+        .iter()
+        .map(|c| {
+            let leaf = c.group.rsplit('.').next().unwrap_or(c.group.as_str());
+            let dotted = if !c.group.is_empty() && c.name == leaf {
+                c.group.clone()
+            } else if c.group.is_empty() {
+                c.name.clone()
+            } else {
+                format!("{}.{}", c.group, c.name)
+            };
+            (dotted, (c.module.clone(), c.function.clone()))
+        })
+        .collect();
+
+    let project_root = tools_dir.parent().unwrap_or(tools_dir);
+    let grafted = crate::argparse::run_for_project(project_root, &parents)
+        .map_err(BuildError::Argparse)?;
+    for (_parent, mut children) in grafted {
+        manifest.commands.append(&mut children);
+    }
+
+    Ok(manifest)
 }
 
 /// Like `build_static_manifest`, but also globs `tools_venv` for
@@ -162,6 +194,8 @@ pub enum BuildError {
     UnsupportedTypes(Vec<TypeResolutionError>),
     #[error("unknown group references ({count}):\n{details}", count = .0.len(), details = format_unknown_groups(.0))]
     UnknownGroupRefs(Vec<UnknownGroupRef>),
+    #[error("argparse scanner error: {0}")]
+    Argparse(#[from] crate::argparse::ArgparseError),
 }
 
 /// One command whose `group="…"` reference doesn't match any
@@ -455,6 +489,67 @@ def backend(ctx):
         assert!(msg.contains("ci.helm-diff-pre-comment"), "got: {msg}");
         assert!(msg.contains("Did you mean"), "got: {msg}");
         assert!(msg.contains("ci.helm-diff-pr-comment"), "got: {msg}");
+    }
+
+    /// The user's `[tool.toolr.argparse.*]` blocks in
+    /// `tools/pyproject.toml` graft children onto user-decorated
+    /// dispatcher commands inside `build_static_manifest`. Verifies the
+    /// dotted-name derivation that maps a `command_group("django")` +
+    /// `def django(...)` dispatcher onto pyproject's `parent = "django"`.
+    #[test]
+    fn build_static_manifest_grafts_argparse_children() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "tools/dispatcher.py",
+            r#""""Django dispatcher."""
+group = command_group("django", "Django")
+
+@group.command
+def django(ctx):
+    """Dispatch to manage.py."""
+    pass
+"#,
+        );
+        write(
+            tmp.path(),
+            "apps/x/management/commands/migrate.py",
+            "def add_arguments(self, parser):\n    parser.add_argument('--check', action='store_true')\n",
+        );
+        write(
+            tmp.path(),
+            "tools/pyproject.toml",
+            r#"
+[tool.toolr.argparse.django]
+scan_paths = ["apps/*/management/commands/*.py"]
+
+[[tool.toolr.argparse.django.attach]]
+parent = "django"
+"#,
+        );
+
+        let manifest = build_static_manifest(&tmp.path().join("tools")).unwrap();
+        let names: std::collections::BTreeSet<_> =
+            manifest.commands.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains("django"), "names: {names:?}");
+        assert!(names.contains("migrate"), "names: {names:?}");
+        let migrate = manifest
+            .commands
+            .iter()
+            .find(|c| c.name == "migrate")
+            .unwrap();
+        assert_eq!(migrate.group, "django");
+        assert_eq!(
+            migrate.dispatched_from.as_deref(),
+            Some("argparse:django"),
+        );
+        let django = manifest
+            .commands
+            .iter()
+            .find(|c| c.name == "django")
+            .unwrap();
+        assert_eq!(migrate.module, django.module);
+        assert_eq!(migrate.function, django.function);
     }
 
     /// Bare `@command` (no `group=` kwarg) is a build error pointing

--- a/crates/toolr-core/src/parser/commands.rs
+++ b/crates/toolr-core/src/parser/commands.rs
@@ -237,6 +237,7 @@ fn build_command(
         imports: Vec::new(),
         origin: Origin::Static,
         dispatched_from: None,
+        is_dispatcher: false,
     }
 }
 

--- a/crates/toolr-core/src/parser/commands.rs
+++ b/crates/toolr-core/src/parser/commands.rs
@@ -9,7 +9,7 @@ use super::signatures::extract_arguments;
 use super::symbols::ArgSectionTable;
 use super::symbols::EnumTable;
 use super::symbols::TypeAliasTable;
-use super::types::{TypeImports, TypeResolutionError, resolve_arguments};
+use super::types::{SourcesImports, TypeImports, TypeResolutionError, resolve_arguments};
 use crate::SimpleDocstringParser;
 use crate::manifest::{Command, Origin};
 
@@ -25,6 +25,7 @@ pub fn extract_commands(
     bindings: &[GroupBinding],
     enums: &EnumTable,
     type_imports: &TypeImports,
+    sources: &SourcesImports,
     aliases: &TypeAliasTable,
     sections: &ArgSectionTable,
     global_vars: &GlobalVars,
@@ -69,6 +70,7 @@ pub fn extract_commands(
             module_path,
             enums,
             type_imports,
+            sources,
             aliases,
             sections,
             errors,
@@ -187,6 +189,7 @@ fn build_command(
     module_path: &str,
     enums: &EnumTable,
     type_imports: &TypeImports,
+    sources: &SourcesImports,
     aliases: &TypeAliasTable,
     sections: &ArgSectionTable,
     errors: &mut Vec<TypeResolutionError>,
@@ -201,7 +204,7 @@ fn build_command(
         .as_ref()
         .and_then(|d| d.long_description.clone())
         .unwrap_or_default();
-    let mut arguments = extract_arguments(func, enums);
+    let mut arguments = extract_arguments(func, enums, sources);
     if let Some(d) = parsed.as_ref() {
         for arg in &mut arguments {
             if let Some(Some(help)) = d.params.get(&arg.name) {
@@ -214,6 +217,7 @@ fn build_command(
         &mut arguments,
         enums,
         type_imports,
+        sources,
         aliases,
         sections,
         module_path,
@@ -260,7 +264,7 @@ def generate_build_matrix(ctx):
 "#;
         let m = parse_src(src);
         let bindings = extract_groups(&m, "", &HashMap::new());
-        let commands = extract_commands(&m, "tools.ci", &bindings, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
+        let commands = extract_commands(&m, "tools.ci", &bindings, &EnumTable::default(), &TypeImports::default(), &SourcesImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].name, "generate-build-matrix");
         assert_eq!(commands[0].group, "ci");
@@ -277,7 +281,7 @@ def x(ctx):
 "#;
         let m = parse_src(src);
         let bindings = vec![];
-        let commands = extract_commands(&m, "tools.x", &bindings, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
+        let commands = extract_commands(&m, "tools.x", &bindings, &EnumTable::default(), &TypeImports::default(), &SourcesImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
         assert!(commands.is_empty());
     }
 
@@ -290,7 +294,7 @@ def bare_function(ctx):
 "#;
         let m = parse_src(src);
         let bindings = extract_groups(&m, "", &HashMap::new());
-        let commands = extract_commands(&m, "tools.ci", &bindings, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
+        let commands = extract_commands(&m, "tools.ci", &bindings, &EnumTable::default(), &TypeImports::default(), &SourcesImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
         assert!(commands.is_empty());
     }
 
@@ -305,7 +309,7 @@ def hello(ctx):
 "#;
         let m = parse_src(src);
         let bindings = extract_groups(&m, "", &HashMap::new());
-        let commands = extract_commands(&m, "tools.ci", &bindings, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
+        let commands = extract_commands(&m, "tools.ci", &bindings, &EnumTable::default(), &TypeImports::default(), &SourcesImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
         assert_eq!(commands[0].summary, "Say hello.");
     }
 
@@ -326,6 +330,7 @@ def check_run_build(ctx):
             &bindings,
             &EnumTable::default(),
             &TypeImports::default(),
+            &SourcesImports::default(),
             &TypeAliasTable::default(),
             &ArgSectionTable::default(),
             &HashMap::new(),
@@ -353,6 +358,7 @@ def check_snippets(ctx):
             &bindings,
             &EnumTable::default(),
             &TypeImports::default(),
+            &SourcesImports::default(),
             &TypeAliasTable::default(),
             &ArgSectionTable::default(),
             &HashMap::new(),
@@ -381,6 +387,7 @@ def hello(ctx):
             &bindings,
             &EnumTable::default(),
             &TypeImports::default(),
+            &SourcesImports::default(),
             &TypeAliasTable::default(),
             &ArgSectionTable::default(),
             &HashMap::new(),
@@ -405,7 +412,7 @@ def hello(ctx, name="world"):
 "#;
         let m = parse_src(src);
         let bindings = extract_groups(&m, "", &HashMap::new());
-        let commands = extract_commands(&m, "tools.ci", &bindings, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
+        let commands = extract_commands(&m, "tools.ci", &bindings, &EnumTable::default(), &TypeImports::default(), &SourcesImports::default(), &TypeAliasTable::default(), &ArgSectionTable::default(), &HashMap::new(), &mut Vec::new());
         let name_arg = commands[0]
             .arguments
             .iter()

--- a/crates/toolr-core/src/parser/commands.rs
+++ b/crates/toolr-core/src/parser/commands.rs
@@ -232,6 +232,7 @@ fn build_command(
         arguments,
         imports: Vec::new(),
         origin: Origin::Static,
+        dispatched_from: None,
     }
 }
 

--- a/crates/toolr-core/src/parser/mod.rs
+++ b/crates/toolr-core/src/parser/mod.rs
@@ -20,8 +20,8 @@ pub use symbols::{ArgSectionEntry, ArgSectionTable, EnumTable, TypeAliasTable};
 
 pub mod types;
 pub use types::{
-    PathConstraints, SupportedType, TypeImports, UnsupportedType, extract_path_constraints,
-    resolve as resolve_type,
+    PathConstraints, SourcesImports, SupportedType, TypeImports, UnsupportedType,
+    extract_path_constraints, resolve as resolve_type,
 };
 
 pub mod build;

--- a/crates/toolr-core/src/parser/signatures.rs
+++ b/crates/toolr-core/src/parser/signatures.rs
@@ -579,4 +579,91 @@ def f(ctx, *, name: str = "x", dispatched: toolr.sources.DispatchCommand): pass
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].name, "name");
     }
+
+    /// `Annotated[DispatchCommand, arg(...)]` should be skipped just
+    /// like a bare `DispatchCommand` annotation — users reasonably want
+    /// to attach `arg(...)` metadata to the injection slot. Without
+    /// peeling, the kwarg falls through to the type resolver and the
+    /// whole module is rejected with "type `DispatchCommand` is not
+    /// supported".
+    #[test]
+    fn dispatch_command_kwarg_in_annotated_is_filtered_out() {
+        let src = r#"
+from typing import Annotated
+from toolr.sources import DispatchCommand
+from toolr import arg
+
+def f(ctx, *, cpu: str = "1", dispatched: Annotated[DispatchCommand, arg(help="x")]): pass
+"#;
+        let m = module(src);
+        let sources = SourcesImports::from_module(&m);
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                ruff_python_ast::Stmt::FunctionDef(f) => Some(f.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let args = extract_arguments(&func, &EnumTable::default(), &sources);
+        assert!(
+            args.iter().all(|a| a.name != "dispatched"),
+            "expected `dispatched` to be filtered out, got {args:?}"
+        );
+    }
+
+    /// String forward-reference annotations (`"DispatchCommand"`) are
+    /// common under `from __future__ import annotations` or just
+    /// stylistic forward refs. Must filter out the same way.
+    #[test]
+    fn dispatch_command_kwarg_in_string_forward_ref_is_filtered_out() {
+        let src = r#"
+from toolr.sources import DispatchCommand
+
+def f(ctx, *, cpu: str = "1", dispatched: "DispatchCommand"): pass
+"#;
+        let m = module(src);
+        let sources = SourcesImports::from_module(&m);
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                ruff_python_ast::Stmt::FunctionDef(f) => Some(f.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let args = extract_arguments(&func, &EnumTable::default(), &sources);
+        assert!(
+            args.iter().all(|a| a.name != "dispatched"),
+            "expected `dispatched` to be filtered out, got {args:?}"
+        );
+    }
+
+    /// An aliased import (`from toolr.sources import DispatchCommand as DC`)
+    /// combined with a string forward ref (`"DC"`) should also filter
+    /// out — the string contents are compared against the local alias
+    /// table, not just the canonical `"DispatchCommand"` literal.
+    #[test]
+    fn dispatch_command_kwarg_in_aliased_string_forward_ref_is_filtered_out() {
+        let src = r#"
+from toolr.sources import DispatchCommand as DC
+
+def f(ctx, *, cpu: str = "1", dispatched: "DC"): pass
+"#;
+        let m = module(src);
+        let sources = SourcesImports::from_module(&m);
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                ruff_python_ast::Stmt::FunctionDef(f) => Some(f.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let args = extract_arguments(&func, &EnumTable::default(), &sources);
+        assert!(
+            args.iter().all(|a| a.name != "dispatched"),
+            "expected `dispatched` to be filtered out, got {args:?}"
+        );
+    }
 }

--- a/crates/toolr-core/src/parser/signatures.rs
+++ b/crates/toolr-core/src/parser/signatures.rs
@@ -3,11 +3,22 @@
 use ruff_python_ast::{Expr, Number, StmtFunctionDef};
 
 use super::symbols::EnumTable;
+use super::types::SourcesImports;
 use crate::manifest::{Argument, ArgumentKind};
 
 /// Build the argument list for a command from its function definition.
 /// Skips the first parameter (assumed to be `ctx: Context`).
-pub fn extract_arguments(func: &StmtFunctionDef, enums: &EnumTable) -> Vec<Argument> {
+///
+/// Keyword-only parameters annotated with `toolr.sources.DispatchCommand`
+/// are dropped — they're a runtime-injection slot, not a CLI argument.
+/// `sources` carries the import table needed to resolve the annotation
+/// to that type (handles `from toolr.sources import DispatchCommand`
+/// with or without an alias, plus `import toolr.sources` qualified use).
+pub fn extract_arguments(
+    func: &StmtFunctionDef,
+    enums: &EnumTable,
+    sources: &SourcesImports,
+) -> Vec<Argument> {
     let params = func.parameters.as_ref();
     let mut out = Vec::new();
 
@@ -44,8 +55,18 @@ pub fn extract_arguments(func: &StmtFunctionDef, enums: &EnumTable) -> Vec<Argum
     // Keyword-only parameters (after the `*` separator). With or without a
     // default, they're always exposed as a keyword on the CLI; the kind
     // depends on the annotation shape (bool / list / other).
+    //
+    // Exception: a kwarg annotated with `toolr.sources.DispatchCommand`
+    // is a runtime injection slot used by the dispatcher implementation
+    // and never lands on the CLI — skip it entirely so the type
+    // resolver doesn't see it as an unsupported name.
     for p in &params.kwonlyargs {
         let annotation = p.parameter.annotation.as_deref();
+        if let Some(ann) = annotation {
+            if sources.is_dispatch_command(ann) {
+                continue;
+            }
+        }
         let kind = classify_keyword_kind(annotation);
         out.push(build_argument(
             p.parameter.name.to_string(),
@@ -274,7 +295,7 @@ mod tests {
     #[test]
     fn skips_ctx_first_argument() {
         let func = first_func("def f(ctx, name): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].name, "name");
     }
@@ -282,7 +303,7 @@ mod tests {
     #[test]
     fn marks_arguments_with_defaults_as_optional() {
         let func = first_func("def f(ctx, name=\"x\"): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args[0].kind, ArgumentKind::Optional);
         assert_eq!(args[0].default.as_deref(), Some("x"));
     }
@@ -290,7 +311,7 @@ mod tests {
     #[test]
     fn bool_with_false_default_classified_as_flag() {
         let func = first_func("def f(ctx, verbose: bool = False): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args[0].kind, ArgumentKind::Flag);
         assert_eq!(args[0].default.as_deref(), Some("false"));
     }
@@ -307,7 +328,7 @@ mod tests {
              from toolr import arg\n\
              def f(ctx, verbose: Annotated[bool, arg(env=\"VERBOSE\")] = False): pass\n",
         );
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args[0].kind, ArgumentKind::Flag);
     }
 
@@ -318,21 +339,21 @@ mod tests {
              from toolr import arg\n\
              def f(ctx, items: Annotated[list[str], arg(aliases=[\"-i\"])] = []): pass\n",
         );
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args[0].kind, ArgumentKind::Repeated);
     }
 
     #[test]
     fn list_keyword_classified_as_repeated() {
         let func = first_func("def f(ctx, files: list[str] = []): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args[0].kind, ArgumentKind::Repeated);
     }
 
     #[test]
     fn star_args_emits_var_positional() {
         let func = first_func("def f(ctx, *files: str): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].name, "files");
         assert_eq!(args[0].kind, ArgumentKind::VarPositional);
@@ -342,14 +363,14 @@ mod tests {
     #[test]
     fn integer_default_serialized_without_format_noise() {
         let func = first_func("def f(ctx, n: int = 5): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args[0].default.as_deref(), Some("5"));
     }
 
     #[test]
     fn string_default_has_no_embedded_quotes() {
         let func = first_func("def f(ctx, name: str = \"world\"): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args[0].default.as_deref(), Some("world"));
     }
 
@@ -375,14 +396,14 @@ def f(ctx, op: Operation = Operation.ADD): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &enums);
+        let args = extract_arguments(&func, &enums, &SourcesImports::default());
         assert_eq!(args[0].default.as_deref(), Some("add"));
     }
 
     #[test]
     fn unknown_enum_attribute_falls_back_to_expr_placeholder() {
         let func = first_func("def f(ctx, x = Unknown.MEMBER): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args[0].default.as_deref(), Some("<expr>"));
     }
 
@@ -395,7 +416,7 @@ def f(ctx, op: Operation = Operation.ADD): pass
     #[test]
     fn captures_type_annotations_as_strings() {
         let func = first_func("def f(ctx, name: str = \"x\"): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(args[0].type_annotation.as_deref(), Some("str"));
     }
 
@@ -407,7 +428,7 @@ from typing import Literal
 def f(ctx, mode: Literal["a", "b"]): pass
 "#,
         );
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert_eq!(
             args[0].allowed_values,
             vec!["a".to_string(), "b".to_string()]
@@ -417,7 +438,7 @@ def f(ctx, mode: Literal["a", "b"]): pass
     #[test]
     fn leaves_allowed_values_empty_for_non_literal_types() {
         let func = first_func("def f(ctx, name: str): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &SourcesImports::default());
         assert!(args[0].allowed_values.is_empty());
     }
 
@@ -449,10 +470,113 @@ def f(ctx, mode: Mode): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &enums);
+        let args = extract_arguments(&func, &enums, &SourcesImports::default());
         assert_eq!(
             args[0].allowed_values,
             vec!["fast".to_string(), "slow".to_string()]
         );
+    }
+
+    /// A dispatcher command's `DispatchCommand`-annotated kwarg is a
+    /// runtime injection slot, not a CLI argument. It must be filtered
+    /// out before the type resolver sees it — otherwise
+    /// `build_static_manifest` rejects the whole module with
+    /// "type `DispatchCommand` is not supported".
+    #[test]
+    fn dispatch_command_kwarg_is_filtered_out() {
+        let src = r#"
+from toolr.sources import DispatchCommand
+
+def f(ctx, *, cpu: str = "1", dispatched: DispatchCommand): pass
+"#;
+        let m = module(src);
+        let sources = SourcesImports::from_module(&m);
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                ruff_python_ast::Stmt::FunctionDef(f) => Some(f.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let args = extract_arguments(&func, &EnumTable::default(), &sources);
+        assert_eq!(args.len(), 1, "expected `dispatched` to be filtered out, got {args:?}");
+        assert_eq!(args[0].name, "cpu");
+    }
+
+    /// `from toolr.sources import DispatchCommand as DC` — aliased
+    /// import should still resolve to the runtime-injection type and
+    /// drop the kwarg from the CLI surface.
+    #[test]
+    fn aliased_dispatch_command_kwarg_is_filtered_out() {
+        let src = r#"
+from toolr.sources import DispatchCommand as DC
+
+def f(ctx, *, name: str = "x", dispatched: DC): pass
+"#;
+        let m = module(src);
+        let sources = SourcesImports::from_module(&m);
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                ruff_python_ast::Stmt::FunctionDef(f) => Some(f.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let args = extract_arguments(&func, &EnumTable::default(), &sources);
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, "name");
+    }
+
+    /// A normal (non-dispatcher) command, with the same import in
+    /// scope, must be unaffected — only kwargs whose annotation actually
+    /// resolves to `DispatchCommand` are skipped.
+    #[test]
+    fn regular_kwarg_unaffected_by_sources_import() {
+        let src = r#"
+from toolr.sources import DispatchCommand
+
+def f(ctx, *, name: str = "x"): pass
+"#;
+        let m = module(src);
+        let sources = SourcesImports::from_module(&m);
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                ruff_python_ast::Stmt::FunctionDef(f) => Some(f.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let args = extract_arguments(&func, &EnumTable::default(), &sources);
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, "name");
+        // The annotation rendering hasn't lost the type tag.
+        assert_eq!(args[0].type_annotation.as_deref(), Some("str"));
+    }
+
+    /// Qualified `toolr.sources.DispatchCommand` reference via
+    /// `import toolr.sources` (no alias) also filters out.
+    #[test]
+    fn qualified_dispatch_command_kwarg_is_filtered_out() {
+        let src = r#"
+import toolr.sources
+
+def f(ctx, *, name: str = "x", dispatched: toolr.sources.DispatchCommand): pass
+"#;
+        let m = module(src);
+        let sources = SourcesImports::from_module(&m);
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                ruff_python_ast::Stmt::FunctionDef(f) => Some(f.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let args = extract_arguments(&func, &EnumTable::default(), &sources);
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, "name");
     }
 }

--- a/crates/toolr-core/src/parser/types.rs
+++ b/crates/toolr-core/src/parser/types.rs
@@ -333,7 +333,28 @@ impl SourcesImports {
     /// `toolr.sources.DispatchCommand` — either as a direct name (with
     /// or without aliasing) or as a `<module-alias>.DispatchCommand`
     /// attribute access.
+    ///
+    /// Also peels `Annotated[T, ...]` wrappers and handles string
+    /// forward references (`"DispatchCommand"`, common under
+    /// `from __future__ import annotations`). For forward refs we do a
+    /// canonical-name compare against `direct_aliases` rather than
+    /// reparsing the string — the realistic shapes are bare names like
+    /// `"DispatchCommand"` or `"DC"` (after aliasing), and a literal
+    /// match handles both without dragging the ruff parser into the
+    /// static-analysis path.
     pub fn is_dispatch_command(&self, expr: &Expr) -> bool {
+        // `Annotated[DispatchCommand, arg(...)]` — peel to the inner T.
+        if let Some(inner) = peel_annotated_inner(expr) {
+            return self.is_dispatch_command(inner);
+        }
+        // `"DispatchCommand"` / `"DC"` forward-ref string — match the
+        // trimmed contents against direct aliases. Doesn't try to handle
+        // dotted forward refs like `"toolr.sources.DispatchCommand"`;
+        // those are vanishingly rare and a `parse_expression` round-trip
+        // would be heavier than the value it adds.
+        if let Expr::StringLiteral(s) = expr {
+            return self.is_dispatch_command_name(s.value.to_str().trim());
+        }
         match expr {
             Expr::Name(n) => self.direct_aliases.contains(n.id.as_str()),
             Expr::Attribute(attr) => {
@@ -353,6 +374,35 @@ impl SourcesImports {
             }
             _ => false,
         }
+    }
+
+    /// Whether `name` is a local symbol bound to
+    /// `toolr.sources.DispatchCommand` (e.g. `DispatchCommand` itself
+    /// or any `as <alias>` rebinding). Used to resolve string
+    /// forward-ref annotations without reparsing.
+    pub fn is_dispatch_command_name(&self, name: &str) -> bool {
+        self.direct_aliases.contains(name)
+    }
+}
+
+/// If `expr` is `Annotated[T, ...]`, return `T`; otherwise `None`.
+/// Mirrors the helper in `signatures.rs` — kept here so
+/// `is_dispatch_command` can peel without that helper being public.
+fn peel_annotated_inner(expr: &Expr) -> Option<&Expr> {
+    let Expr::Subscript(sub) = expr else {
+        return None;
+    };
+    let head = match sub.value.as_ref() {
+        Expr::Name(n) => n.id.as_str(),
+        Expr::Attribute(a) => a.attr.as_str(),
+        _ => return None,
+    };
+    if head != "Annotated" {
+        return None;
+    }
+    match sub.slice.as_ref() {
+        Expr::Tuple(t) => t.elts.first(),
+        single => Some(single),
     }
 }
 

--- a/crates/toolr-core/src/parser/types.rs
+++ b/crates/toolr-core/src/parser/types.rs
@@ -175,6 +175,37 @@ pub struct TypeImports {
     module_aliases: Vec<String>,
 }
 
+/// Records which local symbols in the current module refer to
+/// `toolr.sources.DispatchCommand` (or to the `toolr.sources` module
+/// itself, when used as `toolr.sources.DispatchCommand`).
+///
+/// `DispatchCommand` is a runtime injection slot, not a CLI argument.
+/// When a keyword-only parameter's annotation resolves to this type
+/// the static parser must skip it during CLI-argument extraction —
+/// otherwise the dispatcher command's `DispatchCommand` kwarg lands in
+/// the type resolver as an unknown name and rejects the whole module.
+///
+/// Supported import shapes (mirrors `TypeImports`):
+///
+/// * `from toolr.sources import DispatchCommand`
+/// * `from toolr.sources import DispatchCommand as <alias>`
+/// * `import toolr.sources` (or `import toolr.sources as X`), then a
+///   `toolr.sources.DispatchCommand` / `X.DispatchCommand` annotation.
+///
+/// Not currently handled: `from toolr import sources` followed by a
+/// `sources.DispatchCommand` reference. That requires tracking which
+/// local name aliases the `sources` submodule and is not in the
+/// canonical-form spec; we'll add it if a real user hits it.
+#[derive(Debug, Default, Clone)]
+pub struct SourcesImports {
+    /// Local names bound to `toolr.sources.DispatchCommand`. Populated by
+    /// `from toolr.sources import DispatchCommand [as <alias>]`.
+    direct_aliases: std::collections::HashSet<String>,
+    /// Local names that refer to the `toolr.sources` module. Populated by
+    /// `import toolr.sources` (default `toolr`) and `import toolr.sources as X`.
+    module_aliases: Vec<String>,
+}
+
 impl TypeImports {
     /// Walk the module's top-level statements to find imports from
     /// `toolr.types`.
@@ -252,6 +283,79 @@ impl TypeImports {
     }
 }
 
+impl SourcesImports {
+    /// Walk the module's top-level statements to find imports that name
+    /// `toolr.sources.DispatchCommand`.
+    pub fn from_module(module: &ModModule) -> Self {
+        let mut imports = Self::default();
+        for stmt in &module.body {
+            match stmt {
+                Stmt::ImportFrom(import) => {
+                    let module_name = import
+                        .module
+                        .as_ref()
+                        .map(|m| m.as_str())
+                        .unwrap_or_default();
+                    if module_name != "toolr.sources" {
+                        continue;
+                    }
+                    for alias in &import.names {
+                        if alias.name.as_str() != "DispatchCommand" {
+                            continue;
+                        }
+                        let local = alias
+                            .asname
+                            .as_ref()
+                            .map(|n| n.as_str().to_string())
+                            .unwrap_or_else(|| alias.name.as_str().to_string());
+                        imports.direct_aliases.insert(local);
+                    }
+                }
+                Stmt::Import(import) => {
+                    for alias in &import.names {
+                        if alias.name.as_str() == "toolr.sources" {
+                            let local = alias
+                                .asname
+                                .as_ref()
+                                .map(|n| n.as_str().to_string())
+                                .unwrap_or_else(|| "toolr".to_string());
+                            imports.module_aliases.push(local);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        imports
+    }
+
+    /// Whether `expr` is a parameter annotation referring to
+    /// `toolr.sources.DispatchCommand` — either as a direct name (with
+    /// or without aliasing) or as a `<module-alias>.DispatchCommand`
+    /// attribute access.
+    pub fn is_dispatch_command(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::Name(n) => self.direct_aliases.contains(n.id.as_str()),
+            Expr::Attribute(attr) => {
+                if attr.attr.as_str() != "DispatchCommand" {
+                    return false;
+                }
+                match attr.value.as_ref() {
+                    // `<alias>.DispatchCommand` for `import toolr.sources as <alias>`.
+                    Expr::Name(n) => self.module_aliases.iter().any(|a| a == n.id.as_str()),
+                    // `toolr.sources.DispatchCommand` for bare `import toolr.sources`.
+                    Expr::Attribute(inner) => matches!(
+                        inner.value.as_ref(),
+                        Expr::Name(n) if n.id.as_str() == "toolr" && inner.attr.as_str() == "sources"
+                    ),
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+}
+
 /// Walk a function's parameters and populate `resolved_type` on each
 /// matching [`Argument`]. Unsupported annotations are pushed to `errors`
 /// with `module` / function-name context, and the corresponding
@@ -262,6 +366,7 @@ pub fn resolve_arguments(
     arguments: &mut [Argument],
     enums: &EnumTable,
     type_imports: &TypeImports,
+    sources: &SourcesImports,
     aliases: &TypeAliasTable,
     sections: &ArgSectionTable,
     module: &str,
@@ -299,7 +404,16 @@ pub fn resolve_arguments(
         );
         i += 1;
     }
+    // Kwarg walk must stay in lockstep with `extract_arguments`, which
+    // already dropped any `DispatchCommand`-annotated kwargs from the
+    // arguments slice. Skip the same params here so we don't run the
+    // type resolver against a runtime injection slot.
     for p in &params.kwonlyargs {
+        if let Some(ann) = p.parameter.annotation.as_deref() {
+            if sources.is_dispatch_command(ann) {
+                continue;
+            }
+        }
         resolve_one(
             p.parameter.annotation.as_deref(),
             &mut arguments[i],

--- a/crates/toolr-core/src/third_party/merge.rs
+++ b/crates/toolr-core/src/third_party/merge.rs
@@ -92,6 +92,7 @@ fn command_from_fragment(fc: FragmentCommand) -> Command {
             .collect(),
         imports: fc.imports,
         origin: Origin::Static,
+        dispatched_from: None,
     }
 }
 

--- a/crates/toolr-core/src/third_party/merge.rs
+++ b/crates/toolr-core/src/third_party/merge.rs
@@ -93,6 +93,7 @@ fn command_from_fragment(fc: FragmentCommand) -> Command {
         imports: fc.imports,
         origin: Origin::Static,
         dispatched_from: None,
+        is_dispatcher: false,
     }
 }
 

--- a/crates/toolr-core/src/third_party/tests.rs
+++ b/crates/toolr-core/src/third_party/tests.rs
@@ -277,6 +277,7 @@ fn merge_skips_third_party_command_when_local_already_defines_it() {
         imports: vec![],
         origin: Origin::Static,
         dispatched_from: None,
+        is_dispatcher: false,
     });
     let merged =
         merge_into_manifest(base, vec![sample_fragment("pkg_a", "deploy", "rollout")]).unwrap();

--- a/crates/toolr-core/src/third_party/tests.rs
+++ b/crates/toolr-core/src/third_party/tests.rs
@@ -276,6 +276,7 @@ fn merge_skips_third_party_command_when_local_already_defines_it() {
         arguments: vec![],
         imports: vec![],
         origin: Origin::Static,
+        dispatched_from: None,
     });
     let merged =
         merge_into_manifest(base, vec![sample_fragment("pkg_a", "deploy", "rollout")]).unwrap();

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -29,6 +29,9 @@ from typing import get_type_hints
 import msgspec
 
 from toolr._exc import ToolrDeprecationWarning
+from toolr.sources import CommandSchema
+from toolr.sources import DispatchCommand
+from toolr.utils._signature import detect_dispatch_parameter
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -66,6 +69,21 @@ class ContextSpec(msgspec.Struct, frozen=True):
     default_no_output_timeout_secs: float | None = None
 
 
+class DispatchPayloadSpec(msgspec.Struct, frozen=True):
+    """Dispatch payload written by the Rust binary for dispatched leaves.
+
+    Mirrors `DispatchSpec` in `crates/toolr-core/src/execute/spec.rs`.
+    When set on a :class:`RunnerSpec`, the runner constructs a
+    `toolr.sources.DispatchCommand` from these fields and calls
+    :func:`invoke_dispatcher` instead of running the spec as a normal
+    command invocation.
+    """
+
+    command: str
+    command_args: dict[str, Any]
+    schema: CommandSchema
+
+
 class RunnerSpec(msgspec.Struct, frozen=True):
     """Top-level spec written by the Rust binary into ``$TOOLR_SPEC_FILE``."""
 
@@ -76,6 +94,7 @@ class RunnerSpec(msgspec.Struct, frozen=True):
     function: str
     args: dict[str, Any]
     context: ContextSpec
+    dispatch: DispatchPayloadSpec | None = None
 
 
 def load_spec(path: str | os.PathLike[str]) -> RunnerSpec:
@@ -273,6 +292,33 @@ def _coerce_args(target: Callable[..., Any], raw: dict[str, Any]) -> tuple[list[
     return positional, keyword
 
 
+def invoke_dispatcher(
+    *,
+    ctx: Any,
+    func: Callable[..., Any],
+    parent_kwargs: dict[str, Any],
+    child_name: str,
+    child_args: dict[str, Any],
+    child_schema: CommandSchema,
+) -> Any:
+    """Call ``func(ctx, **parent_kwargs, <dispatch_param>=DispatchCommand(...))``.
+
+    Raises ``RuntimeError`` if ``func`` doesn't have a DispatchCommand-
+    annotated parameter (manifest builder should have caught this at
+    build time; this is a defensive guard against a stale manifest).
+    """
+    param = detect_dispatch_parameter(func)
+    if param is None:
+        msg = f"invoke_dispatcher: {func.__qualname__!r} has no DispatchCommand parameter (manifest out of sync?)"
+        raise RuntimeError(msg)
+    dispatched = DispatchCommand(
+        command=child_name,
+        command_args=child_args,
+        schema=child_schema,
+    )
+    return func(ctx, **parent_kwargs, **{param: dispatched})
+
+
 def run(spec: RunnerSpec) -> int:
     """Execute the command described by ``spec``. Returns a process exit code.
 
@@ -282,8 +328,24 @@ def run(spec: RunnerSpec) -> int:
     try:
         ctx = _build_context(spec)
         target = _import_target(spec)
-        var_args, kw_args = _coerce_args(target, spec.args)
-        target(ctx, *var_args, **kw_args)
+        if spec.dispatch is not None:
+            # Dispatched leaf: `target` is the parent dispatcher, `args`
+            # carries the parent's own kwargs, `dispatch` carries the
+            # child name/args/schema. Coerce the parent kwargs against
+            # the parent's hints — `invoke_dispatcher` injects the
+            # `DispatchCommand` keyword on top of those.
+            _, parent_kwargs = _coerce_args(target, spec.args)
+            invoke_dispatcher(
+                ctx=ctx,
+                func=target,
+                parent_kwargs=parent_kwargs,
+                child_name=spec.dispatch.command,
+                child_args=spec.dispatch.command_args,
+                child_schema=spec.dispatch.schema,
+            )
+        else:
+            var_args, kw_args = _coerce_args(target, spec.args)
+            target(ctx, *var_args, **kw_args)
     except SystemExit as exc:
         code = exc.code
         if code is None:

--- a/crates/toolr-py/python/toolr/sources/__init__.py
+++ b/crates/toolr-py/python/toolr/sources/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
+from toolr.sources._dispatch import DispatchCommand
 from toolr.sources._types import ArgSchema
 from toolr.sources._types import CommandSchema
 
-__all__ = ["ArgSchema", "CommandSchema"]
+__all__ = ["ArgSchema", "CommandSchema", "DispatchCommand"]

--- a/crates/toolr-py/python/toolr/sources/__init__.py
+++ b/crates/toolr-py/python/toolr/sources/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from toolr.sources._types import ArgSchema
+from toolr.sources._types import CommandSchema
 
-__all__ = ["ArgSchema"]
+__all__ = ["ArgSchema", "CommandSchema"]

--- a/crates/toolr-py/python/toolr/sources/__init__.py
+++ b/crates/toolr-py/python/toolr/sources/__init__.py
@@ -1,0 +1,7 @@
+"""Public surface for externally-discovered toolr command schemas."""
+
+from __future__ import annotations
+
+from toolr.sources._types import ArgSchema
+
+__all__ = ["ArgSchema"]

--- a/crates/toolr-py/python/toolr/sources/_dispatch.py
+++ b/crates/toolr-py/python/toolr/sources/_dispatch.py
@@ -1,0 +1,26 @@
+"""DispatchCommand — the runtime payload injected into dispatcher commands.
+
+A dispatcher command is a user-written toolr command whose signature
+declares exactly one keyword-only parameter annotated as
+DispatchCommand. When the runtime matches one of the dispatcher's
+attached children, it constructs this object and passes it in as the
+value of that parameter.
+
+`argv` reconstructs argparse-shaped argv — typically used by the
+dispatcher body to forward to a subprocess (e.g.
+`ctx.run('python', 'manage.py', *dispatched.argv)`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from msgspec import Struct
+
+from toolr.sources._types import CommandSchema  # noqa: TC001
+
+
+class DispatchCommand(Struct, frozen=True):
+    command: str
+    command_args: dict[str, Any]
+    schema: CommandSchema

--- a/crates/toolr-py/python/toolr/sources/_dispatch.py
+++ b/crates/toolr-py/python/toolr/sources/_dispatch.py
@@ -1,15 +1,4 @@
-"""DispatchCommand — the runtime payload injected into dispatcher commands.
-
-A dispatcher command is a user-written toolr command whose signature
-declares exactly one keyword-only parameter annotated as
-DispatchCommand. When the runtime matches one of the dispatcher's
-attached children, it constructs this object and passes it in as the
-value of that parameter.
-
-`argv` reconstructs argparse-shaped argv — typically used by the
-dispatcher body to forward to a subprocess (e.g.
-`ctx.run('python', 'manage.py', *dispatched.argv)`).
-"""
+"""DispatchCommand — the runtime payload injected into dispatcher commands."""
 
 from __future__ import annotations
 
@@ -17,10 +6,55 @@ from typing import Any
 
 from msgspec import Struct
 
-from toolr.sources._types import CommandSchema  # noqa: TC001
+from toolr.sources._types import CommandSchema  # noqa: TC001 — msgspec needs runtime annotations
+
+
+def _flag_for(name: str) -> str:
+    """`dry_run` → `--dry-run`."""
+    return "--" + name.replace("_", "-")
 
 
 class DispatchCommand(Struct, frozen=True):
     command: str
     command_args: dict[str, Any]
     schema: CommandSchema
+
+    @property
+    def argv(self) -> list[str]:
+        """Argparse-shaped argv reconstructed from `command_args` per `schema`.
+
+        For each argument in `schema.arguments` that appears in
+        `command_args`, emit the appropriate token(s):
+
+        - `positional` → bare value
+        - `flag` → `--name` when truthy, omitted when falsy
+        - `optional` → `--name value`, omitted when value == default
+        - `repeated` → `--name value` per element
+
+        Keys in `command_args` not found in `schema.arguments` raise
+        ValueError so typos surface loudly.
+        """
+        known = {a.name for a in self.schema.arguments}
+        for key in self.command_args:
+            if key not in known:
+                msg = f"DispatchCommand.argv: unknown argument {key!r} (not in schema)"
+                raise ValueError(msg)
+
+        out: list[str] = []
+        for arg in self.schema.arguments:
+            if arg.name not in self.command_args:
+                continue
+            value = self.command_args[arg.name]
+            if arg.kind == "positional":
+                out.append(str(value))
+            elif arg.kind == "flag":
+                if value:
+                    out.append(_flag_for(arg.name))
+            elif arg.kind == "optional":
+                if arg.default is not None and str(value) == arg.default:
+                    continue
+                out.extend([_flag_for(arg.name), str(value)])
+            elif arg.kind == "repeated":
+                for element in value:
+                    out.extend([_flag_for(arg.name), str(element)])
+        return out

--- a/crates/toolr-py/python/toolr/sources/_types.py
+++ b/crates/toolr-py/python/toolr/sources/_types.py
@@ -1,0 +1,31 @@
+"""Schema types for externally-discovered toolr commands.
+
+`ArgSchema` and `CommandSchema` are produced by the Rust argparse
+scanner (or, in the future, by external source plugins) and shipped
+through the manifest. They are also exposed on
+`DispatchCommand.schema` so dispatcher bodies can reconstruct argv.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from msgspec import Struct
+
+
+class ArgSchema(Struct, frozen=True):
+    """One argument on a discovered command.
+
+    Mirrors the argparse `add_argument` fields the scanner can extract.
+    Anything the scanner can't statically resolve is left at its default
+    (`None`) and recorded as a warning at scan time.
+    """
+
+    name: str
+    kind: Literal["positional", "optional", "flag", "repeated"]
+    help: str = ""
+    default: str | None = None
+    choices: list[str] | None = None
+    metavar: str | None = None
+    type_annotation: str | None = None  # "str" / "int" / "float" / "bool"
+    nargs: Literal["*", "+", "?"] | int | None = None

--- a/crates/toolr-py/python/toolr/sources/_types.py
+++ b/crates/toolr-py/python/toolr/sources/_types.py
@@ -29,3 +29,18 @@ class ArgSchema(Struct, frozen=True):
     metavar: str | None = None
     type_annotation: str | None = None  # "str" / "int" / "float" / "bool"
     nargs: Literal["*", "+", "?"] | int | None = None
+
+
+class CommandSchema(Struct, frozen=True):
+    """One command discovered by the argparse scanner.
+
+    `arguments` carries only the command-specific args. Hoisted
+    common_args (declared in `[tool.toolr.argparse.<name>]`) are
+    applied at attach time and merged with `arguments`; consumers see
+    a single combined list on the manifest side.
+    """
+
+    name: str
+    summary: str
+    description: str
+    arguments: list[ArgSchema]

--- a/crates/toolr-py/python/toolr/utils/_signature.py
+++ b/crates/toolr-py/python/toolr/utils/_signature.py
@@ -677,3 +677,47 @@ def _build_aliases(param_name: str, positional: bool, aliases: list[str] | None)
     if default_alias not in aliases:
         aliases.insert(0, default_alias)
     return aliases
+
+
+class DispatcherDetectionError(Exception):
+    """Raised when a function's DispatchCommand usage is malformed."""
+
+
+def detect_dispatch_parameter(func: Callable[..., Any]) -> str | None:
+    """Return the name of the function's `DispatchCommand` parameter, or None.
+
+    A command qualifies as a dispatcher iff exactly one keyword-only
+    parameter is annotated with `toolr.sources.DispatchCommand`. The
+    parameter name itself is free. Subclasses are not supported in v1.
+    Returns `None` when the function isn't a dispatcher; raises
+    `DispatcherDetectionError` on a malformed usage.
+    """
+    # Local import: keep toolr.sources out of the import-time graph of
+    # toolr.utils._signature.
+    from toolr.sources import DispatchCommand  # noqa: PLC0415
+
+    sig = inspect.signature(func)
+    # Resolve string annotations (PEP 563 / ``from __future__ import annotations``)
+    # so the identity check against ``DispatchCommand`` works regardless of
+    # how the caller declared the parameter.
+    try:
+        resolved = get_type_hints(func)
+    except (NameError, AttributeError, TypeError):
+        resolved = {}
+
+    found_kw: list[str] = []
+    for name, param in sig.parameters.items():
+        annotation = resolved.get(name, param.annotation)
+        if annotation is inspect.Parameter.empty:
+            continue
+        if annotation is not DispatchCommand:
+            continue
+        if param.kind != inspect.Parameter.KEYWORD_ONLY:
+            msg = f"DispatchCommand parameter {name!r} on {func.__qualname__!r} must be keyword-only"
+            raise DispatcherDetectionError(msg)
+        found_kw.append(name)
+
+    if len(found_kw) > 1:
+        msg = f"{func.__qualname__!r} declares more than one DispatchCommand parameter: {found_kw}"
+        raise DispatcherDetectionError(msg)
+    return found_kw[0] if found_kw else None

--- a/crates/toolr/src/bootstrap.rs
+++ b/crates/toolr/src/bootstrap.rs
@@ -4,7 +4,51 @@
 //! See `specs/2026-05-19-fill-the-gaps-design.md` (gap 1) for the
 //! decision logic.
 
-#[allow(dead_code)] // Wired into `main::run` in Task 2.
+use std::path::Path;
+
+use toolr_core::discovery::discover_project_root;
+use toolr_core::dynamic::rebuild_manifest_full;
+use toolr_core::venv::resolve_venv_path;
+
+/// Bootstrap step that runs before clap parses the user's command.
+///
+/// When the manifest is missing AND `tools/pyproject.toml` exists AND
+/// argv doesn't look like a built-in / help / completion call, run a
+/// full `rebuild_manifest_full` so the user's command can succeed on
+/// a fresh clone. Errors propagate so `main.rs` can print them and
+/// exit non-zero — we intentionally do NOT fall through to an empty
+/// manifest, since that's the buggy old behaviour this task fixes.
+pub(crate) fn ensure_manifest_present_or_bootstrap(
+    cwd: &Path,
+    argv: &[String],
+) -> anyhow::Result<()> {
+    let Ok(root) = discover_project_root(cwd) else {
+        return Ok(());
+    };
+    let tools = root.join("tools");
+    if !tools.join("pyproject.toml").is_file() {
+        return Ok(());
+    }
+    if tools.join(".toolr-manifest.json").is_file() {
+        return Ok(());
+    }
+    if should_skip_auto_rebuild(argv) {
+        return Ok(());
+    }
+
+    let resolved = match resolve_venv_path(&root) {
+        Ok(r) => r,
+        Err(_) => return Ok(()),
+    };
+    if !resolved.python.is_file() {
+        return Ok(());
+    }
+
+    eprintln!("toolr: manifest missing; building (first-time setup)...");
+    rebuild_manifest_full(&root, &resolved.python, &resolved.venv_dir)?;
+    Ok(())
+}
+
 pub(crate) fn should_skip_auto_rebuild(argv: &[String]) -> bool {
     const BUILTINS: &[&str] = &["__complete", "project", "self", "init"];
     const HELP_FLAGS: &[&str] = &["--help", "--version", "-h", "-V"];

--- a/crates/toolr/src/bootstrap.rs
+++ b/crates/toolr/src/bootstrap.rs
@@ -1,0 +1,89 @@
+//! Pre-clap bootstrap: detect missing `tools/.toolr-manifest.json`
+//! and run a full rebuild before clap parses the user's command.
+//!
+//! See `specs/2026-05-19-fill-the-gaps-design.md` (gap 1) for the
+//! decision logic.
+
+#[allow(dead_code)] // Wired into `main::run` in Task 2.
+pub(crate) fn should_skip_auto_rebuild(argv: &[String]) -> bool {
+    const BUILTINS: &[&str] = &["__complete", "project", "self", "init"];
+    const HELP_FLAGS: &[&str] = &["--help", "--version", "-h", "-V"];
+
+    // Any help/version flag anywhere in argv → skip.
+    if argv.iter().skip(1).any(|a| HELP_FLAGS.contains(&a.as_str())) {
+        return true;
+    }
+    // First positional (= first arg after `toolr` that doesn't start with `-`).
+    let first_positional = argv.iter().skip(1).find(|a| !a.starts_with('-'));
+    match first_positional {
+        None => true, // `toolr` alone
+        Some(name) => BUILTINS.contains(&name.as_str()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_skip_auto_rebuild;
+
+    fn args(parts: &[&str]) -> Vec<String> {
+        std::iter::once("toolr")
+            .chain(parts.iter().copied())
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn skips_for_long_help_flag() {
+        assert!(should_skip_auto_rebuild(&args(&["--help"])));
+    }
+
+    #[test]
+    fn skips_for_short_help_flag() {
+        assert!(should_skip_auto_rebuild(&args(&["-h"])));
+    }
+
+    #[test]
+    fn skips_for_long_version_flag() {
+        assert!(should_skip_auto_rebuild(&args(&["--version"])));
+    }
+
+    #[test]
+    fn skips_for_short_version_flag() {
+        assert!(should_skip_auto_rebuild(&args(&["-V"])));
+    }
+
+    #[test]
+    fn skips_for_bare_toolr() {
+        assert!(should_skip_auto_rebuild(&args(&[])));
+    }
+
+    #[test]
+    fn skips_for_tab_completion() {
+        assert!(should_skip_auto_rebuild(&args(&["__complete", "/tmp", "..."])));
+    }
+
+    #[test]
+    fn skips_for_project_subcommands() {
+        assert!(should_skip_auto_rebuild(&args(&["project", "manifest", "rebuild"])));
+    }
+
+    #[test]
+    fn skips_for_self_subcommands() {
+        assert!(should_skip_auto_rebuild(&args(&["self", "cache", "list"])));
+    }
+
+    #[test]
+    fn skips_for_init() {
+        assert!(should_skip_auto_rebuild(&args(&["init"])));
+    }
+
+    #[test]
+    fn fires_for_user_command() {
+        assert!(!should_skip_auto_rebuild(&args(&["jenkins", "job", "migrate"])));
+    }
+
+    #[test]
+    fn fires_with_leading_global_flag() {
+        assert!(!should_skip_auto_rebuild(&args(&["--debug", "django", "migrate"])));
+    }
+}

--- a/crates/toolr/src/cli.rs
+++ b/crates/toolr/src/cli.rs
@@ -35,6 +35,24 @@ fn children_by_parent(manifest: &Manifest) -> HashMap<Option<String>, Vec<&Group
     map
 }
 
+/// Compute the dotted name a dispatcher is addressable by from the
+/// CLI. Mirrors `toolr_core::parser::build::dotted_name`: a command
+/// whose `name` matches the leaf segment of its `group` is addressable
+/// as the group path itself; otherwise it's `"<group>.<name>"` (or
+/// just `name` when the group is empty). The argparse pipeline sets
+/// each grafted child's `group` field to this dotted name (the
+/// attachment.parent), so we use the same value to look children up.
+fn dispatcher_dotted_name(cmd: &toolr_core::manifest::Command) -> String {
+    let leaf = cmd.group.rsplit('.').next().unwrap_or(cmd.group.as_str());
+    if !cmd.group.is_empty() && cmd.name == leaf {
+        cmd.group.clone()
+    } else if cmd.group.is_empty() {
+        cmd.name.clone()
+    } else {
+        format!("{}.{}", cmd.group, cmd.name)
+    }
+}
+
 /// Recursively build a clap `Command` subtree for `group`, attaching
 /// direct commands and child groups discovered via `children`.
 fn build_group_subtree(
@@ -48,35 +66,40 @@ fn build_group_subtree(
         g = g.long_about(group.description.clone());
     }
 
-    // Bucket grafted children of this group by their dispatcher's
-    // (module, function). `graft_children` copies those from the
-    // parent dispatcher entry, so the pair uniquely identifies which
-    // dispatcher hosts each child.
-    let grafted_by_dispatcher: HashMap<(&str, &str), Vec<&toolr_core::manifest::Command>> = manifest
-        .commands
-        .iter()
-        .filter(|c| c.group == full_path && c.dispatched_from.is_some())
-        .fold(HashMap::new(), |mut acc, c| {
-            acc.entry((c.module.as_str(), c.function.as_str()))
-                .or_default()
-                .push(c);
-            acc
-        });
-
     // For each NON-grafted command in this group, decide whether to
     // build it as a dispatcher (own args + the children-bucket as
-    // subcommands) or as a normal leaf.
+    // subcommands) or as a normal leaf. Grafted children live under
+    // the dispatcher's dotted name (set by `graft_children` from the
+    // `[[attach]] parent = "..."` value).
+    //
+    // When the dispatcher's name matches the group's leaf segment
+    // (e.g. `command_group("django")` + `def django(...)`), its dotted
+    // name equals the group path. In that case its grafted children
+    // are hoisted directly onto the group itself, so the user types
+    // `toolr django migrate` rather than `toolr django django migrate`.
+    let group_leaf = full_path.rsplit('.').next().unwrap_or(full_path.as_str());
     for cmd in manifest
         .commands
         .iter()
         .filter(|c| c.group == full_path && c.dispatched_from.is_none())
     {
         if cmd.is_dispatcher {
-            let dispatched_children = grafted_by_dispatcher
-                .get(&(cmd.module.as_str(), cmd.function.as_str()))
-                .cloned()
-                .unwrap_or_default();
-            g = g.subcommand(build_dispatcher_command(cmd, &dispatched_children));
+            let dotted = dispatcher_dotted_name(cmd);
+            let dispatched_children: Vec<&toolr_core::manifest::Command> = manifest
+                .commands
+                .iter()
+                .filter(|child| child.group == dotted && child.dispatched_from.is_some())
+                .collect();
+            if cmd.name == group_leaf {
+                // Hoist: the dispatcher's children become direct
+                // subcommands of the group, and the dispatcher itself
+                // disappears as a redundant CLI hop.
+                for child in &dispatched_children {
+                    g = g.subcommand(build_user_command(child));
+                }
+            } else {
+                g = g.subcommand(build_dispatcher_command(cmd, &dispatched_children));
+            }
         } else {
             g = g.subcommand(build_user_command(cmd));
         }
@@ -679,8 +702,10 @@ mod cli_tree_tests {
             "jenkins",
             vec![empty_arg("cpu", ArgumentKind::Optional)],
         );
-        let migrate = child("migrate", "jenkins", "tools.job", "job");
-        let runserver = child("runserver", "jenkins", "tools.job", "job");
+        // Grafted children live under the dispatcher's dotted_name
+        // ("jenkins.job"), mirroring the argparse pipeline's output.
+        let migrate = child("migrate", "jenkins.job", "tools.job", "job");
+        let runserver = child("runserver", "jenkins.job", "tools.job", "job");
 
         let manifest = Manifest {
             schema_version: 1,
@@ -705,8 +730,8 @@ mod cli_tree_tests {
     fn two_dispatchers_in_one_group_each_host_their_own_children() {
         let build_cmd = dispatcher("build", "docker", vec![]);
         let image_cmd = dispatcher("image", "docker", vec![]);
-        let build_child = child("compile", "docker", "tools.build", "build");
-        let image_child = child("push", "docker", "tools.image", "image");
+        let build_child = child("compile", "docker.build", "tools.build", "build");
+        let image_child = child("push", "docker.image", "tools.image", "image");
 
         let manifest = Manifest {
             schema_version: 1,
@@ -729,7 +754,7 @@ mod cli_tree_tests {
     #[test]
     fn dispatcher_and_normal_leaf_coexist_in_one_group() {
         let dispatcher_cmd = dispatcher("job", "jenkins", vec![]);
-        let migrate = child("migrate", "jenkins", "tools.job", "job");
+        let migrate = child("migrate", "jenkins.job", "tools.job", "job");
         let status = normal_leaf("status", "jenkins");
 
         let manifest = Manifest {
@@ -751,5 +776,28 @@ mod cli_tree_tests {
 
         let status_sub = jenkins.find_subcommand("status").unwrap();
         assert_eq!(status_sub.get_subcommands().count(), 0);
+    }
+
+    #[test]
+    fn dispatcher_with_matching_leaf_name_hoists_children_onto_group() {
+        // command_group("django") + def django(...) → dotted_name == "django"
+        // (matches the leaf), so the dispatcher's children appear
+        // directly under the group, not under a redundant `django`
+        // subcommand. User types `toolr django migrate`, not
+        // `toolr django django migrate`.
+        let dispatcher_cmd = dispatcher("django", "django", vec![]);
+        let migrate = child("migrate", "django", "tools.dispatcher", "django");
+
+        let manifest = Manifest {
+            schema_version: 1,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups: vec![group("django")],
+            commands: vec![dispatcher_cmd, migrate],
+        };
+
+        let django = build_for(manifest);
+        let group_subs: Vec<&str> = django.get_subcommands().map(|c| c.get_name()).collect();
+        assert_eq!(group_subs, vec!["migrate"]);
     }
 }

--- a/crates/toolr/src/cli.rs
+++ b/crates/toolr/src/cli.rs
@@ -47,15 +47,58 @@ fn build_group_subtree(
     if !group.description.is_empty() {
         g = g.long_about(group.description.clone());
     }
-    for cmd in manifest.commands.iter().filter(|c| c.group == full_path) {
-        g = g.subcommand(build_user_command(cmd));
+
+    // Bucket grafted children of this group by their dispatcher's
+    // (module, function). `graft_children` copies those from the
+    // parent dispatcher entry, so the pair uniquely identifies which
+    // dispatcher hosts each child.
+    let grafted_by_dispatcher: HashMap<(&str, &str), Vec<&toolr_core::manifest::Command>> = manifest
+        .commands
+        .iter()
+        .filter(|c| c.group == full_path && c.dispatched_from.is_some())
+        .fold(HashMap::new(), |mut acc, c| {
+            acc.entry((c.module.as_str(), c.function.as_str()))
+                .or_default()
+                .push(c);
+            acc
+        });
+
+    // For each NON-grafted command in this group, decide whether to
+    // build it as a dispatcher (own args + the children-bucket as
+    // subcommands) or as a normal leaf.
+    for cmd in manifest
+        .commands
+        .iter()
+        .filter(|c| c.group == full_path && c.dispatched_from.is_none())
+    {
+        if cmd.is_dispatcher {
+            let dispatched_children = grafted_by_dispatcher
+                .get(&(cmd.module.as_str(), cmd.function.as_str()))
+                .cloned()
+                .unwrap_or_default();
+            g = g.subcommand(build_dispatcher_command(cmd, &dispatched_children));
+        } else {
+            g = g.subcommand(build_user_command(cmd));
+        }
     }
+
     if let Some(child_groups) = children.get(&Some(full_path)) {
         for child in child_groups {
             g = g.subcommand(build_group_subtree(child, manifest, children));
         }
     }
     g
+}
+
+fn build_dispatcher_command(
+    dispatcher: &toolr_core::manifest::Command,
+    children: &[&toolr_core::manifest::Command],
+) -> Command {
+    let mut c = build_user_command(dispatcher).subcommand_required(true);
+    for child in children {
+        c = c.subcommand(build_user_command(child));
+    }
+    c
 }
 
 /// Construct the full clap Command tree, given a loaded manifest.
@@ -536,4 +579,177 @@ fn apply_arg_metadata(
         a = a.help_heading(section.title.clone());
     }
     a
+}
+
+#[cfg(test)]
+mod cli_tree_tests {
+    use super::*;
+    use toolr_core::manifest::{Argument, ArgumentKind, Command, Group, Manifest, Origin};
+
+    fn empty_arg(name: &str, kind: ArgumentKind) -> Argument {
+        Argument {
+            name: name.into(),
+            kind,
+            help: String::new(),
+            default: None,
+            type_annotation: None,
+            resolved_type: None,
+            allowed_values: vec![],
+            path_constraints: None,
+            metadata: Default::default(),
+        }
+    }
+
+    fn dispatcher(name: &str, group: &str, args: Vec<Argument>) -> Command {
+        Command {
+            name: name.into(),
+            group: group.into(),
+            module: format!("tools.{name}"),
+            function: name.into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: args,
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: None,
+            is_dispatcher: true,
+        }
+    }
+
+    fn child(name: &str, group: &str, dispatcher_module: &str, dispatcher_fn: &str) -> Command {
+        Command {
+            name: name.into(),
+            group: group.into(),
+            module: dispatcher_module.into(),
+            function: dispatcher_fn.into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: Some(format!("argparse:{group}")),
+            is_dispatcher: false,
+        }
+    }
+
+    fn normal_leaf(name: &str, group: &str) -> Command {
+        Command {
+            name: name.into(),
+            group: group.into(),
+            module: format!("tools.{name}"),
+            function: name.into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: None,
+            is_dispatcher: false,
+        }
+    }
+
+    fn group(name: &str) -> Group {
+        Group {
+            name: name.into(),
+            title: name.into(),
+            description: String::new(),
+            parent: None,
+            origin: Origin::Static,
+        }
+    }
+
+    fn build_for(manifest: Manifest) -> clap::Command {
+        let groups: Vec<&Group> = manifest.groups.iter().collect();
+        let mut children_map: std::collections::HashMap<Option<String>, Vec<&Group>> =
+            std::collections::HashMap::new();
+        for g in &groups {
+            children_map
+                .entry(g.parent.clone())
+                .or_default()
+                .push(g);
+        }
+        let top: Vec<&Group> = manifest.groups.iter().filter(|g| g.parent.is_none()).collect();
+        build_group_subtree(top[0], &manifest, &children_map)
+    }
+
+    #[test]
+    fn dispatcher_hosts_two_grafted_children() {
+        let dispatcher_cmd = dispatcher(
+            "job",
+            "jenkins",
+            vec![empty_arg("cpu", ArgumentKind::Optional)],
+        );
+        let migrate = child("migrate", "jenkins", "tools.job", "job");
+        let runserver = child("runserver", "jenkins", "tools.job", "job");
+
+        let manifest = Manifest {
+            schema_version: 1,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups: vec![group("jenkins")],
+            commands: vec![dispatcher_cmd, migrate, runserver],
+        };
+
+        let jenkins = build_for(manifest);
+
+        let group_subs: Vec<&str> = jenkins.get_subcommands().map(|c| c.get_name()).collect();
+        assert_eq!(group_subs, vec!["job"]);
+
+        let job = jenkins.find_subcommand("job").expect("job under jenkins");
+        let mut job_subs: Vec<&str> = job.get_subcommands().map(|c| c.get_name()).collect();
+        job_subs.sort();
+        assert_eq!(job_subs, vec!["migrate", "runserver"]);
+    }
+
+    #[test]
+    fn two_dispatchers_in_one_group_each_host_their_own_children() {
+        let build_cmd = dispatcher("build", "docker", vec![]);
+        let image_cmd = dispatcher("image", "docker", vec![]);
+        let build_child = child("compile", "docker", "tools.build", "build");
+        let image_child = child("push", "docker", "tools.image", "image");
+
+        let manifest = Manifest {
+            schema_version: 1,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups: vec![group("docker")],
+            commands: vec![build_cmd, image_cmd, build_child, image_child],
+        };
+
+        let docker = build_for(manifest);
+        let build_sub = docker.find_subcommand("build").unwrap();
+        let image_sub = docker.find_subcommand("image").unwrap();
+
+        let build_subs: Vec<&str> = build_sub.get_subcommands().map(|c| c.get_name()).collect();
+        let image_subs: Vec<&str> = image_sub.get_subcommands().map(|c| c.get_name()).collect();
+        assert_eq!(build_subs, vec!["compile"]);
+        assert_eq!(image_subs, vec!["push"]);
+    }
+
+    #[test]
+    fn dispatcher_and_normal_leaf_coexist_in_one_group() {
+        let dispatcher_cmd = dispatcher("job", "jenkins", vec![]);
+        let migrate = child("migrate", "jenkins", "tools.job", "job");
+        let status = normal_leaf("status", "jenkins");
+
+        let manifest = Manifest {
+            schema_version: 1,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups: vec![group("jenkins")],
+            commands: vec![dispatcher_cmd, migrate, status],
+        };
+
+        let jenkins = build_for(manifest);
+        let mut group_subs: Vec<&str> = jenkins.get_subcommands().map(|c| c.get_name()).collect();
+        group_subs.sort();
+        assert_eq!(group_subs, vec!["job", "status"]);
+
+        let job = jenkins.find_subcommand("job").unwrap();
+        let job_subs: Vec<&str> = job.get_subcommands().map(|c| c.get_name()).collect();
+        assert_eq!(job_subs, vec!["migrate"]);
+
+        let status_sub = jenkins.find_subcommand("status").unwrap();
+        assert_eq!(status_sub.get_subcommands().count(), 0);
+    }
 }

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -113,17 +113,26 @@ pub fn dispatch(
     // iterating the leaf's arguments (which are packed in `packed`).
     let spec = if cmd.dispatched_from.is_some() {
         let packed = pack_child_args(cmd, cmd_matches);
-        let group_leaf = cmd.group.rsplit('.').next().unwrap_or(cmd.group.as_str());
+        // The dispatcher's manifest entry shares `(module, function)`
+        // with each of its grafted children (the argparse pipeline
+        // copies those fields onto the children at graft time). Find
+        // the dispatcher's own entry by matching that pair and
+        // requiring `is_dispatcher = true` so we don't accidentally
+        // grab a sibling child.
         let dispatcher = manifest
             .commands
             .iter()
-            .find(|p| p.group == cmd.group && p.name == group_leaf)
+            .find(|p| {
+                p.is_dispatcher
+                    && p.module == cmd.module
+                    && p.function == cmd.function
+            })
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "dispatcher manifest entry for `{}` (group `{}`, name `{}`) not found",
+                    "dispatcher manifest entry for `{}` (module `{}`, function `{}`) not found",
                     cmd.name,
-                    cmd.group,
-                    group_leaf,
+                    cmd.module,
+                    cmd.function,
                 )
             })?;
         build_dispatch_spec(dispatcher, parent_matches, packed, &repo_root, &output_opts)

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -79,12 +79,31 @@ pub fn dispatch(
     // Dispatched leaves take a separate spec-shape: the runner sees
     // `dispatch: Some(...)` and routes to `invoke_dispatcher` instead
     // of calling `function` as a regular command. Pack the child first,
-    // then build a parent-shaped spec — `cmd.module`/`cmd.function`
-    // already point at the parent dispatcher because `graft_children`
-    // copies them from the matched parent at scan time.
+    // then build a parent-shaped spec around the dispatcher entry.
+    //
+    // The dispatcher's own manifest entry lives next to the leaf in the
+    // same group; its `name` matches the group's final segment (the
+    // "@group.command def <group_leaf>(...)" pattern produced by
+    // `graft_children`). We look it up so `build_dispatch_spec` can
+    // iterate the dispatcher's OWN arguments (the --cpu/--ram-style
+    // outer flags) and extract them from `parent_matches`, instead of
+    // iterating the leaf's arguments (which are packed in `packed`).
     let spec = if cmd.dispatched_from.is_some() {
         let packed = pack_child_args(cmd, cmd_matches);
-        build_dispatch_spec(cmd, parent_matches, packed, &repo_root, &output_opts)
+        let group_leaf = cmd.group.rsplit('.').next().unwrap_or(cmd.group.as_str());
+        let dispatcher = manifest
+            .commands
+            .iter()
+            .find(|p| p.group == cmd.group && p.name == group_leaf)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "dispatcher manifest entry for `{}` (group `{}`, name `{}`) not found",
+                    cmd.name,
+                    cmd.group,
+                    group_leaf,
+                )
+            })?;
+        build_dispatch_spec(dispatcher, parent_matches, packed, &repo_root, &output_opts)
     } else {
         build_spec(cmd, cmd_matches, &repo_root, &output_opts)
     };

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -16,6 +16,35 @@ use toolr_core::venv::resolve_venv_path;
 
 use crate::execute_build::{OutputOptions, build_dispatch_spec, build_spec, pack_child_args};
 
+/// Resolve a parsed subcommand `path` (e.g. `["jenkins", "job", "migrate"]`)
+/// to its manifest entry. Tries the most-specific candidate group first
+/// (`path[..len-1]`), then falls back one level up (`path[..len-2]`) so
+/// that grafted children dispatched under a parent group still resolve
+/// when the user typed an extra hop (the dispatcher segment) on the
+/// command line. Returns `None` when no candidate group hosts a command
+/// with the leaf name.
+fn find_command_for_path<'a>(
+    manifest: &'a Manifest,
+    path: &[String],
+) -> Option<&'a toolr_core::manifest::Command> {
+    let leaf_name = path.last()?;
+    let candidates: Vec<String> = if path.len() >= 2 {
+        vec![
+            path[..path.len() - 1].join("."),
+            path[..path.len() - 2].join("."),
+        ]
+    } else {
+        vec![String::new()]
+    };
+    // Try the most-specific group first; first match wins.
+    candidates.iter().find_map(|group| {
+        manifest
+            .commands
+            .iter()
+            .find(|c| &c.group == group && &c.name == leaf_name)
+    })
+}
+
 pub fn dispatch(
     matches: &ArgMatches,
     manifest: &Manifest,
@@ -56,19 +85,13 @@ pub fn dispatch(
         current = next_matches;
     }
     let cmd_matches = current;
-    let leaf_name = path.last().cloned().expect("path non-empty");
-    let group_full_path = path[..path.len() - 1].join(".");
-    if group_full_path.is_empty() {
+    if path.len() < 2 {
         // toolr <group> with no command → print group help
         return Ok(ExitCode::SUCCESS);
     }
-    let cmd = manifest
-        .commands
-        .iter()
-        .find(|c| c.group == group_full_path && c.name == leaf_name)
-        .ok_or_else(|| {
-            anyhow::anyhow!("unknown command: {} {leaf_name}", path[..path.len() - 1].join(" "))
-        })?;
+    let cmd = find_command_for_path(manifest, &path).ok_or_else(|| {
+        anyhow::anyhow!("unknown command: {}", path.join(" "))
+    })?;
 
     let cwd = std::env::current_dir()?;
     let repo_root = discover_project_root(&cwd)?;
@@ -605,5 +628,83 @@ mod tests {
         let m = parse(&["--no-output-timeout-secs", "3"]);
         let opts = output_options_from_matches(&m);
         assert_eq!(opts.default_no_output_timeout_secs, Some(3.0));
+    }
+}
+
+#[cfg(test)]
+mod path_lookup_tests {
+    //! Unit tests for `find_command_for_path`, the pure helper that
+    //! resolves a parsed subcommand path to its manifest entry. After
+    //! Task 6 grafts children under dispatchers, a 3-segment path like
+    //! `toolr jenkins job migrate` must still find `migrate` at
+    //! `group == "jenkins"` (the dispatcher hop is invisible to the
+    //! manifest). These tests pin the most-specific-first preference
+    //! and the one-level fallback.
+    use super::*;
+    use toolr_core::manifest::{Command, Manifest, Origin};
+
+    fn cmd(name: &str, group: &str) -> Command {
+        Command {
+            name: name.into(),
+            group: group.into(),
+            module: format!("tools.{name}"),
+            function: name.into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: None,
+            is_dispatcher: false,
+        }
+    }
+
+    fn manifest_with(commands: Vec<Command>) -> Manifest {
+        Manifest {
+            schema_version: 1,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups: vec![],
+            commands,
+        }
+    }
+
+    fn parts(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn finds_two_segment_path_in_group() {
+        let m = manifest_with(vec![cmd("migrate", "jenkins")]);
+        let c = find_command_for_path(&m, &parts(&["jenkins", "migrate"])).unwrap();
+        assert_eq!(c.name, "migrate");
+    }
+
+    #[test]
+    fn finds_three_segment_path_under_dispatcher() {
+        // `migrate` lives at group=jenkins (the group), name=migrate;
+        // the user typed `toolr jenkins job migrate` (3 segments).
+        let m = manifest_with(vec![cmd("migrate", "jenkins")]);
+        let c = find_command_for_path(&m, &parts(&["jenkins", "job", "migrate"])).unwrap();
+        assert_eq!(c.name, "migrate");
+    }
+
+    #[test]
+    fn prefers_more_specific_group_when_both_exist() {
+        // If both `docker.image.build` and `docker.build` exist, the
+        // 3-segment path `docker image build` must resolve to the
+        // nested one, not the top-level one.
+        let m = manifest_with(vec![
+            cmd("build", "docker"),
+            cmd("build", "docker.image"),
+        ]);
+        let c = find_command_for_path(&m, &parts(&["docker", "image", "build"])).unwrap();
+        assert_eq!(c.group, "docker.image");
+    }
+
+    #[test]
+    fn returns_none_when_no_command_matches() {
+        let m = manifest_with(vec![cmd("migrate", "jenkins")]);
+        assert!(find_command_for_path(&m, &parts(&["unknown"])).is_none());
     }
 }

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -14,7 +14,7 @@ use toolr_core::execute::{
 use toolr_core::manifest::Manifest;
 use toolr_core::venv::resolve_venv_path;
 
-use crate::execute_build::{OutputOptions, build_spec};
+use crate::execute_build::{OutputOptions, build_dispatch_spec, build_spec, pack_child_args};
 
 pub fn dispatch(
     matches: &ArgMatches,
@@ -43,11 +43,16 @@ pub fn dispatch(
     // Walk down the subcommand chain so nested groups (`docker image
     // build`) reach their leaf command. `path` collects every
     // intermediate name; the last entry is the leaf, the prefix is
-    // the dotted full_path of the owning group.
+    // the dotted full_path of the owning group. `parent_matches`
+    // tracks the matches one level above the leaf — needed when the
+    // leaf is a dispatched grafted command so we can extract the
+    // parent dispatcher's own kwargs.
     let mut path: Vec<String> = vec![first_name.to_string()];
     let mut current = first_matches;
+    let mut parent_matches: &ArgMatches = matches;
     while let Some((next_name, next_matches)) = current.subcommand() {
         path.push(next_name.to_string());
+        parent_matches = current;
         current = next_matches;
     }
     let cmd_matches = current;
@@ -71,7 +76,18 @@ pub fn dispatch(
     // manifest was last written. Tab completion never takes this path.
     ensure_dynamic_layer_fresh(&repo_root, manifest)?;
     let output_opts = output_options_from_matches(matches);
-    let spec = build_spec(cmd, cmd_matches, &repo_root, &output_opts);
+    // Dispatched leaves take a separate spec-shape: the runner sees
+    // `dispatch: Some(...)` and routes to `invoke_dispatcher` instead
+    // of calling `function` as a regular command. Pack the child first,
+    // then build a parent-shaped spec — `cmd.module`/`cmd.function`
+    // already point at the parent dispatcher because `graft_children`
+    // copies them from the matched parent at scan time.
+    let spec = if cmd.dispatched_from.is_some() {
+        let packed = pack_child_args(cmd, cmd_matches);
+        build_dispatch_spec(cmd, parent_matches, packed, &repo_root, &output_opts)
+    } else {
+        build_spec(cmd, cmd_matches, &repo_root, &output_opts)
+    };
 
     let tempfile = write_spec_to_tempfile(&spec)?;
     // Prefer the resolved tools-venv python (Plan 3). Fall back to the

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -361,6 +361,7 @@ mod tests {
             imports: vec![],
             origin: Origin::Static,
             dispatched_from: None,
+            is_dispatcher: false,
         }
     }
 
@@ -427,6 +428,7 @@ mod tests {
             imports: vec![],
             origin: Origin::Static,
             dispatched_from: None,
+            is_dispatcher: false,
         };
         let matches = clap::Command::new("switch")
             .arg(Arg::new("force").long("force").action(ArgAction::SetTrue))
@@ -470,6 +472,7 @@ mod tests {
             imports: vec![],
             origin: Origin::Static,
             dispatched_from: None,
+            is_dispatcher: false,
         }
     }
 
@@ -710,6 +713,7 @@ mod dispatched_pack_tests {
             imports: vec![],
             origin: Origin::Static,
             dispatched_from: Some("argparse:django".into()),
+            is_dispatcher: false,
         }
     }
 

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -49,6 +49,59 @@ pub fn build_spec(
     }
 }
 
+/// Packed payload extracted from clap matches for a dispatched leaf.
+///
+/// Built when the matched command has `dispatched_from` set on its
+/// manifest entry. The pyo3 invocation seam (added in Task 17) turns
+/// this into a `toolr.sources.DispatchCommand` and passes it as the
+/// `dispatch` keyword to the parent dispatcher function instead of
+/// running the leaf as a regular command call.
+//
+// `#[allow(dead_code)]` because the dispatch seam that consumes this
+// lands in Task 17. The fields are not read yet — `dead_code` would
+// otherwise trigger because the test module accesses them but the
+// production code does not. Drop this attribute when Task 17 lands.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct PackedChild {
+    /// The leaf command's name (e.g. `"migrate"`).
+    pub name: String,
+    /// Per-argument values extracted from clap matches, keyed by the
+    /// argument's manifest name. Values are JSON-shaped so the existing
+    /// `extract_value` machinery (used by `build_spec`) drives the
+    /// encoding — keeping flags as bools, counts as numbers, etc. —
+    /// rather than coercing everything to `String`.
+    pub args: BTreeMap<String, Value>,
+    /// The full manifest entry for the leaf, so the runtime side has
+    /// access to schema metadata (argument list, dispatched_from, …)
+    /// without re-looking-up the command.
+    pub schema: Command,
+}
+
+/// Pack a matched dispatched-leaf's clap arguments into a `PackedChild`.
+///
+/// Reuses the same per-argument extraction logic as `build_spec` so the
+/// on-the-wire shape of dispatched-leaf args is identical to a normal
+/// command invocation. Task 17 consumes this on the Python side.
+//
+// `#[allow(dead_code)]` for the same reason as `PackedChild`: the
+// dispatch seam that calls this lands in Task 17. The unit tests in
+// `dispatched_pack_tests` already exercise it.
+#[allow(dead_code)]
+pub(crate) fn pack_child_args(cmd: &Command, matches: &ArgMatches) -> PackedChild {
+    let mut args = BTreeMap::new();
+    for arg in &cmd.arguments {
+        if let Some(value) = extract_value(arg, matches) {
+            args.insert(arg.name.clone(), value);
+        }
+    }
+    PackedChild {
+        name: cmd.name.clone(),
+        args,
+        schema: cmd.clone(),
+    }
+}
+
 /// Plumbing struct bundling the root-level "Output Options" flag
 /// values for `build_spec`. Adding a new flag is a one-field change
 /// instead of growing the `build_spec` argument list again.
@@ -529,5 +582,102 @@ mod tests {
         assert_eq!(opts.log_level, "INFO");
         assert!(opts.default_timeout_secs.is_none());
         assert!(opts.default_no_output_timeout_secs.is_none());
+    }
+}
+
+#[cfg(test)]
+mod dispatched_pack_tests {
+    //! `pack_child_args` packs a matched dispatched-leaf into a
+    //! `PackedChild`. These tests pin the on-the-wire encoding (which
+    //! reuses `extract_value`, so flags stay bools and missing
+    //! arguments stay absent rather than null) — Task 17's pyo3 wiring
+    //! reads the resulting `args` map and must keep getting the same
+    //! JSON shape `build_spec` would have produced.
+    use super::*;
+    use clap::{Arg, ArgAction};
+    use toolr_core::manifest::{Argument, ArgumentKind, Command, Origin};
+
+    fn migrate_cmd() -> Command {
+        Command {
+            name: "migrate".into(),
+            group: "django".into(),
+            module: "tools.dispatcher".into(),
+            function: "django".into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![Argument {
+                name: "check".into(),
+                kind: ArgumentKind::Flag,
+                help: String::new(),
+                default: None,
+                type_annotation: None,
+                resolved_type: None,
+                allowed_values: vec![],
+                path_constraints: None,
+                metadata: Default::default(),
+            }],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: Some("argparse:django".into()),
+        }
+    }
+
+    #[test]
+    fn pack_child_args_extracts_flag_as_bool() {
+        let clap_cmd = clap::Command::new("migrate")
+            .arg(Arg::new("check").long("check").action(ArgAction::SetTrue));
+        let matches = clap_cmd
+            .try_get_matches_from(vec!["migrate", "--check"])
+            .unwrap();
+        let cmd = migrate_cmd();
+        let packed = pack_child_args(&cmd, &matches);
+        assert_eq!(packed.name, "migrate");
+        assert_eq!(packed.args.get("check"), Some(&Value::Bool(true)));
+        // Schema round-trips intact (Task 17 reads it on the Python side).
+        assert_eq!(packed.schema.dispatched_from.as_deref(), Some("argparse:django"));
+        assert_eq!(packed.schema.function, "django");
+    }
+
+    #[test]
+    fn pack_child_args_unset_flag_records_false_value() {
+        // Flags route through `get_flag`, which always yields a bool,
+        // so an unset flag still appears in the map as `false`. This
+        // matches `build_spec`'s encoding — `extract_value` always
+        // returns Some for `ArgumentKind::Flag`.
+        let clap_cmd = clap::Command::new("migrate")
+            .arg(Arg::new("check").long("check").action(ArgAction::SetTrue));
+        let matches = clap_cmd
+            .try_get_matches_from(vec!["migrate"])
+            .unwrap();
+        let packed = pack_child_args(&migrate_cmd(), &matches);
+        assert_eq!(packed.args.get("check"), Some(&Value::Bool(false)));
+    }
+
+    #[test]
+    fn pack_child_args_omits_unset_optional() {
+        // Optional args with no clap value present should be absent
+        // from the packed map (rather than `null`) — matches the
+        // `build_spec_missing_optional_value_does_not_appear_in_args_map`
+        // contract.
+        let cmd = Command {
+            arguments: vec![Argument {
+                name: "label".into(),
+                kind: ArgumentKind::Optional,
+                help: String::new(),
+                default: None,
+                type_annotation: None,
+                resolved_type: None,
+                allowed_values: vec![],
+                path_constraints: None,
+                metadata: Default::default(),
+            }],
+            ..migrate_cmd()
+        };
+        let clap_cmd = clap::Command::new("migrate").arg(Arg::new("label").long("label"));
+        let matches = clap_cmd
+            .try_get_matches_from(vec!["migrate"])
+            .unwrap();
+        let packed = pack_child_args(&cmd, &matches);
+        assert!(!packed.args.contains_key("label"));
     }
 }

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -6,7 +6,10 @@ use std::path::Path;
 use clap::ArgMatches;
 use serde_json::Value;
 
-use toolr_core::execute::{ContextSpec, ExecutionSpec, RUNNER_SCHEMA_VERSION};
+use toolr_core::execute::{
+    ArgSchemaSpec, CommandSchemaSpec, ContextSpec, DispatchSpec, ExecutionSpec,
+    RUNNER_SCHEMA_VERSION,
+};
 use toolr_core::manifest::{Argument, ArgumentKind, Command};
 use toolr_core::parser::SupportedType;
 
@@ -46,22 +49,18 @@ pub fn build_spec(
             default_timeout_secs: output_opts.default_timeout_secs,
             default_no_output_timeout_secs: output_opts.default_no_output_timeout_secs,
         },
+        dispatch: None,
     }
 }
 
 /// Packed payload extracted from clap matches for a dispatched leaf.
 ///
 /// Built when the matched command has `dispatched_from` set on its
-/// manifest entry. The pyo3 invocation seam (added in Task 17) turns
-/// this into a `toolr.sources.DispatchCommand` and passes it as the
-/// `dispatch` keyword to the parent dispatcher function instead of
-/// running the leaf as a regular command call.
-//
-// `#[allow(dead_code)]` because the dispatch seam that consumes this
-// lands in Task 17. The fields are not read yet — `dead_code` would
-// otherwise trigger because the test module accesses them but the
-// production code does not. Drop this attribute when Task 17 lands.
-#[allow(dead_code)]
+/// manifest entry. The dispatch seam in [`build_dispatch_spec`] turns
+/// this into a `DispatchSpec` (the wire-shape of
+/// `toolr.sources.DispatchCommand`) so the Python runner can call
+/// `toolr._runner.invoke_dispatcher` instead of running the leaf as a
+/// regular command call.
 #[derive(Debug, Clone)]
 pub struct PackedChild {
     /// The leaf command's name (e.g. `"migrate"`).
@@ -82,12 +81,8 @@ pub struct PackedChild {
 ///
 /// Reuses the same per-argument extraction logic as `build_spec` so the
 /// on-the-wire shape of dispatched-leaf args is identical to a normal
-/// command invocation. Task 17 consumes this on the Python side.
-//
-// `#[allow(dead_code)]` for the same reason as `PackedChild`: the
-// dispatch seam that calls this lands in Task 17. The unit tests in
-// `dispatched_pack_tests` already exercise it.
-#[allow(dead_code)]
+/// command invocation. Consumed by [`build_dispatch_spec`] on the
+/// Rust side and `toolr._runner.invoke_dispatcher` on the Python side.
 pub(crate) fn pack_child_args(cmd: &Command, matches: &ArgMatches) -> PackedChild {
     let mut args = BTreeMap::new();
     for arg in &cmd.arguments {
@@ -99,6 +94,102 @@ pub(crate) fn pack_child_args(cmd: &Command, matches: &ArgMatches) -> PackedChil
         name: cmd.name.clone(),
         args,
         schema: cmd.clone(),
+    }
+}
+
+/// Build the execution spec for a dispatched leaf invocation.
+///
+/// `parent` is the dispatcher Command whose `module`/`function` get
+/// invoked; `parent_matches` are clap matches at the level *above* the
+/// leaf (i.e. the group-level matches owning the dispatcher's own
+/// args, if any). `packed` carries the leaf's name + args + schema —
+/// shipped to the runner under [`ExecutionSpec::dispatch`].
+///
+/// The runner sees `module`/`function` pointing at the parent, `args`
+/// carrying the parent's own kwargs, and `dispatch` carrying everything
+/// `invoke_dispatcher` needs to build a `DispatchCommand`.
+pub fn build_dispatch_spec(
+    parent: &Command,
+    parent_matches: &ArgMatches,
+    packed: PackedChild,
+    repo_root: &Path,
+    output_opts: &OutputOptions,
+) -> ExecutionSpec {
+    let mut parent_args = BTreeMap::new();
+    for arg in &parent.arguments {
+        if let Some(value) = extract_value(arg, parent_matches) {
+            parent_args.insert(arg.name.clone(), value);
+        }
+    }
+    ExecutionSpec {
+        schema_version: RUNNER_SCHEMA_VERSION,
+        group: parent.group.clone(),
+        command: parent.name.clone(),
+        module: parent.module.clone(),
+        function: parent.function.clone(),
+        args: parent_args,
+        context: ContextSpec {
+            repo_root: repo_root.to_string_lossy().into_owned(),
+            verbosity: output_opts.verbosity.clone(),
+            timestamps: output_opts.timestamps,
+            log_level: output_opts.log_level.clone(),
+            default_timeout_secs: output_opts.default_timeout_secs,
+            default_no_output_timeout_secs: output_opts.default_no_output_timeout_secs,
+        },
+        dispatch: Some(DispatchSpec {
+            command: packed.name,
+            command_args: packed.args,
+            schema: command_to_schema_spec(&packed.schema),
+        }),
+    }
+}
+
+/// Convert a manifest [`Command`] into the wire-shape consumed by
+/// `msgspec.convert` on the Python side to reconstruct a
+/// `toolr.sources.CommandSchema`.
+fn command_to_schema_spec(cmd: &Command) -> CommandSchemaSpec {
+    CommandSchemaSpec {
+        name: cmd.name.clone(),
+        summary: cmd.summary.clone(),
+        description: cmd.description.clone(),
+        arguments: cmd.arguments.iter().map(argument_to_arg_schema).collect(),
+    }
+}
+
+/// Convert a manifest [`Argument`] into the wire-shape of
+/// `toolr.sources.ArgSchema`.
+///
+/// Maps:
+/// - `kind` → one of `"positional" | "optional" | "flag" | "repeated"`.
+///   `VarPositional` is encoded as `"repeated"` (closest argparse-shaped
+///   equivalent for argv reconstruction); `Count` falls back to
+///   `"flag"`. The argparse scanner only emits the first four kinds, so
+///   those two arms only fire for hand-authored manifests today.
+/// - `choices` ← `allowed_values` (empty → `None`).
+/// - `metavar` ← `metadata.metavar`.
+/// - `type_annotation` ← `type_annotation`.
+/// - `nargs` is always `None` — the manifest doesn't carry argparse-
+///   compatible nargs information.
+fn argument_to_arg_schema(arg: &Argument) -> ArgSchemaSpec {
+    let kind = match arg.kind {
+        ArgumentKind::Positional => "positional",
+        ArgumentKind::Optional => "optional",
+        ArgumentKind::Flag | ArgumentKind::Count => "flag",
+        ArgumentKind::Repeated | ArgumentKind::VarPositional => "repeated",
+    };
+    ArgSchemaSpec {
+        name: arg.name.clone(),
+        kind: kind.to_string(),
+        help: arg.help.clone(),
+        default: arg.default.clone(),
+        choices: if arg.allowed_values.is_empty() {
+            None
+        } else {
+            Some(arg.allowed_values.clone())
+        },
+        metavar: arg.metadata.metavar.clone(),
+        type_annotation: arg.type_annotation.clone(),
+        nargs: None,
     }
 }
 
@@ -590,9 +681,9 @@ mod dispatched_pack_tests {
     //! `pack_child_args` packs a matched dispatched-leaf into a
     //! `PackedChild`. These tests pin the on-the-wire encoding (which
     //! reuses `extract_value`, so flags stay bools and missing
-    //! arguments stay absent rather than null) — Task 17's pyo3 wiring
-    //! reads the resulting `args` map and must keep getting the same
-    //! JSON shape `build_spec` would have produced.
+    //! arguments stay absent rather than null) — `build_dispatch_spec`
+    //! and the Python runner read the resulting `args` map and must keep
+    //! getting the same JSON shape `build_spec` would have produced.
     use super::*;
     use clap::{Arg, ArgAction};
     use toolr_core::manifest::{Argument, ArgumentKind, Command, Origin};
@@ -651,6 +742,150 @@ mod dispatched_pack_tests {
             .unwrap();
         let packed = pack_child_args(&migrate_cmd(), &matches);
         assert_eq!(packed.args.get("check"), Some(&Value::Bool(false)));
+    }
+
+    #[test]
+    fn build_dispatch_spec_routes_to_parent_function() {
+        // The grafted leaf carries the parent dispatcher's module +
+        // function (set by `graft_children`). `build_dispatch_spec`
+        // copies those into the spec so the runner imports the parent.
+        let leaf = migrate_cmd();
+        let packed = pack_child_args(
+            &leaf,
+            &clap::Command::new("migrate")
+                .arg(Arg::new("check").long("check").action(ArgAction::SetTrue))
+                .try_get_matches_from(vec!["migrate", "--check"])
+                .unwrap(),
+        );
+        // Parent dispatcher has no own args in this scenario — use a
+        // copy of the leaf shape but with an empty arguments list so
+        // `build_dispatch_spec` won't try to extract a `check` arg
+        // from the parent matches.
+        let parent = Command {
+            arguments: vec![],
+            ..migrate_cmd()
+        };
+        let parent_matches = clap::Command::new("django")
+            .try_get_matches_from(vec!["django"])
+            .unwrap();
+        let spec = build_dispatch_spec(
+            &parent,
+            &parent_matches,
+            packed,
+            Path::new("/repo"),
+            &OutputOptions::default(),
+        );
+        assert_eq!(spec.module, "tools.dispatcher");
+        assert_eq!(spec.function, "django");
+        let dispatch = spec.dispatch.expect("dispatch present");
+        assert_eq!(dispatch.command, "migrate");
+        assert_eq!(
+            dispatch.command_args.get("check"),
+            Some(&Value::Bool(true))
+        );
+        assert_eq!(dispatch.schema.name, "migrate");
+        assert_eq!(dispatch.schema.arguments.len(), 1);
+        assert_eq!(dispatch.schema.arguments[0].name, "check");
+        assert_eq!(dispatch.schema.arguments[0].kind, "flag");
+    }
+
+    #[test]
+    fn build_dispatch_spec_extracts_parent_kwargs() {
+        // When the parent dispatcher has its own args (e.g. `--cpu`),
+        // those are extracted from `parent_matches` into `spec.args` —
+        // distinct from the leaf args carried under `dispatch`.
+        let parent = Command {
+            arguments: vec![Argument {
+                name: "cpu".into(),
+                kind: ArgumentKind::Optional,
+                help: String::new(),
+                default: None,
+                type_annotation: None,
+                resolved_type: None,
+                allowed_values: vec![],
+                path_constraints: None,
+                metadata: Default::default(),
+            }],
+            ..migrate_cmd()
+        };
+        let parent_matches = clap::Command::new("django")
+            .arg(Arg::new("cpu").long("cpu"))
+            .try_get_matches_from(vec!["django", "--cpu", "5000m"])
+            .unwrap();
+        let leaf_matches = clap::Command::new("migrate")
+            .arg(Arg::new("check").long("check").action(ArgAction::SetTrue))
+            .try_get_matches_from(vec!["migrate"])
+            .unwrap();
+        let packed = pack_child_args(&migrate_cmd(), &leaf_matches);
+        let spec = build_dispatch_spec(
+            &parent,
+            &parent_matches,
+            packed,
+            Path::new("/repo"),
+            &OutputOptions::default(),
+        );
+        assert_eq!(
+            spec.args.get("cpu"),
+            Some(&Value::String("5000m".into()))
+        );
+        // Dispatch payload still carries the leaf's args, independent of parent kwargs.
+        let dispatch = spec.dispatch.expect("dispatch present");
+        assert_eq!(dispatch.command_args.get("check"), Some(&Value::Bool(false)));
+    }
+
+    #[test]
+    fn argument_to_arg_schema_maps_all_kinds() {
+        fn argument_named(name: &str, kind: ArgumentKind) -> Argument {
+            Argument {
+                name: name.into(),
+                kind,
+                help: String::new(),
+                default: None,
+                type_annotation: None,
+                resolved_type: None,
+                allowed_values: vec![],
+                path_constraints: None,
+                metadata: Default::default(),
+            }
+        }
+        let cases = [
+            (ArgumentKind::Positional, "positional"),
+            (ArgumentKind::Optional, "optional"),
+            (ArgumentKind::Flag, "flag"),
+            (ArgumentKind::Count, "flag"),
+            (ArgumentKind::Repeated, "repeated"),
+            (ArgumentKind::VarPositional, "repeated"),
+        ];
+        for (kind, expected) in cases {
+            let schema = argument_to_arg_schema(&argument_named("a", kind));
+            assert_eq!(schema.kind, expected, "kind {kind:?}");
+        }
+    }
+
+    #[test]
+    fn argument_to_arg_schema_carries_choices_metavar_and_type_annotation() {
+        let metadata = toolr_core::manifest::ArgMetadata {
+            metavar: Some("PATH".into()),
+            ..Default::default()
+        };
+        let arg = Argument {
+            name: "out".into(),
+            kind: ArgumentKind::Optional,
+            help: "where to write".into(),
+            default: Some("/tmp".into()),
+            type_annotation: Some("str".into()),
+            resolved_type: None,
+            allowed_values: vec!["a".into(), "b".into()],
+            path_constraints: None,
+            metadata,
+        };
+        let schema = argument_to_arg_schema(&arg);
+        assert_eq!(schema.name, "out");
+        assert_eq!(schema.help, "where to write");
+        assert_eq!(schema.default.as_deref(), Some("/tmp"));
+        assert_eq!(schema.metavar.as_deref(), Some("PATH"));
+        assert_eq!(schema.type_annotation.as_deref(), Some("str"));
+        assert_eq!(schema.choices.as_deref(), Some(&["a".to_string(), "b".to_string()][..]));
     }
 
     #[test]

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -216,6 +216,7 @@ mod tests {
             }],
             imports: vec![],
             origin: Origin::Static,
+            dispatched_from: None,
         }
     }
 
@@ -281,6 +282,7 @@ mod tests {
             }],
             imports: vec![],
             origin: Origin::Static,
+            dispatched_from: None,
         };
         let matches = clap::Command::new("switch")
             .arg(Arg::new("force").long("force").action(ArgAction::SetTrue))
@@ -323,6 +325,7 @@ mod tests {
             arguments: args,
             imports: vec![],
             origin: Origin::Static,
+            dispatched_from: None,
         }
     }
 

--- a/crates/toolr/src/main.rs
+++ b/crates/toolr/src/main.rs
@@ -1,3 +1,4 @@
+mod bootstrap;
 mod cli;
 mod dispatch;
 mod execute_build;

--- a/crates/toolr/src/main.rs
+++ b/crates/toolr/src/main.rs
@@ -27,9 +27,11 @@ fn main() -> ExitCode {
 
 fn run() -> anyhow::Result<ExitCode> {
     let cwd = std::env::current_dir()?;
+    let argv: Vec<String> = std::env::args().collect();
     // Emit the passive cache hint before clap touches argv, so `--version`
     // and `--help` (which would otherwise exit inside clap) still see it.
     maybe_emit_cache_hint_from_argv();
+    bootstrap::ensure_manifest_present_or_bootstrap(&cwd, &argv)?;
     let manifest = load_or_empty(&cwd);
     let mut command = cli::build_command(&manifest);
     let matches = command.clone().get_matches();

--- a/specs/2026-05-19-external-command-sources-plan-a.md
+++ b/specs/2026-05-19-external-command-sources-plan-a.md
@@ -1056,7 +1056,20 @@ git commit -m "argparse: scaffold module + parse [tool.toolr.argparse.*] blocks"
 
 - Modify: `crates/toolr-core/src/argparse/scan.rs`
 
-**Background:** Find every call expression whose function is `<anything>.add_argument` and extract structured info about each. We use the existing `ruff_python_parser` workspace dep.
+**Background:** Find every call expression whose function is `<anything>.add_argument` AND whose call shape matches argparse (1+ string-literal positional args + only-argparse-known kwargs). We use the existing `ruff_python_parser` workspace dep.
+
+**Matching heuristic (signature-shape filter):**
+
+The receiver name is intentionally NOT checked — Django uses `parser.add_argument(...)` inside `def add_arguments(self, parser):`, ad-hoc scripts use `parser.add_argument(...)` after `parser = argparse.ArgumentParser()`, and some code uses `self.parser.add_argument(...)`. All should match. But matching every `.add_argument(...)` call would create false positives (e.g. `mylist.add_argument(int_value)` on a custom class).
+
+A call qualifies as an argparse `add_argument` iff:
+
+1. The function is an attribute access ending in `.add_argument` (any receiver).
+2. **At least one positional argument is present, AND every positional argument is a string literal.** Argparse `add_argument` takes one or more name-or-flag strings as positionals (e.g. `add_argument('--verbose', '-v')` or `add_argument('app_label')`); any non-string-literal positional disqualifies the call.
+3. **Every keyword argument's name is in the argparse-known set:**
+   `action`, `nargs`, `const`, `default`, `type`, `choices`, `required`, `help`, `metavar`, `dest`, `version`. An unknown kwarg disqualifies the call.
+
+Calls that fail (2) or (3) are silently skipped — they're not argparse calls and shouldn't surface scanner warnings (otherwise random `.add_argument` calls in user code spam the log).
 
 - [ ] **Step 1: Write failing test**
 
@@ -1148,6 +1161,48 @@ def add_arguments(self, parser):
         assert_eq!(scanned.arguments[0].type_annotation, None);
         assert!(scanned.warnings.iter().any(|w| w.contains("type=")));
     }
+
+    #[test]
+    fn matches_any_receiver_name() {
+        // Django-style (`parser`), nested attribute (`self.parser`), and
+        // a custom name should all be picked up — receiver is not checked.
+        let source = r#"
+def add_arguments(self, parser):
+    parser.add_argument('a')
+    self.parser.add_argument('--b', action='store_true')
+    sub_parser.add_argument('c')
+"#;
+        let scanned = scan_source("x", source).unwrap();
+        let names: Vec<_> = scanned.arguments.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn skips_calls_whose_positional_is_not_a_string_literal() {
+        // First positional is an int — not an argparse name/flag, skip.
+        let source = "def f(): mylist.add_argument(42, default='x')";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(scanned.arguments.is_empty());
+        assert!(scanned.warnings.is_empty(), "skipping non-argparse calls should not warn");
+    }
+
+    #[test]
+    fn skips_calls_with_unknown_kwarg() {
+        // `frobnicate` is not in the argparse kwarg set; this is some other
+        // method named `add_argument`. Skip silently.
+        let source = "def f(): widget.add_argument('--x', frobnicate=True)";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(scanned.arguments.is_empty());
+        assert!(scanned.warnings.is_empty());
+    }
+
+    #[test]
+    fn skips_calls_with_no_positional_arguments() {
+        let source = "def f(): widget.add_argument(action='store_true')";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(scanned.arguments.is_empty());
+        assert!(scanned.warnings.is_empty());
+    }
 }
 ```
 
@@ -1197,14 +1252,29 @@ pub fn scan_source(command_name: &str, source_text: &str) -> Result<ScannedComma
 }
 ```
 
-`module_docstring`, `split_first_paragraph`, `find_add_argument_calls`, and `argument_from_call` are private helpers in the same file. `argument_from_call` is the bulk of the work:
+`module_docstring`, `split_first_paragraph`, `find_add_argument_calls`, and `argument_from_call` are private helpers in the same file.
 
-- Inspect the first positional argument string literal to determine `kind`:
-    - Starts with `--` → `Optional` or `Flag` (decided by `action=`).
+`find_add_argument_calls` walks the module AST and yields every `Expr::Call` whose `.func` is an `Attribute` access ending in `add_argument`, regardless of the receiver expression's name or shape. That gives the broadest set of candidate calls.
+
+`argument_from_call` applies the signature-shape filter and extracts structure:
+
+1. **Filter — fail-fast (return `Err(skip)`):**
+    - Zero positional arguments → skip.
+    - Any positional argument that isn't a string literal (`Expr::StringLiteral`) → skip.
+    - Any keyword argument whose name is outside the argparse-known set (`action`, `nargs`, `const`, `default`, `type`, `choices`, `required`, `help`, `metavar`, `dest`, `version`) → skip.
+
+    The caller silently drops skipped calls — these are not argparse calls, no warning fires.
+
+2. **Classify `kind` from the first positional string:**
+    - Starts with `--` → `Optional` or `Flag` (refined by `action=` below).
     - Starts with `-` followed by a single character → still `Optional`/`Flag` (short alias).
     - Otherwise → `Positional`.
-- Look at `action=` (`store_true`/`store_false` → `Flag`; `append` → `Repeated`).
-- Pull `default=`, `help=`, `choices=`, `type=`, `nargs=`, `metavar=` as best-effort string-encoded values. Anything not statically resolvable becomes a warning + `None`.
+
+3. **Refine `kind` from `action=`:**
+    - `store_true`/`store_false` → `Flag`.
+    - `append` → `Repeated`.
+
+4. **Pull `default=`, `help=`, `choices=`, `type=`, `nargs=`, `metavar=`** as best-effort string-encoded values. Anything not statically resolvable becomes a warning + `None`.
 
 Use `ruff_python_ast` walkers / pattern matching against `Expr::Call` and the `Attribute` access on `.func`. See the existing usage in `crates/toolr-core/src/parser/` for the AST traversal idioms.
 
@@ -1214,7 +1284,7 @@ Use `ruff_python_ast` walkers / pattern matching against `Expr::Call` and the `A
 cargo test -p toolr-core --quiet argparse::scan
 ```
 
-Expected: 3 passed.
+Expected: 7 passed (3 happy-path + 4 filter / receiver tests).
 
 - [ ] **Step 5: Commit**
 

--- a/specs/2026-05-19-fill-the-gaps-design.md
+++ b/specs/2026-05-19-fill-the-gaps-design.md
@@ -1,0 +1,371 @@
+# Filling the gaps from Plan A
+
+**Status:** Draft (2026-05-19)
+**Topic:** Two follow-up fixes deferred from `specs/2026-05-19-external-command-sources-plan-a.md`:
+auto-rebuild on missing manifest, and routing the dispatcher's own CLI flags
+through the grafted-child invocation path.
+
+## Background
+
+Plan A's PR (#222) shipped the built-in argparse scanner and the
+`DispatchCommand` runtime contract, but two known gaps were documented as
+deferred work:
+
+1. **Auto-rebuild on missing manifest.** The user originally said *"if the
+   manifest file was missing, it would be auto-generated (yeah, slower UX for
+   one time)."* That intent isn't implemented today: `main.rs::load_or_empty`
+   silently returns an empty manifest when `tools/.toolr-manifest.json` is
+   absent, so clap rejects every user command before any rebuild can fire.
+
+2. **Dispatcher's own CLI flags reachable on the child invocation path.** The
+   external-command-sources spec called for invocations like
+   `toolr jenkins job --cpu 5000m --ram 12Gi migrate --check`. Today, grafted
+   children are *siblings* of the dispatcher inside the parent group, so the
+   reachable form is `toolr jenkins migrate ...` and the dispatcher's outer
+   flags have nowhere to live on that path.
+
+Both gaps are bounded and independent. This spec fixes both in one PR with
+one implementation plan.
+
+## Goal
+
+After this work lands:
+
+- `toolr <user-cmd>` on a fresh clone (no manifest yet) succeeds — toolr
+  detects the missing manifest, runs a full rebuild, and continues into the
+  command. Tab completion and built-ins (`--help`, `project`, `self`, `init`)
+  skip the auto-rebuild.
+- `toolr <group> <dispatcher> --outer-flags... <child> --child-flags...` works
+  end-to-end. The dispatcher receives both its outer kwargs and a
+  `DispatchCommand` payload for the child.
+
+## Non-goals
+
+- No widening of `invoke_dispatcher` semantics. The dispatcher still requires
+  a `dispatched: DispatchCommand` kwarg; bare `toolr <group> <dispatcher>`
+  (no child) is rejected by clap at parse time via `subcommand_required(true)`.
+- No new auto-rebuild trigger beyond missing-manifest. The existing
+  `ensure_dynamic_layer_fresh` path (stale dynamic hash) is unchanged.
+- No support for an "is-dispatcher" hint on the **dynamic** registry side. The
+  flag is set by the **static** argparse scanner at graft time.
+
+## Architecture
+
+Two independent fixes, sharing one PR:
+
+```text
+                     ┌────────────────────────────┐
+   Gap 1 fix         │ main.rs::ensure_manifest_  │
+   (manifest         │   present_or_bootstrap     │
+    bootstrap)       │ - argv first-pos inspect   │
+                     │ - tools/pyproject.toml?    │
+                     │ - manifest exists?         │
+                     │ - if all green for rebuild:│
+                     │   eprintln + call          │
+                     │   rebuild_manifest_full    │
+                     └──────────────┬─────────────┘
+                                    │ load_manifest
+                                    ▼
+                     ┌────────────────────────────┐
+   Gap 2 fix         │ cli.rs::build_group_subtree│
+   (CLI tree shape   │ - read is_dispatcher       │
+    for dispatchers) │ - when true: dispatcher    │
+                     │   becomes Command with     │
+                     │   its own args + grafted   │
+                     │   children as subcommands  │
+                     │ - children no longer       │
+                     │   sibling-attach to group  │
+                     └──────────────┬─────────────┘
+                                    │ clap parse
+                                    ▼
+                     ┌────────────────────────────┐
+                     │ dispatch.rs                │
+                     │ - same walk, but           │
+                     │   group_full_path needs    │
+                     │   tweak for 3-segment      │
+                     │   path (group/dispatcher/  │
+                     │   child)                   │
+                     └────────────────────────────┘
+```
+
+| Gap | Files | New manifest field |
+|---|---|---|
+| 1 — auto-rebuild | `crates/toolr/src/main.rs`, possibly extracted to `crates/toolr/src/bootstrap.rs` | None |
+| 2 — dispatcher hosts children | `crates/toolr-core/src/manifest/model.rs`, `crates/toolr-core/src/argparse/{attach,mod}.rs`, `crates/toolr-core/src/parser/build.rs`, `crates/toolr/src/cli.rs`, `crates/toolr/src/dispatch.rs` | `is_dispatcher: bool` on `Command` |
+
+Unchanged: the `DispatchCommand` Python contract, the argparse AST scanner,
+the JSON-spec dispatch wire format, the Python runner's `invoke_dispatcher`.
+Children's `group` field still equals `attachment.parent` — the new tree
+shape is purely a CLI-build concern, not a manifest-hierarchy change.
+
+## Gap 1 — Auto-rebuild on missing manifest
+
+### Decision logic
+
+`ensure_manifest_present_or_bootstrap(cwd, argv) -> Result<()>`:
+
+1. Discover project root. If none, return `Ok` (not a toolr project).
+2. If `tools/pyproject.toml` is missing, return `Ok` (toolr-init not yet run).
+3. If `tools/.toolr-manifest.json` exists, return `Ok` (existing freshness path handles it).
+4. Cheap argv inspection: if `should_skip_auto_rebuild(argv)` returns true, return `Ok`.
+5. Resolve the tools venv (`toolr_core::venv::resolve_venv_path`).
+6. If the venv's python doesn't exist, return `Ok` — let the normal downstream error surface (same fallback `ensure_dynamic_layer_fresh` uses).
+7. Print `toolr: manifest missing; building (first-time setup)...` to stderr.
+8. Call `toolr_core::dynamic::rebuild_manifest_full(&root, &python, &venv_dir)`.
+9. On error: propagate. `main.rs` prints it and exits 2. Don't fall through to empty manifest.
+10. Return `Ok`. `main.rs::load_or_empty` will now find the manifest.
+
+### Argv inspector
+
+```rust
+fn should_skip_auto_rebuild(argv: &[String]) -> bool {
+    const BUILTINS: &[&str] = &["__complete", "project", "self", "init"];
+    const HELP_FLAGS: &[&str] = &["--help", "--version", "-h", "-V"];
+
+    if argv.iter().skip(1).any(|a| HELP_FLAGS.contains(&a.as_str())) {
+        return true;
+    }
+    let first_positional = argv.iter().skip(1).find(|a| !a.starts_with('-'));
+    match first_positional {
+        None => true,
+        Some(name) => BUILTINS.contains(&name.as_str()),
+    }
+}
+```
+
+Properties:
+
+- `toolr <user-cmd>` (any user-defined command) → rebuilds.
+- `toolr --debug <user-cmd>` (leading global flag) → rebuilds.
+- `toolr --help` / `-h` / `--version` / `-V` → skips.
+- `toolr` alone → skips (will print group help anyway).
+- `toolr __complete ...` → skips (tab completion must be fast).
+- `toolr project manifest rebuild` / `toolr self cache list` / `toolr init` → skips.
+
+### Tests
+
+Table-driven `should_skip_auto_rebuild` tests (10 cases listed under "Test
+surface" below).
+
+End-to-end: unskip the existing
+`test_e2e_auto_rebuild_runs_argparse` in `tests/sources/test_e2e.py`. The
+test already deletes the manifest and invokes `toolr django migrate --check`,
+asserting the manifest is recreated and the dispatcher receives the right
+payload.
+
+### UX message
+
+`toolr: manifest missing; building (first-time setup)...` — matches the
+existing `toolr: dynamic manifest layer stale; regenerating...` tone.
+
+## Gap 2 — Dispatcher hosts grafted children
+
+### Manifest field
+
+`crates/toolr-core/src/manifest/model.rs`:
+
+```rust
+pub struct Command {
+    // ... existing fields ...
+
+    /// True when this command hosts grafted children as its own
+    /// subcommands. Set by `argparse::run_for_project` on the parent
+    /// dispatcher entry whenever a `[[tool.toolr.argparse.*.attach]]`
+    /// directs children at it. Read by the CLI builder to decide
+    /// whether to build the command as a flat leaf or as a parent
+    /// that owns children.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_dispatcher: bool,
+}
+```
+
+Same `serde(default, skip_serializing_if)` pattern as `dispatched_from`. No
+`SCHEMA_VERSION` bump (pre-1.0). Every existing `Command { ... }` literal
+gets `is_dispatcher: false,` added.
+
+### Setting the flag at graft time
+
+`argparse::run_for_project` is extended to return:
+
+```rust
+pub struct GraftResult {
+    /// {parent_dotted_name -> Vec<grafted child Command>}.
+    pub children_by_parent: HashMap<String, Vec<Command>>,
+    /// Dotted names of parents that received at least one grafted child.
+    pub dispatchers: HashSet<String>,
+}
+```
+
+`build_static_manifest_inner` consumes both: appends children as today, then
+walks `manifest.commands.iter_mut()` and flips `is_dispatcher = true` on every
+entry whose dotted name is in `grafted.dispatchers`.
+
+The dotted-name derivation is the same one already used to populate the
+`parents` map in `build_static_manifest_inner`; factor it into a shared
+`fn dotted_name(cmd: &Command) -> String` helper to keep the two call sites
+in lockstep.
+
+### CLI tree reshape
+
+`crates/toolr/src/cli.rs::build_group_subtree`:
+
+```rust
+fn build_group_subtree(
+    group: &Group,
+    manifest: &Manifest,
+    children: &HashMap<Option<String>, Vec<&Group>>,
+) -> Command {
+    let full_path = group.full_path();
+    let mut g = Command::new(group.name.clone()).about(group.title.clone());
+    if !group.description.is_empty() {
+        g = g.long_about(group.description.clone());
+    }
+
+    // Bucket grafted children of this group by their dispatcher's
+    // (module, function). `graft_children` copies those from the parent
+    // dispatcher entry, so the pair is a precise dispatcher identity.
+    let grafted_by_dispatcher: HashMap<(&str, &str), Vec<&Command>> = manifest
+        .commands
+        .iter()
+        .filter(|c| c.group == full_path && c.dispatched_from.is_some())
+        .fold(HashMap::new(), |mut acc, c| {
+            acc.entry((c.module.as_str(), c.function.as_str()))
+                .or_default()
+                .push(c);
+            acc
+        });
+
+    // For each NON-grafted command in this group, decide whether to
+    // build it as a dispatcher (with its args + the bucket as
+    // subcommands) or a normal leaf.
+    for cmd in manifest
+        .commands
+        .iter()
+        .filter(|c| c.group == full_path && c.dispatched_from.is_none())
+    {
+        if cmd.is_dispatcher {
+            let children = grafted_by_dispatcher
+                .get(&(cmd.module.as_str(), cmd.function.as_str()))
+                .cloned()
+                .unwrap_or_default();
+            g = g.subcommand(build_dispatcher_command(cmd, &children));
+        } else {
+            g = g.subcommand(build_user_command(cmd));
+        }
+    }
+
+    if let Some(child_groups) = children.get(&Some(full_path)) {
+        for child in child_groups {
+            g = g.subcommand(build_group_subtree(child, manifest, children));
+        }
+    }
+    g
+}
+
+fn build_dispatcher_command(dispatcher: &Command, children: &[&Command]) -> Command {
+    let mut c = build_user_command(dispatcher).subcommand_required(true);
+    for child in children {
+        c = c.subcommand(build_user_command(child));
+    }
+    c
+}
+```
+
+Grafted children no longer appear as direct subcommands of the group. They
+appear as subcommands of the dispatcher. A dispatcher's `subcommand_required(true)`
+ensures bare `toolr <group> <dispatcher>` invocations get a clear "Usage" message
+from clap rather than a runtime "missing dispatched argument" error.
+
+### Dispatch path lookup
+
+`crates/toolr/src/dispatch.rs` currently computes
+`group_full_path = path[..len-1].join(".")`. For a dispatched leaf the path
+is three segments (`["jenkins", "job", "migrate"]`), so the leaf's manifest
+`group` (`"jenkins"`) is two levels up, not one. The lookup tries the
+**more-specific** group first and only falls back to the shorter form if no
+command matches, so a hypothetical project with both `docker.build` and
+`docker.image.build` can never silently resolve the wrong one:
+
+```rust
+let candidates: &[String] = &[
+    path[..path.len() - 1].join("."),
+    if path.len() >= 2 {
+        path[..path.len() - 2].join(".")
+    } else {
+        String::new()
+    },
+];
+// Try each candidate group in order (longest/most-specific first). For
+// each, look up by exact (group, name) match. First match wins.
+let cmd = candidates
+    .iter()
+    .find_map(|group| {
+        manifest
+            .commands
+            .iter()
+            .find(|c| &c.group == group && c.name == leaf_name)
+    })
+    .ok_or_else(|| anyhow::anyhow!("unknown command: {}", path.join(" ")))?;
+```
+
+`parent_matches` (already tracked by the existing walk) ends up pointing at
+the dispatcher's `ArgMatches`, which contains the dispatcher's own kwargs.
+`build_dispatch_spec(dispatcher, parent_matches, packed, ...)` is unchanged
+— it just receives a path-resolved-correctly dispatcher.
+
+## Edge cases out of scope
+
+1. **Bare `toolr <group> <dispatcher>`** — `subcommand_required(true)` rejects at parse time. Good UX. No widening of `invoke_dispatcher` semantics.
+2. **Two dispatchers in one group** — covered by the `(module, function)` bucketing in 3c; each dispatcher hosts its own children. Unit-tested below.
+3. **Dispatcher + sibling normal leaf in one group** — the dispatcher hosts grafted children; the normal leaf stays a sibling under the group. Unit-tested.
+4. **Auto-rebuild race** between parallel `toolr <user-cmd>` invocations — both rebuild; the existing atomic-rename in `write_manifest` makes the last-writer-wins result correct.
+5. **Auto-rebuild on a *corrupted* manifest** — `load_manifest` fails for non-`not-found` reasons. Current `load_or_empty` swallows the error to empty. This spec does not change that behaviour; only missing-manifest triggers the new bootstrap.
+
+## Test surface
+
+| Layer | Test | File | Coverage |
+|---|---|---|---|
+| Argv inspector | `should_skip_auto_rebuild` table | `crates/toolr/src/bootstrap.rs` | 10 cases (`--help`, `-h`, `--version`, bare, `__complete`, `project`, `self`, `init`, user-cmd, leading `--debug`) |
+| Manifest field | `Command` serializes / omits `is_dispatcher` | `crates/toolr-core/src/manifest/tests.rs` | Mirror existing `dispatched_from` round-trip tests |
+| Graft result | `run_for_project` returns `dispatchers` set | `crates/toolr-core/src/argparse/mod.rs` tests | Extension of Task-14 test |
+| Manifest flag set | `build_static_manifest_grafts_argparse_children` extended | `crates/toolr-core/src/parser/build.rs` | `assert!(django.is_dispatcher)` |
+| CLI tree — basic | Dispatcher + 2 children → dispatcher has both as subcommands | `crates/toolr/src/cli.rs` | Pure cli.rs unit test, no fixture-on-disk |
+| CLI tree — two dispatchers in one group | Each dispatcher hosts its own children | `crates/toolr/src/cli.rs` | Unit |
+| CLI tree — dispatcher + sibling normal leaf | Coexistence | `crates/toolr/src/cli.rs` | Unit |
+| Dispatch path lookup | 3-segment path resolves correctly | `crates/toolr/src/dispatch.rs` | Likely covered by E2E |
+| E2E auto-rebuild | Unskip `test_e2e_auto_rebuild_runs_argparse` | `tests/sources/test_e2e.py` | Already authored; just remove the `@pytest.mark.skip` |
+| E2E outer flags | New: `toolr django job --cpu 5000m migrate --check`, sidecar asserts both | `tests/sources/test_e2e.py` | New test |
+
+## Failure modes
+
+| Failure | Behaviour |
+|---|---|
+| Auto-rebuild fails (venv broken, plugin error) | `rebuild_manifest_full` error propagates. `main.rs` prints `toolr: <error>` and exits 2. Same shape as `toolr project manifest rebuild` failing today. |
+| Auto-rebuild succeeds but produces a manifest that still doesn't have the user's command | Clap rejects with "unrecognized subcommand" as today. Side-effect: the user now has a manifest. |
+| Dispatcher built with `subcommand_required(true)` but the user typed only the dispatcher name | Clap prints "Usage: toolr jenkins job <COMMAND>" + the list of children. |
+| User adds a new argparse-discoverable file but doesn't run rebuild | Same as today — tab completion stays stale until the next rebuild. Auto-rebuild does **not** fire because the manifest already exists. |
+
+## Rollout sequence
+
+Two stacks of commits inside one PR. They can land in either order; the plan
+will sequence Stack A first because it's smaller.
+
+**Stack A — auto-rebuild (gap 1):**
+
+1. Add `should_skip_auto_rebuild` + 10-case table-driven tests.
+2. Add `ensure_manifest_present_or_bootstrap` and wire into `main.rs::run` between `discover_project_root` and `load_or_empty`.
+3. Unskip `test_e2e_auto_rebuild_runs_argparse`.
+
+**Stack B — dispatcher hosts children (gap 2):**
+
+1. Add `is_dispatcher: bool` to `Command` + round-trip tests + populate all literal sites.
+2. Reshape `argparse::run_for_project` to return `GraftResult { children_by_parent, dispatchers }`; pass through to `build_static_manifest_inner` to flip the flag.
+3. Reshape `cli.rs::build_group_subtree` + new `build_dispatcher_command` helper. Add the 3 cli.rs unit tests.
+4. Fix `dispatch.rs` path lookup to handle 3-segment paths.
+5. New E2E test exercising dispatcher outer flags.
+
+## Out of scope (future work)
+
+- Allowing a dispatcher to run *without* a child subcommand (would require widening `invoke_dispatcher` to construct a `DispatchCommand` with `command=""` or making the kwarg optional in the dispatcher's signature).
+- Auto-rebuild on corrupted manifest (vs missing).
+- Marking dispatchers from non-argparse sources (e.g. future Jenkins plugin). Adding `is_dispatcher = true` from a different graft path would Just Work — no design change needed.

--- a/specs/2026-05-19-fill-the-gaps-plan.md
+++ b/specs/2026-05-19-fill-the-gaps-plan.md
@@ -1,0 +1,1315 @@
+# Fill the gaps — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the two follow-up fixes deferred from Plan A — auto-rebuild on missing manifest, and routing the dispatcher's own CLI flags through the grafted-child invocation path.
+
+**Architecture:** Two independent stacks inside one PR. Stack A adds a pre-clap bootstrap step in `main.rs` that detects a missing `tools/.toolr-manifest.json` and runs `rebuild_manifest_full`, skipping for built-ins / completion via cheap argv inspection. Stack B adds an `is_dispatcher: bool` field on `Command`, set at graft time by `argparse::run_for_project`, read by `cli.rs::build_group_subtree` to hoist grafted children into the dispatcher as subcommands (instead of treating them as siblings of the dispatcher inside the parent group). `dispatch.rs` widens its path-to-command lookup to handle 3-segment paths.
+
+**Tech Stack:** Rust (toolr / toolr-core), pyo3-free dispatch wire (JSON spec), pytest E2E.
+
+**Read first:** `specs/2026-05-19-fill-the-gaps-design.md` is the spec; this plan is the *how*. Plan A's commits on `feat/argparse-scanner` are the baseline.
+
+---
+
+## File map
+
+### New Rust files
+
+- `crates/toolr/src/bootstrap.rs` — argv inspector + manifest-bootstrap entry point. Re-exported via `mod bootstrap;` in `main.rs`.
+
+### Modified Rust files
+
+- `crates/toolr/src/main.rs` — `mod bootstrap;` declaration; `run()` calls `bootstrap::ensure_manifest_present_or_bootstrap(&cwd, &argv)` before `load_or_empty`.
+- `crates/toolr-core/src/manifest/model.rs` — add `is_dispatcher: bool` to `Command`.
+- `crates/toolr-core/src/argparse/mod.rs` — new `GraftResult { children_by_parent, dispatchers }`; `run_for_project` returns it.
+- `crates/toolr-core/src/parser/build.rs` — consume `GraftResult.dispatchers` and flip the flag on each named parent. Factor the dotted-name derivation into `fn dotted_name(cmd: &Command) -> String`.
+- `crates/toolr/src/cli.rs` — `build_group_subtree` reshape + new `build_dispatcher_command` helper.
+- `crates/toolr/src/dispatch.rs` — wider path-to-command lookup that tries most-specific-group-first.
+
+### Modified test files
+
+- `crates/toolr-core/src/manifest/tests.rs` — `is_dispatcher` round-trip tests (mirror existing `dispatched_from` pair).
+- `crates/toolr-core/src/argparse/mod.rs` `#[cfg(test)]` — extend `run_for_project_returns_grafted_children` to assert `dispatchers` set.
+- `crates/toolr-core/src/parser/build.rs` `#[cfg(test)]` — extend `build_static_manifest_grafts_argparse_children` to assert `dispatcher.is_dispatcher == true`.
+- `crates/toolr/src/cli.rs` `#[cfg(test)]` — 3 new clap-tree-shape tests.
+- `tests/sources/test_e2e.py` — unskip `test_e2e_auto_rebuild_runs_argparse`; add new `test_e2e_dispatcher_outer_flags`.
+
+### Sites to update for the new field
+
+All places that construct a `Command { ... }` literal need `is_dispatcher: false,` appended. These are the same 8 sites Task 7 of Plan A already updated for `dispatched_from`:
+
+- `crates/toolr-core/src/manifest/model.rs` (test fixtures)
+- `crates/toolr-core/src/manifest/tests.rs`
+- `crates/toolr-core/src/parser/commands.rs`
+- `crates/toolr-core/src/third_party/merge.rs`
+- `crates/toolr-core/src/third_party/tests.rs`
+- `crates/toolr-core/src/dynamic/tests.rs`
+- `crates/toolr-core/src/dynamic/merge.rs`
+- `crates/toolr-core/src/complete/tests.rs`
+- `crates/toolr/src/execute_build.rs`
+
+Use `rg -n 'Command \{' crates/ tests/` to confirm the list at the start of Task 4.
+
+---
+
+## Task index
+
+- Stack A — auto-rebuild on missing manifest:
+  - Task 1: `should_skip_auto_rebuild` argv inspector + tests
+  - Task 2: `ensure_manifest_present_or_bootstrap` + wire into `main.rs::run`
+  - Task 3: Unskip `test_e2e_auto_rebuild_runs_argparse`
+- Stack B — dispatcher hosts grafted children:
+  - Task 4: `is_dispatcher: bool` field on `Command`
+  - Task 5: `argparse::run_for_project` returns `GraftResult`; `build_static_manifest_inner` flips the flag
+  - Task 6: `cli.rs::build_group_subtree` reshape + `build_dispatcher_command`
+  - Task 7: `dispatch.rs` widens path-to-command lookup
+  - Task 8: New E2E test exercising dispatcher outer flags
+
+---
+
+## Stack A — Auto-rebuild on missing manifest
+
+### Task 1: `should_skip_auto_rebuild` argv inspector
+
+**Files:**
+
+- Create: `crates/toolr/src/bootstrap.rs`
+
+The bootstrap module is empty for now — just the argv inspector and its tests. The wire-up into `main.rs::run` lands in Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/toolr/src/bootstrap.rs`:
+
+```rust
+//! Pre-clap bootstrap: detect missing `tools/.toolr-manifest.json`
+//! and run a full rebuild before clap parses the user's command.
+//!
+//! See `specs/2026-05-19-fill-the-gaps-design.md` (gap 1) for the
+//! decision logic.
+
+pub(crate) fn should_skip_auto_rebuild(argv: &[String]) -> bool {
+    todo!("Task 1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_skip_auto_rebuild;
+
+    fn args(parts: &[&str]) -> Vec<String> {
+        std::iter::once("toolr")
+            .chain(parts.iter().copied())
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn skips_for_long_help_flag() {
+        assert!(should_skip_auto_rebuild(&args(&["--help"])));
+    }
+
+    #[test]
+    fn skips_for_short_help_flag() {
+        assert!(should_skip_auto_rebuild(&args(&["-h"])));
+    }
+
+    #[test]
+    fn skips_for_long_version_flag() {
+        assert!(should_skip_auto_rebuild(&args(&["--version"])));
+    }
+
+    #[test]
+    fn skips_for_short_version_flag() {
+        assert!(should_skip_auto_rebuild(&args(&["-V"])));
+    }
+
+    #[test]
+    fn skips_for_bare_toolr() {
+        assert!(should_skip_auto_rebuild(&args(&[])));
+    }
+
+    #[test]
+    fn skips_for_tab_completion() {
+        assert!(should_skip_auto_rebuild(&args(&["__complete", "/tmp", "..."])));
+    }
+
+    #[test]
+    fn skips_for_project_subcommands() {
+        assert!(should_skip_auto_rebuild(&args(&["project", "manifest", "rebuild"])));
+    }
+
+    #[test]
+    fn skips_for_self_subcommands() {
+        assert!(should_skip_auto_rebuild(&args(&["self", "cache", "list"])));
+    }
+
+    #[test]
+    fn skips_for_init() {
+        assert!(should_skip_auto_rebuild(&args(&["init"])));
+    }
+
+    #[test]
+    fn fires_for_user_command() {
+        assert!(!should_skip_auto_rebuild(&args(&["jenkins", "job", "migrate"])));
+    }
+
+    #[test]
+    fn fires_with_leading_global_flag() {
+        assert!(!should_skip_auto_rebuild(&args(&["--debug", "django", "migrate"])));
+    }
+}
+```
+
+Then declare the module from `crates/toolr/src/main.rs`. Add `mod bootstrap;` next to the existing `mod cli;` etc. block (around `main.rs:1-10`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p toolr --quiet bootstrap
+```
+
+Expected: 11 tests panicking on `todo!("Task 1")`.
+
+- [ ] **Step 3: Implement `should_skip_auto_rebuild`**
+
+Replace the `todo!()` body with:
+
+```rust
+pub(crate) fn should_skip_auto_rebuild(argv: &[String]) -> bool {
+    const BUILTINS: &[&str] = &["__complete", "project", "self", "init"];
+    const HELP_FLAGS: &[&str] = &["--help", "--version", "-h", "-V"];
+
+    // Any help/version flag anywhere in argv → skip.
+    if argv.iter().skip(1).any(|a| HELP_FLAGS.contains(&a.as_str())) {
+        return true;
+    }
+    // First positional (= first arg after `toolr` that doesn't start with `-`).
+    let first_positional = argv.iter().skip(1).find(|a| !a.starts_with('-'));
+    match first_positional {
+        None => true,                                // `toolr` alone
+        Some(name) => BUILTINS.contains(&name.as_str()),
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test -p toolr --quiet bootstrap
+```
+
+Expected: 11 passed.
+
+- [ ] **Step 5: Run clippy**
+
+```bash
+cargo clippy --workspace --tests -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/toolr/src/bootstrap.rs crates/toolr/src/main.rs
+git commit -m "bootstrap: add should_skip_auto_rebuild argv inspector"
+```
+
+---
+
+### Task 2: `ensure_manifest_present_or_bootstrap` + wire into `main.rs::run`
+
+**Files:**
+
+- Modify: `crates/toolr/src/bootstrap.rs`
+- Modify: `crates/toolr/src/main.rs:27-36` (the `run` function)
+
+- [ ] **Step 1: Read the existing seam**
+
+```bash
+sed -n '27,40p' crates/toolr/src/main.rs
+```
+
+The current shape:
+
+```rust
+fn run() -> anyhow::Result<ExitCode> {
+    let cwd = std::env::current_dir()?;
+    maybe_emit_cache_hint_from_argv();
+    let manifest = load_or_empty(&cwd);
+    let mut command = cli::build_command(&manifest);
+    let matches = command.clone().get_matches();
+    dispatch::dispatch(&matches, &manifest, &mut command)
+}
+```
+
+The new bootstrap call lands between `cwd` and `load_or_empty`. It takes `&cwd` and `argv`.
+
+- [ ] **Step 2: Add the function (no test yet — covered by E2E in Task 3)**
+
+Append to `crates/toolr/src/bootstrap.rs`:
+
+```rust
+use std::path::Path;
+
+use toolr_core::discovery::discover_project_root;
+use toolr_core::dynamic::rebuild_manifest_full;
+use toolr_core::venv::resolve_venv_path;
+
+/// Bootstrap step that runs before clap parses the user's command.
+///
+/// When the manifest is missing AND `tools/pyproject.toml` exists AND
+/// argv doesn't look like a built-in / help / completion call, run a
+/// full `rebuild_manifest_full` so the user's command can succeed on
+/// a fresh clone. Errors propagate so `main.rs` can print them and
+/// exit non-zero — we intentionally do NOT fall through to an empty
+/// manifest, since that's the buggy old behaviour this task fixes.
+pub(crate) fn ensure_manifest_present_or_bootstrap(
+    cwd: &Path,
+    argv: &[String],
+) -> anyhow::Result<()> {
+    let Ok(root) = discover_project_root(cwd) else {
+        return Ok(());
+    };
+    let tools = root.join("tools");
+    if !tools.join("pyproject.toml").is_file() {
+        return Ok(());
+    }
+    if tools.join(".toolr-manifest.json").is_file() {
+        return Ok(());
+    }
+    if should_skip_auto_rebuild(argv) {
+        return Ok(());
+    }
+
+    let resolved = match resolve_venv_path(&root) {
+        Ok(r) => r,
+        // Venv not yet set up — let the normal execute path surface
+        // the diagnostic. Same fallback `ensure_dynamic_layer_fresh`
+        // uses.
+        Err(_) => return Ok(()),
+    };
+    if !resolved.python.is_file() {
+        return Ok(());
+    }
+
+    eprintln!("toolr: manifest missing; building (first-time setup)...");
+    rebuild_manifest_full(&root, &resolved.python, &resolved.venv_dir)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Wire into `main.rs::run`**
+
+Modify `crates/toolr/src/main.rs:27-36` to:
+
+```rust
+fn run() -> anyhow::Result<ExitCode> {
+    let cwd = std::env::current_dir()?;
+    let argv: Vec<String> = std::env::args().collect();
+    maybe_emit_cache_hint_from_argv();
+    bootstrap::ensure_manifest_present_or_bootstrap(&cwd, &argv)?;
+    let manifest = load_or_empty(&cwd);
+    let mut command = cli::build_command(&manifest);
+    let matches = command.clone().get_matches();
+    dispatch::dispatch(&matches, &manifest, &mut command)
+}
+```
+
+(`maybe_emit_cache_hint_from_argv` already collects argv internally — leaving it alone keeps the diff minimal.)
+
+- [ ] **Step 4: Verify the workspace still builds and existing tests pass**
+
+```bash
+cargo build --workspace --tests
+cargo test --workspace -- --test-threads=1
+cargo clippy --workspace --tests -- -D warnings
+```
+
+Expected: all green. No new tests yet — Task 3's E2E covers behaviour.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/toolr/src/bootstrap.rs crates/toolr/src/main.rs
+git commit -m "bootstrap: auto-rebuild manifest when missing for user commands"
+```
+
+---
+
+### Task 3: Unskip the existing E2E test
+
+**Files:**
+
+- Modify: `tests/sources/test_e2e.py` (remove the `@pytest.mark.skip` decorator on `test_e2e_auto_rebuild_runs_argparse`)
+
+- [ ] **Step 1: Find and remove the skip**
+
+```bash
+rg -n 'pytest.mark.skip' tests/sources/test_e2e.py
+```
+
+You'll see a `@pytest.mark.skip(reason="Auto-rebuild on missing manifest is not implemented...")` decorator immediately above `def test_e2e_auto_rebuild_runs_argparse(...)`. Delete the decorator and its multi-line `reason=` block.
+
+- [ ] **Step 2: Rebuild the toolr binary into the venv**
+
+The E2E test invokes `.venv/bin/toolr`. Drop in the latest build:
+
+```bash
+cargo build --release -p toolr
+cp target/release/toolr .venv/bin/toolr
+.venv/bin/toolr --version
+```
+
+Expected: prints `toolr 0.11.1` (or whatever the current crate version is).
+
+- [ ] **Step 3: Run the unskipped test**
+
+```bash
+uv run pytest tests/sources/test_e2e.py::test_e2e_auto_rebuild_runs_argparse -v
+```
+
+Expected: PASS. The manifest didn't exist before the invocation; toolr bootstrapped it; the dispatch path then ran and the sidecar got written.
+
+- [ ] **Step 4: Run the full E2E module to confirm no regression**
+
+```bash
+uv run pytest tests/sources/ -v
+```
+
+Expected: all green (4 happy-path E2E + the rest of the sources unit tests). No skipped tests in `test_e2e.py` after this task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/sources/test_e2e.py
+git commit -m "tests: unskip auto-rebuild E2E now that bootstrap is wired in"
+```
+
+---
+
+## Stack B — Dispatcher hosts grafted children
+
+### Task 4: `is_dispatcher: bool` field on `Command`
+
+**Files:**
+
+- Modify: `crates/toolr-core/src/manifest/model.rs`
+- Modify: `crates/toolr-core/src/manifest/tests.rs`
+- Modify: every `Command { ... }` literal site (see file map; ~9 files)
+
+- [ ] **Step 1: List the literal sites**
+
+```bash
+rg -n 'Command \{' crates/ tests/
+```
+
+Skim each hit and confirm it constructs `toolr_core::manifest::Command` (not `clap::Command` or `assert_cmd::Command` — those don't need updating). Make a checklist.
+
+- [ ] **Step 2: Write failing round-trip tests**
+
+Append to the existing `dispatched_from_tests` mod in `crates/toolr-core/src/manifest/tests.rs` (or create a parallel `is_dispatcher_tests` mod next to it):
+
+```rust
+#[cfg(test)]
+mod is_dispatcher_tests {
+    use super::*;
+
+    fn cmd_with(is_dispatcher: bool) -> Command {
+        Command {
+            name: "job".into(),
+            group: "jenkins".into(),
+            module: "tools.jenkins".into(),
+            function: "job".into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: None,
+            is_dispatcher,
+        }
+    }
+
+    #[test]
+    fn command_serializes_is_dispatcher_when_true() {
+        let json = serde_json::to_string(&cmd_with(true)).unwrap();
+        assert!(json.contains(r#""is_dispatcher":true"#));
+    }
+
+    #[test]
+    fn command_omits_is_dispatcher_when_false() {
+        let json = serde_json::to_string(&cmd_with(false)).unwrap();
+        assert!(!json.contains("is_dispatcher"));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail (compile error)**
+
+```bash
+cargo test -p toolr-core --quiet is_dispatcher
+```
+
+Expected: compile error — `Command` has no field `is_dispatcher`.
+
+- [ ] **Step 4: Add the field to `Command`**
+
+In `crates/toolr-core/src/manifest/model.rs`, add to the `Command` struct definition (immediately after `dispatched_from`):
+
+```rust
+    /// True when this command hosts grafted children as its own
+    /// subcommands. Set by `argparse::run_for_project` on the parent
+    /// dispatcher entry whenever a `[[tool.toolr.argparse.*.attach]]`
+    /// directs children at it. Read by the CLI builder to decide
+    /// whether to build the command as a flat leaf or as a parent
+    /// that owns children.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_dispatcher: bool,
+```
+
+- [ ] **Step 5: Update every literal site**
+
+For each `Command { ... }` literal in your Step 1 checklist, append `is_dispatcher: false,` to the struct fields. Search for compile failures to find any you missed:
+
+```bash
+cargo build --workspace --tests 2>&1 | grep -E "error\[E\d+\]"
+```
+
+If any error mentions "missing field `is_dispatcher`", fix that site and rebuild.
+
+- [ ] **Step 6: Run all tests and verify both new tests pass**
+
+```bash
+cargo test -p toolr-core --quiet -- --test-threads=1
+cargo build --workspace --tests
+cargo clippy --workspace --tests -- -D warnings
+```
+
+Expected: all green. New `is_dispatcher_tests::command_serializes_is_dispatcher_when_true` and `command_omits_is_dispatcher_when_false` pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/toolr-core/ crates/toolr/
+git commit -m "manifest: add optional is_dispatcher field on Command"
+```
+
+---
+
+### Task 5: `argparse::run_for_project` returns `GraftResult`; builder flips the flag
+
+**Files:**
+
+- Modify: `crates/toolr-core/src/argparse/mod.rs`
+- Modify: `crates/toolr-core/src/parser/build.rs`
+
+**Background:** Today `run_for_project` returns `HashMap<String, Vec<Command>>` (`{parent_dotted_name -> children}`). The caller appends children to the manifest. To set `is_dispatcher` on each parent, we need to also return the set of parent dotted names. We also factor the dotted-name derivation in `build_static_manifest_inner` (currently a closure) into a free function so the flag-flip pass can reuse it.
+
+- [ ] **Step 1: Extend the existing `run_for_project_returns_grafted_children` test**
+
+In `crates/toolr-core/src/argparse/mod.rs` `#[cfg(test)] mod tests`, modify the existing test to assert the new return shape:
+
+```rust
+#[test]
+fn run_for_project_returns_grafted_children() {
+    // ... existing fixture setup (tempdir, tools/, apps/, pyproject.toml) ...
+
+    let result = run_for_project(project.path(), &parents).unwrap();
+
+    let django_children = result.children_by_parent.get("django").unwrap();
+    assert_eq!(django_children.len(), 1);
+    assert_eq!(django_children[0].name, "sync");
+    assert_eq!(
+        django_children[0].dispatched_from.as_deref(),
+        Some("argparse:django"),
+    );
+
+    // New: `django` received grafted children, so it's in `dispatchers`.
+    assert!(result.dispatchers.contains("django"));
+}
+```
+
+(Keep the existing fixture; only the assertions change.)
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cargo test -p toolr-core --quiet argparse::tests::run_for_project
+```
+
+Expected: compile error — `HashMap<String, Vec<Command>>` doesn't have `children_by_parent` / `dispatchers`.
+
+- [ ] **Step 3: Add `GraftResult` and reshape `run_for_project`**
+
+In `crates/toolr-core/src/argparse/mod.rs`, add at module level (near the existing `ArgparseError`):
+
+```rust
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, Default)]
+pub struct GraftResult {
+    /// `{parent_dotted_name -> [grafted child Command]}`.
+    pub children_by_parent: HashMap<String, Vec<Command>>,
+    /// Dotted names of parents that received at least one grafted
+    /// child. The caller flips `is_dispatcher = true` on each.
+    pub dispatchers: HashSet<String>,
+}
+```
+
+Reshape the function signature and body:
+
+```rust
+pub fn run_for_project(
+    project_root: &Path,
+    parents: &HashMap<String, (String, String)>,
+) -> Result<GraftResult, ArgparseError> {
+    let pyproject = project_root.join("tools").join("pyproject.toml");
+    if !pyproject.exists() {
+        return Ok(GraftResult::default());
+    }
+    let blocks = config::parse_blocks_from_pyproject(&pyproject)?;
+    if blocks.is_empty() {
+        return Ok(GraftResult::default());
+    }
+    attach::validate_attachments(&blocks, parents)?;
+
+    let mut out: HashMap<String, Vec<Command>> = HashMap::new();
+    let mut dispatchers: HashSet<String> = HashSet::new();
+    for block in &blocks {
+        let scanned: Vec<scan::ScannedCommand> = scan::scan_block_paths(project_root, &block.scan_paths)?
+            .into_iter()
+            .map(|s| scan::with_common_args(s, &block.common_args))
+            .collect();
+        let grafted = attach::graft_children(block, &scanned, parents)?;
+        for (parent, children) in grafted {
+            if !children.is_empty() {
+                dispatchers.insert(parent.clone());
+            }
+            out.entry(parent).or_default().extend(children);
+        }
+    }
+    attach::validate_no_collisions(&out)?;
+    Ok(GraftResult {
+        children_by_parent: out,
+        dispatchers,
+    })
+}
+```
+
+- [ ] **Step 4: Update `build_static_manifest_inner` to consume the new shape**
+
+Locate `crates/toolr-core/src/parser/build.rs::build_static_manifest_inner`. The existing call site looks roughly like:
+
+```rust
+let grafted = crate::argparse::run_for_project(project_root, &parents)
+    .map_err(BuildError::Argparse)?;
+for (_parent, mut children) in grafted {
+    manifest.commands.append(&mut children);
+}
+```
+
+Replace with:
+
+```rust
+let grafted = crate::argparse::run_for_project(project_root, &parents)
+    .map_err(BuildError::Argparse)?;
+
+// Splice grafted children into the manifest.
+for (_parent, mut children) in grafted.children_by_parent {
+    manifest.commands.append(&mut children);
+}
+
+// Flip the dispatcher flag on each parent that received children.
+for cmd in manifest.commands.iter_mut() {
+    if grafted.dispatchers.contains(&dotted_name(cmd)) {
+        cmd.is_dispatcher = true;
+    }
+}
+```
+
+`dotted_name(cmd: &Command) -> String` is a new private helper. Add it near the top of `build.rs` (or at the bottom, matching the file's existing helper-placement convention). The body is the same derivation already used inline when populating `parents`:
+
+```rust
+fn dotted_name(cmd: &Command) -> String {
+    let leaf = cmd.group.rsplit('.').next().unwrap_or(cmd.group.as_str());
+    if !cmd.group.is_empty() && cmd.name == leaf {
+        cmd.group.clone()
+    } else if cmd.group.is_empty() {
+        cmd.name.clone()
+    } else {
+        format!("{}.{}", cmd.group, cmd.name)
+    }
+}
+```
+
+Then replace the inline closure that builds the `parents` map with a call to this helper.
+
+- [ ] **Step 5: Extend the existing `build_static_manifest_grafts_argparse_children` test**
+
+Find the assertion block at the end of the test in `crates/toolr-core/src/parser/build.rs`. Append:
+
+```rust
+let django = manifest.commands.iter().find(|c| c.name == "django").unwrap();
+assert!(django.is_dispatcher, "expected dispatcher flag set on django");
+```
+
+- [ ] **Step 6: Run everything**
+
+```bash
+cargo test -p toolr-core --quiet -- --test-threads=1
+cargo build --workspace --tests
+cargo clippy --workspace --tests -- -D warnings
+```
+
+Expected: all green. The two extended tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/toolr-core/src/argparse/mod.rs crates/toolr-core/src/parser/build.rs
+git commit -m "argparse: mark dispatcher commands via GraftResult.dispatchers"
+```
+
+---
+
+### Task 6: `cli.rs::build_group_subtree` reshape + `build_dispatcher_command`
+
+**Files:**
+
+- Modify: `crates/toolr/src/cli.rs:40` (`build_group_subtree`)
+- Modify: `crates/toolr/src/cli.rs` — add `build_dispatcher_command` helper
+- Modify: `crates/toolr/src/cli.rs` `#[cfg(test)]` — add 3 new tests
+
+- [ ] **Step 1: Write the failing tests**
+
+If `crates/toolr/src/cli.rs` already has a `#[cfg(test)] mod tests {…}` block, extend it. Otherwise add one at the bottom of the file:
+
+```rust
+#[cfg(test)]
+mod cli_tree_tests {
+    use super::*;
+    use toolr_core::manifest::{Argument, ArgumentKind, Command, Group, Manifest, Origin};
+
+    fn empty_arg(name: &str, kind: ArgumentKind) -> Argument {
+        Argument {
+            name: name.into(),
+            kind,
+            help: String::new(),
+            default: None,
+            type_annotation: None,
+            resolved_type: None,
+            allowed_values: vec![],
+            path_constraints: None,
+            metadata: Default::default(),
+        }
+    }
+
+    fn dispatcher(name: &str, group: &str, args: Vec<Argument>) -> Command {
+        Command {
+            name: name.into(),
+            group: group.into(),
+            module: format!("tools.{name}"),
+            function: name.into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: args,
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: None,
+            is_dispatcher: true,
+        }
+    }
+
+    fn child(name: &str, group: &str, dispatcher_module: &str, dispatcher_fn: &str) -> Command {
+        Command {
+            name: name.into(),
+            group: group.into(),
+            module: dispatcher_module.into(),
+            function: dispatcher_fn.into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: Some(format!("argparse:{group}")),
+            is_dispatcher: false,
+        }
+    }
+
+    fn normal_leaf(name: &str, group: &str) -> Command {
+        Command {
+            name: name.into(),
+            group: group.into(),
+            module: format!("tools.{name}"),
+            function: name.into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: None,
+            is_dispatcher: false,
+        }
+    }
+
+    fn group(name: &str) -> Group {
+        Group {
+            name: name.into(),
+            title: name.into(),
+            description: String::new(),
+            parent: None,
+            origin: Origin::Static,
+        }
+    }
+
+    fn build_for(manifest: Manifest) -> clap::Command {
+        let groups: Vec<&Group> = manifest.groups.iter().collect();
+        let mut children_map: std::collections::HashMap<Option<String>, Vec<&Group>> =
+            std::collections::HashMap::new();
+        for g in &groups {
+            children_map
+                .entry(g.parent.clone())
+                .or_default()
+                .push(g);
+        }
+        let top: Vec<&Group> = manifest.groups.iter().filter(|g| g.parent.is_none()).collect();
+        // Pick the first top-level group — tests only build one group at a time.
+        build_group_subtree(top[0], &manifest, &children_map)
+    }
+
+    #[test]
+    fn dispatcher_hosts_two_grafted_children() {
+        let dispatcher_cmd = dispatcher(
+            "job",
+            "jenkins",
+            vec![empty_arg("cpu", ArgumentKind::Optional)],
+        );
+        let migrate = child("migrate", "jenkins", "tools.job", "job");
+        let runserver = child("runserver", "jenkins", "tools.job", "job");
+
+        let manifest = Manifest {
+            schema_version: 1,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups: vec![group("jenkins")],
+            commands: vec![dispatcher_cmd, migrate, runserver],
+        };
+
+        let jenkins = build_for(manifest);
+
+        // `jenkins` (the group) has exactly one subcommand: `job`. Children
+        // are NOT siblings of `job` at the group level.
+        let group_subs: Vec<&str> = jenkins.get_subcommands().map(|c| c.get_name()).collect();
+        assert_eq!(group_subs, vec!["job"]);
+
+        let job = jenkins.find_subcommand("job").expect("job under jenkins");
+        let job_subs: Vec<&str> = job.get_subcommands().map(|c| c.get_name()).collect();
+        let mut sorted = job_subs.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec!["migrate", "runserver"]);
+    }
+
+    #[test]
+    fn two_dispatchers_in_one_group_each_host_their_own_children() {
+        let build_cmd = dispatcher("build", "docker", vec![]);
+        let image_cmd = dispatcher("image", "docker", vec![]);
+        let build_child = child("compile", "docker", "tools.build", "build");
+        let image_child = child("push", "docker", "tools.image", "image");
+
+        let manifest = Manifest {
+            schema_version: 1,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups: vec![group("docker")],
+            commands: vec![build_cmd, image_cmd, build_child, image_child],
+        };
+
+        let docker = build_for(manifest);
+        let build_sub = docker.find_subcommand("build").unwrap();
+        let image_sub = docker.find_subcommand("image").unwrap();
+
+        let build_subs: Vec<&str> = build_sub.get_subcommands().map(|c| c.get_name()).collect();
+        let image_subs: Vec<&str> = image_sub.get_subcommands().map(|c| c.get_name()).collect();
+        assert_eq!(build_subs, vec!["compile"]);
+        assert_eq!(image_subs, vec!["push"]);
+    }
+
+    #[test]
+    fn dispatcher_and_normal_leaf_coexist_in_one_group() {
+        let dispatcher_cmd = dispatcher("job", "jenkins", vec![]);
+        let migrate = child("migrate", "jenkins", "tools.job", "job");
+        let status = normal_leaf("status", "jenkins");
+
+        let manifest = Manifest {
+            schema_version: 1,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups: vec![group("jenkins")],
+            commands: vec![dispatcher_cmd, migrate, status],
+        };
+
+        let jenkins = build_for(manifest);
+        let mut group_subs: Vec<&str> = jenkins.get_subcommands().map(|c| c.get_name()).collect();
+        group_subs.sort();
+        assert_eq!(group_subs, vec!["job", "status"]);
+
+        let job = jenkins.find_subcommand("job").unwrap();
+        let job_subs: Vec<&str> = job.get_subcommands().map(|c| c.get_name()).collect();
+        assert_eq!(job_subs, vec!["migrate"]);
+
+        let status_sub = jenkins.find_subcommand("status").unwrap();
+        assert_eq!(status_sub.get_subcommands().count(), 0);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cargo test -p toolr --quiet cli_tree_tests
+```
+
+Expected: the tests fail because the current `build_group_subtree` hoists children as siblings of `job`, not as subcommands of `job`.
+
+- [ ] **Step 3: Reshape `build_group_subtree`**
+
+Locate `crates/toolr/src/cli.rs:40-59`. Replace the body with:
+
+```rust
+fn build_group_subtree(
+    group: &Group,
+    manifest: &Manifest,
+    children: &HashMap<Option<String>, Vec<&Group>>,
+) -> Command {
+    let full_path = group.full_path();
+    let mut g = Command::new(group.name.clone()).about(group.title.clone());
+    if !group.description.is_empty() {
+        g = g.long_about(group.description.clone());
+    }
+
+    // Bucket grafted children of this group by their dispatcher's
+    // (module, function). `graft_children` copies those from the
+    // parent dispatcher entry, so the pair uniquely identifies which
+    // dispatcher hosts each child.
+    let grafted_by_dispatcher: HashMap<(&str, &str), Vec<&toolr_core::manifest::Command>> = manifest
+        .commands
+        .iter()
+        .filter(|c| c.group == full_path && c.dispatched_from.is_some())
+        .fold(HashMap::new(), |mut acc, c| {
+            acc.entry((c.module.as_str(), c.function.as_str()))
+                .or_default()
+                .push(c);
+            acc
+        });
+
+    // For each NON-grafted command in this group, decide whether to
+    // build it as a dispatcher (own args + the children-bucket as
+    // subcommands) or as a normal leaf.
+    for cmd in manifest
+        .commands
+        .iter()
+        .filter(|c| c.group == full_path && c.dispatched_from.is_none())
+    {
+        if cmd.is_dispatcher {
+            let dispatched_children = grafted_by_dispatcher
+                .get(&(cmd.module.as_str(), cmd.function.as_str()))
+                .cloned()
+                .unwrap_or_default();
+            g = g.subcommand(build_dispatcher_command(cmd, &dispatched_children));
+        } else {
+            g = g.subcommand(build_user_command(cmd));
+        }
+    }
+
+    if let Some(child_groups) = children.get(&Some(full_path)) {
+        for child in child_groups {
+            g = g.subcommand(build_group_subtree(child, manifest, children));
+        }
+    }
+    g
+}
+
+fn build_dispatcher_command(
+    dispatcher: &toolr_core::manifest::Command,
+    children: &[&toolr_core::manifest::Command],
+) -> Command {
+    let mut c = build_user_command(dispatcher).subcommand_required(true);
+    for child in children {
+        c = c.subcommand(build_user_command(child));
+    }
+    c
+}
+```
+
+`HashMap` may already be imported at the top of `cli.rs`; if not, add `use std::collections::HashMap;`. Same for the `toolr_core::manifest::Command` alias — adjust to whatever the existing code uses.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p toolr --quiet cli_tree_tests
+cargo build --workspace --tests
+cargo clippy --workspace --tests -- -D warnings
+```
+
+Expected: 3 new tests pass; everything else still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/toolr/src/cli.rs
+git commit -m "cli: hoist grafted children into dispatcher subcommands"
+```
+
+---
+
+### Task 7: `dispatch.rs` widens path-to-command lookup
+
+**Files:**
+
+- Modify: `crates/toolr/src/dispatch.rs:65-71` (the existing find-cmd block)
+
+- [ ] **Step 1: Read the existing seam**
+
+```bash
+sed -n '50,90p' crates/toolr/src/dispatch.rs
+```
+
+Note the variables `path`, `leaf_name`, `group_full_path`. The existing lookup:
+
+```rust
+let cmd = manifest
+    .commands
+    .iter()
+    .find(|c| c.group == group_full_path && c.name == leaf_name)
+    .ok_or_else(|| {
+        anyhow::anyhow!("unknown command: {} {leaf_name}", path[..path.len() - 1].join(" "))
+    })?;
+```
+
+After Task 6 the user can type `toolr jenkins job migrate` (3 segments). `group_full_path` would be `"jenkins.job"` but `migrate.group == "jenkins"`. The current lookup fails.
+
+- [ ] **Step 2: Write a unit test in dispatch.rs**
+
+If `dispatch.rs` has a `#[cfg(test)] mod tests`, append; otherwise add one. The unit test exercises the path-to-command-lookup logic. Since that logic isn't currently factored out, factor it into a free function first:
+
+```rust
+fn find_command_for_path<'a>(
+    manifest: &'a Manifest,
+    path: &[String],
+) -> Option<&'a toolr_core::manifest::Command> {
+    let leaf_name = path.last()?;
+    let candidates: Vec<String> = if path.len() >= 2 {
+        vec![
+            path[..path.len() - 1].join("."),
+            path[..path.len() - 2].join("."),
+        ]
+    } else {
+        vec![String::new()]
+    };
+    // Try the most-specific group first; first match wins.
+    candidates.iter().find_map(|group| {
+        manifest
+            .commands
+            .iter()
+            .find(|c| &c.group == group && &c.name == leaf_name)
+    })
+}
+```
+
+Then add tests (still in dispatch.rs):
+
+```rust
+#[cfg(test)]
+mod path_lookup_tests {
+    use super::*;
+    use toolr_core::manifest::{Argument, Command, Manifest, Origin};
+
+    fn cmd(name: &str, group: &str) -> Command {
+        Command {
+            name: name.into(),
+            group: group.into(),
+            module: format!("tools.{name}"),
+            function: name.into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: None,
+            is_dispatcher: false,
+        }
+    }
+
+    fn manifest_with(commands: Vec<Command>) -> Manifest {
+        Manifest {
+            schema_version: 1,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups: vec![],
+            commands,
+        }
+    }
+
+    fn parts(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn finds_two_segment_path_in_group() {
+        let m = manifest_with(vec![cmd("migrate", "jenkins")]);
+        let c = find_command_for_path(&m, &parts(&["jenkins", "migrate"])).unwrap();
+        assert_eq!(c.name, "migrate");
+    }
+
+    #[test]
+    fn finds_three_segment_path_under_dispatcher() {
+        // `migrate` lives at group=jenkins (the group), name=migrate;
+        // the user typed `toolr jenkins job migrate` (3 segments).
+        let m = manifest_with(vec![cmd("migrate", "jenkins")]);
+        let c = find_command_for_path(&m, &parts(&["jenkins", "job", "migrate"])).unwrap();
+        assert_eq!(c.name, "migrate");
+    }
+
+    #[test]
+    fn prefers_more_specific_group_when_both_exist() {
+        // If both `docker.image.build` and `docker.build` exist, the
+        // 3-segment path `docker image build` must resolve to the
+        // nested one, not the top-level one.
+        let m = manifest_with(vec![
+            cmd("build", "docker"),
+            cmd("build", "docker.image"),
+        ]);
+        let c = find_command_for_path(&m, &parts(&["docker", "image", "build"])).unwrap();
+        assert_eq!(c.group, "docker.image");
+    }
+
+    #[test]
+    fn returns_none_when_no_command_matches() {
+        let m = manifest_with(vec![cmd("migrate", "jenkins")]);
+        assert!(find_command_for_path(&m, &parts(&["unknown"])).is_none());
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify the new tests fail**
+
+```bash
+cargo test -p toolr --quiet path_lookup_tests
+```
+
+Expected: compile error or missing-function error on `find_command_for_path`.
+
+- [ ] **Step 4: Add the helper at module level in dispatch.rs**
+
+Paste the `find_command_for_path` function from Step 2 into `crates/toolr/src/dispatch.rs` (top of the file alongside other helpers, or anywhere appropriate).
+
+- [ ] **Step 5: Replace the existing find-cmd block**
+
+The block currently around `dispatch.rs:65-71`. Replace:
+
+```rust
+let cmd = manifest
+    .commands
+    .iter()
+    .find(|c| c.group == group_full_path && c.name == leaf_name)
+    .ok_or_else(|| {
+        anyhow::anyhow!("unknown command: {} {leaf_name}", path[..path.len() - 1].join(" "))
+    })?;
+```
+
+with:
+
+```rust
+let cmd = find_command_for_path(manifest, &path).ok_or_else(|| {
+    anyhow::anyhow!("unknown command: {}", path.join(" "))
+})?;
+```
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+cargo test -p toolr --quiet -- --test-threads=1
+cargo build --workspace --tests
+cargo clippy --workspace --tests -- -D warnings
+```
+
+Expected: all green. The 4 new `path_lookup_tests` pass; the existing E2E happy-path test (with 2-segment path) still passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/toolr/src/dispatch.rs
+git commit -m "dispatch: widen path lookup to handle 3-segment dispatcher paths"
+```
+
+---
+
+### Task 8: E2E test exercising dispatcher outer flags
+
+**Files:**
+
+- Modify: `tests/sources/test_e2e.py` — add `test_e2e_dispatcher_outer_flags`
+
+- [ ] **Step 1: Rebuild the toolr binary**
+
+After Tasks 4–7 land, the installed binary in `.venv/bin/toolr` is stale relative to the new tree shape. Refresh it:
+
+```bash
+cargo build --release -p toolr
+cp target/release/toolr .venv/bin/toolr
+.venv/bin/toolr --version
+```
+
+- [ ] **Step 2: Write the new test**
+
+Append to `tests/sources/test_e2e.py`:
+
+```python
+def test_e2e_dispatcher_outer_flags(tmp_path: Path, toolr_bin: Path) -> None:
+    """Dispatcher's --cpu/--ram flags are reachable on the child path.
+
+    Invocation shape: `toolr jenkins job --cpu 5000m migrate --check`.
+    The dispatcher writes both its own kwargs (`cpu`) and the
+    DispatchCommand payload (`migrate`, `check=True`) to a sidecar.
+    """
+    tools_py = textwrap.dedent(
+        """
+        import json
+        import os
+        from toolr import command_group, Context
+        from toolr.sources import DispatchCommand
+
+        group = command_group("jenkins", "Jenkins", description="Jenkins dispatcher")
+
+        @group.command
+        def job(
+            ctx: Context,
+            *,
+            cpu: str = "1000m",
+            ram: str = "4Gi",
+            dispatched: DispatchCommand,
+        ) -> int:
+            payload = {
+                "cpu": cpu,
+                "ram": ram,
+                "command": dispatched.command,
+                "command_args": dispatched.command_args,
+            }
+            with open(os.environ["E2E_SIDECAR"], "w") as fh:
+                json.dump(payload, fh)
+            return 0
+        """
+    ).strip() + "\n"
+    pyproject = textwrap.dedent(
+        """
+        [project]
+        name = "demo-tools"
+        version = "0"
+
+        [tool.toolr]
+        venv-location = "in-tree"
+
+        [tool.toolr.argparse.django]
+        scan_paths = ["apps/*/management/commands/*.py"]
+
+        [[tool.toolr.argparse.django.attach]]
+        parent = "jenkins"
+        """
+    ).strip() + "\n"
+    project = _make_project(
+        tmp_path,
+        "dispatcher-flags",
+        tools_py,
+        pyproject,
+        {
+            "apps/x/management/commands/migrate.py":
+                'def add_arguments(self, parser):\n    parser.add_argument("--check", action="store_true")\n',
+        },
+    )
+
+    sidecar = tmp_path / "captured.json"
+    env = {**os.environ, "TOOLR_TEST_PYTHON": sys.executable, "E2E_SIDECAR": str(sidecar)}
+
+    subprocess.run(  # noqa: S603
+        [str(toolr_bin), "project", "manifest", "rebuild"],
+        check=True, cwd=project, env=env,
+    )
+    result = subprocess.run(  # noqa: S603
+        [str(toolr_bin), "jenkins", "job", "--cpu", "5000m", "migrate", "--check"],
+        check=False, cwd=project, env=env, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        msg = (
+            f"dispatcher-outer-flags dispatch failed (exit {result.returncode})\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+        raise AssertionError(msg)
+
+    captured = json.loads(sidecar.read_text())
+    assert captured["cpu"] == "5000m"
+    assert captured["ram"] == "4Gi"  # default value preserved
+    assert captured["command"] == "migrate"
+    assert captured["command_args"]["check"] is True
+```
+
+This reuses the `_make_project` helper added during Plan A Task 19.
+
+- [ ] **Step 3: Run the new test**
+
+```bash
+uv run pytest tests/sources/test_e2e.py::test_e2e_dispatcher_outer_flags -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the full E2E module**
+
+```bash
+uv run pytest tests/sources/ -v
+```
+
+Expected: all green. 5 E2E tests now (4 from Plan A + 1 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/sources/test_e2e.py
+git commit -m "tests: e2e dispatcher outer flags reachable via grafted child path"
+```
+
+---
+
+## Wrap-up
+
+After Task 8:
+
+- [ ] **Full suite check:**
+
+```bash
+uv run pytest -q
+cargo test --workspace -- --test-threads=1
+cargo clippy --workspace --tests -- -D warnings
+uv run prek run --all-files
+```
+
+Expected: all green.
+
+- [ ] **Push to PR #222:**
+
+```bash
+git-spice branch submit
+```
+
+`git-spice` will update the existing PR with the new commits.
+
+- [ ] **Update memory:** Note in `MEMORY.md` that auto-rebuild on missing manifest now Just Works, and that dispatchers host their grafted children as subcommands (with `subcommand_required(true)`).
+
+---
+
+## Out of scope (handled by Plan A, the design, or future work)
+
+- Widening `invoke_dispatcher` to support a dispatcher invoked without a child (`toolr <group> <dispatcher>` alone). Today clap rejects at parse time via `subcommand_required(true)` — clean failure mode.
+- Auto-rebuild on a *corrupted* manifest (vs missing). Out of scope; current `load_or_empty` swallows non-`not-found` errors.
+- Marking dispatchers from non-argparse sources. The mechanism (`is_dispatcher = true`) is source-agnostic; a future Jenkins plugin just sets the flag the same way.

--- a/specs/2026-05-19-fill-the-gaps-plan.md
+++ b/specs/2026-05-19-fill-the-gaps-plan.md
@@ -56,15 +56,15 @@ Use `rg -n 'Command \{' crates/ tests/` to confirm the list at the start of Task
 ## Task index
 
 - Stack A — auto-rebuild on missing manifest:
-  - Task 1: `should_skip_auto_rebuild` argv inspector + tests
-  - Task 2: `ensure_manifest_present_or_bootstrap` + wire into `main.rs::run`
-  - Task 3: Unskip `test_e2e_auto_rebuild_runs_argparse`
+    - Task 1: `should_skip_auto_rebuild` argv inspector + tests
+    - Task 2: `ensure_manifest_present_or_bootstrap` + wire into `main.rs::run`
+    - Task 3: Unskip `test_e2e_auto_rebuild_runs_argparse`
 - Stack B — dispatcher hosts grafted children:
-  - Task 4: `is_dispatcher: bool` field on `Command`
-  - Task 5: `argparse::run_for_project` returns `GraftResult`; `build_static_manifest_inner` flips the flag
-  - Task 6: `cli.rs::build_group_subtree` reshape + `build_dispatcher_command`
-  - Task 7: `dispatch.rs` widens path-to-command lookup
-  - Task 8: New E2E test exercising dispatcher outer flags
+    - Task 4: `is_dispatcher: bool` field on `Command`
+    - Task 5: `argparse::run_for_project` returns `GraftResult`; `build_static_manifest_inner` flips the flag
+    - Task 6: `cli.rs::build_group_subtree` reshape + `build_dispatcher_command`
+    - Task 7: `dispatch.rs` widens path-to-command lookup
+    - Task 8: New E2E test exercising dispatcher outer flags
 
 ---
 
@@ -224,7 +224,6 @@ git commit -m "bootstrap: add should_skip_auto_rebuild argv inspector"
 
 - Modify: `crates/toolr/src/bootstrap.rs`
 - Modify: `crates/toolr/src/main.rs:27-36` (the `run` function)
-
 - [ ] **Step 1: Read the existing seam**
 
 ```bash
@@ -398,7 +397,6 @@ git commit -m "tests: unskip auto-rebuild E2E now that bootstrap is wired in"
 - Modify: `crates/toolr-core/src/manifest/model.rs`
 - Modify: `crates/toolr-core/src/manifest/tests.rs`
 - Modify: every `Command { ... }` literal site (see file map; ~9 files)
-
 - [ ] **Step 1: List the literal sites**
 
 ```bash
@@ -681,7 +679,6 @@ git commit -m "argparse: mark dispatcher commands via GraftResult.dispatchers"
 - Modify: `crates/toolr/src/cli.rs:40` (`build_group_subtree`)
 - Modify: `crates/toolr/src/cli.rs` — add `build_dispatcher_command` helper
 - Modify: `crates/toolr/src/cli.rs` `#[cfg(test)]` — add 3 new tests
-
 - [ ] **Step 1: Write the failing tests**
 
 If `crates/toolr/src/cli.rs` already has a `#[cfg(test)] mod tests {…}` block, extend it. Otherwise add one at the bottom of the file:

--- a/specs/2026-05-19-fill-the-gaps-plan.md
+++ b/specs/2026-05-19-fill-the-gaps-plan.md
@@ -878,6 +878,24 @@ Expected: the tests fail because the current `build_group_subtree` hoists childr
 Locate `crates/toolr/src/cli.rs:40-59`. Replace the body with:
 
 ```rust
+/// Compute the dotted name a dispatcher is addressable by from the
+/// CLI. Mirrors `toolr_core::parser::build::dotted_name`: a command
+/// whose `name` matches the leaf segment of its `group` is addressable
+/// as the group path itself; otherwise it's `"<group>.<name>"` (or
+/// just `name` when the group is empty). `graft_children` sets each
+/// grafted child's `group` field to this dotted name (the
+/// `attachment.parent`), so we use the same value to look children up.
+fn dispatcher_dotted_name(cmd: &toolr_core::manifest::Command) -> String {
+    let leaf = cmd.group.rsplit('.').next().unwrap_or(cmd.group.as_str());
+    if !cmd.group.is_empty() && cmd.name == leaf {
+        cmd.group.clone()
+    } else if cmd.group.is_empty() {
+        cmd.name.clone()
+    } else {
+        format!("{}.{}", cmd.group, cmd.name)
+    }
+}
+
 fn build_group_subtree(
     group: &Group,
     manifest: &Manifest,
@@ -889,35 +907,38 @@ fn build_group_subtree(
         g = g.long_about(group.description.clone());
     }
 
-    // Bucket grafted children of this group by their dispatcher's
-    // (module, function). `graft_children` copies those from the
-    // parent dispatcher entry, so the pair uniquely identifies which
-    // dispatcher hosts each child.
-    let grafted_by_dispatcher: HashMap<(&str, &str), Vec<&toolr_core::manifest::Command>> = manifest
-        .commands
-        .iter()
-        .filter(|c| c.group == full_path && c.dispatched_from.is_some())
-        .fold(HashMap::new(), |mut acc, c| {
-            acc.entry((c.module.as_str(), c.function.as_str()))
-                .or_default()
-                .push(c);
-            acc
-        });
-
-    // For each NON-grafted command in this group, decide whether to
-    // build it as a dispatcher (own args + the children-bucket as
-    // subcommands) or as a normal leaf.
+    // Grafted children's `group` field stores the dispatcher's dotted
+    // name (the `[[attach]] parent` value), NOT the parent group's
+    // name. For each non-grafted command in this group, decide whether
+    // it's a dispatcher and, if so, look up its grafted children at
+    // its own dotted name. When the dispatcher's name matches the
+    // group's leaf (e.g. `command_group("django")` + `def django(...)`)
+    // its dotted name equals the group path itself, and the children
+    // are hoisted directly onto the group (so users type
+    // `toolr django migrate`, not `toolr django django migrate`).
+    let group_leaf = full_path.rsplit('.').next().unwrap_or(full_path.as_str());
     for cmd in manifest
         .commands
         .iter()
         .filter(|c| c.group == full_path && c.dispatched_from.is_none())
     {
         if cmd.is_dispatcher {
-            let dispatched_children = grafted_by_dispatcher
-                .get(&(cmd.module.as_str(), cmd.function.as_str()))
-                .cloned()
-                .unwrap_or_default();
-            g = g.subcommand(build_dispatcher_command(cmd, &dispatched_children));
+            let dotted = dispatcher_dotted_name(cmd);
+            let dispatched_children: Vec<&toolr_core::manifest::Command> = manifest
+                .commands
+                .iter()
+                .filter(|child| child.group == dotted && child.dispatched_from.is_some())
+                .collect();
+            if cmd.name == group_leaf {
+                // Hoist branch: children become direct subcommands of
+                // the group; the dispatcher itself disappears as a
+                // redundant CLI hop.
+                for child in &dispatched_children {
+                    g = g.subcommand(build_user_command(child));
+                }
+            } else {
+                g = g.subcommand(build_dispatcher_command(cmd, &dispatched_children));
+            }
         } else {
             g = g.subcommand(build_user_command(cmd));
         }
@@ -944,6 +965,8 @@ fn build_dispatcher_command(
 ```
 
 `HashMap` may already be imported at the top of `cli.rs`; if not, add `use std::collections::HashMap;`. Same for the `toolr_core::manifest::Command` alias — adjust to whatever the existing code uses.
+
+**Important correction vs. the original plan draft:** an earlier revision of this section bucketed grafted children by `c.group == full_path` (the parent group's name). That's wrong — `argparse::graft_children` stores each child with `group = attachment.parent` (the full **dispatcher** dotted name). The fix above looks up children at the dispatcher's `dispatcher_dotted_name(cmd)` value instead, and adds the hoist branch for the `name == group_leaf` case. The corresponding `dispatch.rs` lookup (Task 7) was likewise fixed to find the dispatcher manifest entry by `(module, function) + is_dispatcher` rather than by name guessing.
 
 - [ ] **Step 4: Run tests**
 

--- a/tests/sources/test_detection.py
+++ b/tests/sources/test_detection.py
@@ -1,0 +1,41 @@
+"""Tests for the DispatchCommand-based dispatcher detection rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from toolr.sources import DispatchCommand
+from toolr.utils._signature import DispatcherDetectionError
+from toolr.utils._signature import detect_dispatch_parameter
+
+
+def test_normal_command_returns_none():
+    def cmd(ctx, *, name: str = "x") -> None: ...
+
+    assert detect_dispatch_parameter(cmd) is None
+
+
+def test_dispatcher_returns_parameter_name():
+    def cmd(ctx, *, cpu: str = "1", dispatched: DispatchCommand) -> None: ...
+
+    assert detect_dispatch_parameter(cmd) == "dispatched"
+
+
+def test_dispatcher_param_name_is_free():
+    def cmd(ctx, *, target: DispatchCommand) -> None: ...
+
+    assert detect_dispatch_parameter(cmd) == "target"
+
+
+def test_multiple_dispatchcommand_params_raises():
+    def cmd(ctx, *, a: DispatchCommand, b: DispatchCommand) -> None: ...
+
+    with pytest.raises(DispatcherDetectionError, match="more than one"):
+        detect_dispatch_parameter(cmd)
+
+
+def test_dispatchcommand_in_positional_raises():
+    def cmd(ctx, dispatched: DispatchCommand) -> None: ...
+
+    with pytest.raises(DispatcherDetectionError, match="keyword-only"):
+        detect_dispatch_parameter(cmd)

--- a/tests/sources/test_dispatch.py
+++ b/tests/sources/test_dispatch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from toolr.sources import ArgSchema
 from toolr.sources import CommandSchema
 from toolr.sources import DispatchCommand
@@ -28,3 +30,59 @@ def test_dispatch_command_holds_match():
     assert dc.command == "migrate"
     assert dc.command_args == {"check": True, "database": "primary"}
     assert dc.schema.name == "migrate"
+
+
+@pytest.mark.parametrize(
+    ("args_in", "schema_args", "expected"),
+    [
+        # Positional value.
+        (
+            {"app_label": "auth"},
+            [ArgSchema(name="app_label", kind="positional", help="")],
+            ["auth"],
+        ),
+        # Flag set True → emit, False → omit.
+        (
+            {"check": True, "verbose": False},
+            [
+                ArgSchema(name="check", kind="flag", help=""),
+                ArgSchema(name="verbose", kind="flag", help=""),
+            ],
+            ["--check"],
+        ),
+        # Optional with default — omit when equal, emit otherwise.
+        (
+            {"database": "default"},
+            [ArgSchema(name="database", kind="optional", help="", default="default")],
+            [],
+        ),
+        (
+            {"database": "primary"},
+            [ArgSchema(name="database", kind="optional", help="", default="default")],
+            ["--database", "primary"],
+        ),
+        # Repeated → one `--name value` per element.
+        (
+            {"exclude": ["a", "b"]},
+            [ArgSchema(name="exclude", kind="repeated", help="")],
+            ["--exclude", "a", "--exclude", "b"],
+        ),
+        # Underscores in the name become dashes on the wire.
+        (
+            {"dry_run": True},
+            [ArgSchema(name="dry_run", kind="flag", help="")],
+            ["--dry-run"],
+        ),
+    ],
+)
+def test_argv_reconstruction(args_in, schema_args, expected):
+    schema = CommandSchema(name="x", summary="", description="", arguments=schema_args)
+    dc = DispatchCommand(command="x", command_args=args_in, schema=schema)
+    assert dc.argv == expected
+
+
+def test_argv_unknown_arg_name_raises():
+    schema = CommandSchema(name="x", summary="", description="", arguments=[])
+    dc = DispatchCommand(command="x", command_args={"surprise": True}, schema=schema)
+    with pytest.raises(ValueError, match="surprise"):
+        _ = dc.argv

--- a/tests/sources/test_dispatch.py
+++ b/tests/sources/test_dispatch.py
@@ -1,0 +1,30 @@
+"""Tests for DispatchCommand basic shape (argv tested separately)."""
+
+from __future__ import annotations
+
+from toolr.sources import ArgSchema
+from toolr.sources import CommandSchema
+from toolr.sources import DispatchCommand
+
+
+def _migrate_schema() -> CommandSchema:
+    return CommandSchema(
+        name="migrate",
+        summary="",
+        description="",
+        arguments=[
+            ArgSchema(name="check", kind="flag", help=""),
+            ArgSchema(name="database", kind="optional", help="", default="default"),
+        ],
+    )
+
+
+def test_dispatch_command_holds_match():
+    dc = DispatchCommand(
+        command="migrate",
+        command_args={"check": True, "database": "primary"},
+        schema=_migrate_schema(),
+    )
+    assert dc.command == "migrate"
+    assert dc.command_args == {"check": True, "database": "primary"}
+    assert dc.schema.name == "migrate"

--- a/tests/sources/test_e2e.py
+++ b/tests/sources/test_e2e.py
@@ -1,0 +1,138 @@
+"""End-to-end: argparse scanner → rebuild → dispatch → assert payload."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def project_with_dispatcher_and_command(tmp_path: Path) -> Path:
+    """Tiny tools project plus an argparse-scannable management command."""
+    project = tmp_path / "demo"
+    project.mkdir()
+    tools = project / "tools"
+    tools.mkdir()
+    (tools / "__init__.py").write_text("")
+    (tools / "dispatcher.py").write_text(
+        textwrap.dedent(
+            """
+            import json
+            import os
+            from toolr import command_group, Context
+            from toolr.sources import DispatchCommand
+
+            group = command_group("django", "Django", description="Django dispatcher")
+
+            @group.command
+            def django(ctx: Context, *, dispatched: DispatchCommand) -> int:
+                payload = {
+                    "command": dispatched.command,
+                    "command_args": dispatched.command_args,
+                    "argv": dispatched.argv,
+                }
+                with open(os.environ["E2E_SIDECAR"], "w") as fh:
+                    json.dump(payload, fh)
+                return 0
+            """
+        ).strip()
+        + "\n"
+    )
+
+    cmds = project / "apps" / "billing" / "management" / "commands"
+    cmds.mkdir(parents=True)
+    (cmds / "migrate.py").write_text(
+        textwrap.dedent(
+            """
+            \"\"\"Migrate the database.\"\"\"
+            def add_arguments(self, parser):
+                parser.add_argument('--check', action='store_true', help='Dry run')
+                parser.add_argument('--database', default='default', help='Target DB')
+            """
+        ).strip()
+        + "\n"
+    )
+
+    (tools / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """
+            [project]
+            name = "demo-tools"
+            version = "0"
+
+            [tool.toolr]
+            venv-location = "in-tree"
+
+            [tool.toolr.argparse.django]
+            scan_paths = ["apps/*/management/commands/*.py"]
+
+            [[tool.toolr.argparse.django.attach]]
+            parent = "django"
+            """
+        ).strip()
+        + "\n"
+    )
+
+    # Pre-populate tools/.venv by symlinking the workspace venv. That
+    # interpreter already has toolr-py installed, so toolr's dynamic-
+    # layer introspect helper can `import tools.dispatcher` and
+    # `import toolr.sources` without an expensive `uv sync` per test.
+    # Use sys.prefix (the venv root) directly, not Path(sys.executable).resolve()
+    # — the latter resolves through the venv's python symlink to the base
+    # interpreter, which doesn't have toolr-py installed.
+    workspace_venv = Path(sys.prefix)
+    (tools / ".venv").symlink_to(workspace_venv)
+
+    return project
+
+
+def test_e2e_dispatch_through_argparse_scanner(
+    project_with_dispatcher_and_command: Path,
+    tmp_path: Path,
+    toolr_bin: Path,
+) -> None:
+    project = project_with_dispatcher_and_command
+    sidecar = tmp_path / "captured.json"
+
+    # `TOOLR_TEST_PYTHON` short-circuits toolr's project-venv resolution
+    # so the test doesn't need to run `uv sync` in the tmp project. The
+    # interpreter must have `toolr-py` importable so the dynamic-layer
+    # introspect helper can `import tools.dispatcher`.
+    base_env = {**os.environ, "TOOLR_TEST_PYTHON": sys.executable}
+
+    # 1. Explicit rebuild.
+    subprocess.run(  # noqa: S603
+        [str(toolr_bin), "project", "manifest", "rebuild"],
+        check=True,
+        cwd=project,
+        env=base_env,
+    )
+
+    # 2. Invoke through the dispatcher.
+    env = {**base_env, "E2E_SIDECAR": str(sidecar)}
+    result = subprocess.run(  # noqa: S603
+        [str(toolr_bin), "django", "migrate", "--check", "--database", "primary"],
+        check=False,
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        msg = f"dispatch failed (exit {result.returncode})\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        raise AssertionError(msg)
+
+    # 3. Assert payload.
+    captured = json.loads(sidecar.read_text())
+    assert captured["command"] == "migrate"
+    assert captured["command_args"]["check"] is True
+    assert captured["command_args"]["database"] == "primary"
+    assert "--check" in captured["argv"]
+    assert "--database" in captured["argv"]
+    assert "primary" in captured["argv"]

--- a/tests/sources/test_e2e.py
+++ b/tests/sources/test_e2e.py
@@ -335,3 +335,100 @@ def test_e2e_auto_rebuild_runs_argparse(
     captured = json.loads(sidecar.read_text())
     assert captured["command"] == "migrate"
     assert captured["command_args"]["check"] is True
+
+
+def test_e2e_dispatcher_outer_flags(tmp_path: Path, toolr_bin: Path) -> None:
+    """Dispatcher's --cpu/--ram flags are reachable on the child path.
+
+    Invocation shape: `toolr jenkins job --cpu 5000m migrate --check`.
+    The dispatcher writes both its own kwargs (`cpu`) and the
+    DispatchCommand payload (`migrate`, `check=True`) to a sidecar.
+    """
+    tools_py = (
+        textwrap.dedent(
+            """
+        import json
+        import os
+        from toolr import command_group, Context
+        from toolr.sources import DispatchCommand
+
+        group = command_group("jenkins", "Jenkins", description="Jenkins dispatcher")
+
+        @group.command
+        def job(
+            ctx: Context,
+            *,
+            cpu: str = "1000m",
+            ram: str = "4Gi",
+            dispatched: DispatchCommand,
+        ) -> int:
+            payload = {
+                "cpu": cpu,
+                "ram": ram,
+                "command": dispatched.command,
+                "command_args": dispatched.command_args,
+            }
+            with open(os.environ["E2E_SIDECAR"], "w") as fh:
+                json.dump(payload, fh)
+            return 0
+        """
+        ).strip()
+        + "\n"
+    )
+    pyproject = (
+        textwrap.dedent(
+            """
+        [project]
+        name = "demo-tools"
+        version = "0"
+
+        [tool.toolr]
+        venv-location = "in-tree"
+
+        [tool.toolr.argparse.django]
+        scan_paths = ["apps/*/management/commands/*.py"]
+
+        [[tool.toolr.argparse.django.attach]]
+        parent = "jenkins.job"
+        """
+        ).strip()
+        + "\n"
+    )
+    migrate_body = 'def add_arguments(self, parser):\n    parser.add_argument("--check", action="store_true")\n'
+    project = _make_project(
+        tmp_path,
+        "dispatcher-flags",
+        tools_py,
+        pyproject,
+        {"apps/x/management/commands/migrate.py": migrate_body},
+    )
+
+    sidecar = tmp_path / "captured.json"
+    env = {**os.environ, "TOOLR_TEST_PYTHON": sys.executable, "E2E_SIDECAR": str(sidecar)}
+
+    subprocess.run(  # noqa: S603
+        [str(toolr_bin), "project", "manifest", "rebuild"],
+        check=True,
+        cwd=project,
+        env=env,
+    )
+    result = subprocess.run(  # noqa: S603
+        [str(toolr_bin), "jenkins", "job", "--cpu", "5000m", "migrate", "--check"],
+        check=False,
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        msg = (
+            f"dispatcher-outer-flags dispatch failed (exit {result.returncode})\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+        raise AssertionError(msg)
+
+    captured = json.loads(sidecar.read_text())
+    assert captured["cpu"] == "5000m"
+    assert captured["ram"] == "4Gi"  # default value preserved
+    assert captured["command"] == "migrate"
+    assert captured["command_args"]["check"] is True

--- a/tests/sources/test_e2e.py
+++ b/tests/sources/test_e2e.py
@@ -136,3 +136,203 @@ def test_e2e_dispatch_through_argparse_scanner(
     assert "--check" in captured["argv"]
     assert "--database" in captured["argv"]
     assert "primary" in captured["argv"]
+
+
+def _make_project(tmp_path: Path, name: str, tools_py: str, pyproject_toml: str, command_files: dict[str, str]) -> Path:
+    project = tmp_path / name
+    project.mkdir()
+    tools = project / "tools"
+    tools.mkdir()
+    (tools / "__init__.py").write_text("")
+    (tools / "dispatcher.py").write_text(tools_py)
+    (tools / "pyproject.toml").write_text(pyproject_toml)
+    (tools / ".venv").symlink_to(Path(sys.prefix))
+    for relpath, body in command_files.items():
+        target = project / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    return project
+
+
+def test_e2e_same_source_attached_to_two_parents(tmp_path: Path, toolr_bin: Path) -> None:
+    """A single argparse block attaching to two parents produces working
+    children under each parent independently. The user can reach
+    `migrate` via either dispatcher, and the dispatcher invoked records
+    which path was taken (different print output)."""
+    tools_py = (
+        textwrap.dedent(
+            """
+        from toolr import command_group, Context
+        from toolr.sources import DispatchCommand
+
+        django_grp = command_group("django", "Django", description="Local Django dispatcher")
+        jenkins_grp = command_group("jenkins", "Jenkins", description="Jenkins dispatcher")
+
+        @django_grp.command
+        def django(ctx: Context, *, dispatched: DispatchCommand) -> int:
+            print(f"local:{dispatched.command}")
+            return 0
+
+        @jenkins_grp.command
+        def jenkins(ctx: Context, *, dispatched: DispatchCommand) -> int:
+            print(f"jenkins:{dispatched.command}")
+            return 0
+        """
+        ).strip()
+        + "\n"
+    )
+    pyproject = (
+        textwrap.dedent(
+            """
+        [project]
+        name = "demo-tools"
+        version = "0"
+
+        [tool.toolr]
+        venv-location = "in-tree"
+
+        [tool.toolr.argparse.commands]
+        scan_paths = ["apps/*/management/commands/*.py"]
+
+        [[tool.toolr.argparse.commands.attach]]
+        parent = "django"
+
+        [[tool.toolr.argparse.commands.attach]]
+        parent = "jenkins"
+        """
+        ).strip()
+        + "\n"
+    )
+    project = _make_project(
+        tmp_path,
+        "two-parents",
+        tools_py,
+        pyproject,
+        {
+            "apps/x/management/commands/migrate.py": 'def add_arguments(self, parser):\n    parser.add_argument("--check", action="store_true")\n'
+        },
+    )
+
+    env = {**os.environ, "TOOLR_TEST_PYTHON": sys.executable}
+    subprocess.run([str(toolr_bin), "project", "manifest", "rebuild"], check=True, cwd=project, env=env)
+
+    out_local = subprocess.run(
+        [str(toolr_bin), "django", "migrate"],
+        check=True,
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    out_remote = subprocess.run(
+        [str(toolr_bin), "jenkins", "migrate"],
+        check=True,
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert out_local == "local:migrate"
+    assert out_remote == "jenkins:migrate"
+
+
+def test_e2e_collision_across_sources_fails_build(tmp_path: Path, toolr_bin: Path) -> None:
+    """Two argparse blocks attaching to the same parent with the same
+    discovered command name must fail `toolr project manifest rebuild`
+    with a clear collision message."""
+    tools_py = (
+        textwrap.dedent(
+            """
+        from toolr import command_group, Context
+        from toolr.sources import DispatchCommand
+
+        group = command_group("django", "Django", description="Django dispatcher")
+
+        @group.command
+        def django(ctx: Context, *, dispatched: DispatchCommand) -> int:
+            return 0
+        """
+        ).strip()
+        + "\n"
+    )
+    pyproject = (
+        textwrap.dedent(
+            """
+        [project]
+        name = "demo-tools"
+        version = "0"
+
+        [tool.toolr]
+        venv-location = "in-tree"
+
+        [tool.toolr.argparse.first]
+        scan_paths = ["apps/a/management/commands/*.py"]
+        [[tool.toolr.argparse.first.attach]]
+        parent = "django"
+
+        [tool.toolr.argparse.second]
+        scan_paths = ["apps/b/management/commands/*.py"]
+        [[tool.toolr.argparse.second.attach]]
+        parent = "django"
+        """
+        ).strip()
+        + "\n"
+    )
+    cmd_body = 'def add_arguments(self, parser):\n    parser.add_argument("--flag", action="store_true")\n'
+    project = _make_project(
+        tmp_path,
+        "collision",
+        tools_py,
+        pyproject,
+        {
+            "apps/a/management/commands/migrate.py": cmd_body,
+            "apps/b/management/commands/migrate.py": cmd_body,
+        },
+    )
+
+    env = {**os.environ, "TOOLR_TEST_PYTHON": sys.executable}
+    result = subprocess.run(
+        [str(toolr_bin), "project", "manifest", "rebuild"],
+        check=False,
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "migrate" in combined
+    # Names of both colliding sources surface in the error.
+    assert "first" in combined and "second" in combined
+
+
+@pytest.mark.skip(
+    reason="Auto-rebuild on missing manifest is not implemented in the binary "
+    "yet. main.rs::load_or_empty silently returns an empty manifest and clap "
+    "rejects the user's command before dispatch::ensure_dynamic_layer_fresh "
+    "gets a chance to rebuild. See follow-up task in the plan."
+)
+def test_e2e_auto_rebuild_runs_argparse(
+    project_with_dispatcher_and_command: Path,
+    tmp_path: Path,
+    toolr_bin: Path,
+) -> None:
+    """Deleting (or never creating) .toolr-manifest.json forces the
+    auto-rebuild path, which must include the argparse scanner."""
+    project = project_with_dispatcher_and_command
+    sidecar = tmp_path / "auto-captured.json"
+    manifest_path = project / "tools" / ".toolr-manifest.json"
+    assert not manifest_path.exists()  # never built yet
+
+    env = {**os.environ, "E2E_SIDECAR": str(sidecar)}
+    subprocess.run(  # noqa: S603
+        [str(toolr_bin), "django", "migrate", "--check"],
+        check=True,
+        cwd=project,
+        env=env,
+    )
+
+    assert manifest_path.exists()
+    captured = json.loads(sidecar.read_text())
+    assert captured["command"] == "migrate"
+    assert captured["command_args"]["check"] is True

--- a/tests/sources/test_e2e.py
+++ b/tests/sources/test_e2e.py
@@ -209,14 +209,18 @@ def test_e2e_same_source_attached_to_two_parents(tmp_path: Path, toolr_bin: Path
         tools_py,
         pyproject,
         {
-            "apps/x/management/commands/migrate.py": 'def add_arguments(self, parser):\n    parser.add_argument("--check", action="store_true")\n'
+            "apps/x/management/commands/migrate.py": (
+                'def add_arguments(self, parser):\n    parser.add_argument("--check", action="store_true")\n'
+            )
         },
     )
 
     env = {**os.environ, "TOOLR_TEST_PYTHON": sys.executable}
-    subprocess.run([str(toolr_bin), "project", "manifest", "rebuild"], check=True, cwd=project, env=env)
+    subprocess.run(  # noqa: S603
+        [str(toolr_bin), "project", "manifest", "rebuild"], check=True, cwd=project, env=env
+    )
 
-    out_local = subprocess.run(
+    out_local = subprocess.run(  # noqa: S603
         [str(toolr_bin), "django", "migrate"],
         check=True,
         cwd=project,
@@ -224,7 +228,7 @@ def test_e2e_same_source_attached_to_two_parents(tmp_path: Path, toolr_bin: Path
         capture_output=True,
         text=True,
     ).stdout.strip()
-    out_remote = subprocess.run(
+    out_remote = subprocess.run(  # noqa: S603
         [str(toolr_bin), "jenkins", "migrate"],
         check=True,
         cwd=project,
@@ -291,7 +295,7 @@ def test_e2e_collision_across_sources_fails_build(tmp_path: Path, toolr_bin: Pat
     )
 
     env = {**os.environ, "TOOLR_TEST_PYTHON": sys.executable}
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603
         [str(toolr_bin), "project", "manifest", "rebuild"],
         check=False,
         cwd=project,
@@ -303,15 +307,10 @@ def test_e2e_collision_across_sources_fails_build(tmp_path: Path, toolr_bin: Pat
     combined = result.stdout + result.stderr
     assert "migrate" in combined
     # Names of both colliding sources surface in the error.
-    assert "first" in combined and "second" in combined
+    assert "first" in combined
+    assert "second" in combined
 
 
-@pytest.mark.skip(
-    reason="Auto-rebuild on missing manifest is not implemented in the binary "
-    "yet. main.rs::load_or_empty silently returns an empty manifest and clap "
-    "rejects the user's command before dispatch::ensure_dynamic_layer_fresh "
-    "gets a chance to rebuild. See follow-up task in the plan."
-)
 def test_e2e_auto_rebuild_runs_argparse(
     project_with_dispatcher_and_command: Path,
     tmp_path: Path,

--- a/tests/sources/test_public_surface.py
+++ b/tests/sources/test_public_surface.py
@@ -1,0 +1,16 @@
+"""toolr.sources should re-export exactly the documented public surface."""
+
+from __future__ import annotations
+
+import toolr.sources
+
+EXPECTED = {"ArgSchema", "CommandSchema", "DispatchCommand"}
+
+
+def test_all_lists_public_surface():
+    assert set(toolr.sources.__all__) == EXPECTED
+
+
+def test_each_name_is_importable():
+    for name in EXPECTED:
+        assert hasattr(toolr.sources, name), f"missing: {name}"

--- a/tests/sources/test_runner_dispatch.py
+++ b/tests/sources/test_runner_dispatch.py
@@ -1,0 +1,59 @@
+"""Runner-side: construct DispatchCommand and call the dispatcher function."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from toolr._runner import invoke_dispatcher
+from toolr.sources import ArgSchema
+from toolr.sources import CommandSchema
+from toolr.sources import DispatchCommand
+
+
+def test_invoke_dispatcher_passes_dispatch_command():
+    captured: dict[str, Any] = {}
+
+    def parent(ctx, *, cpu: str = "1", dispatched: DispatchCommand) -> int:
+        captured["cpu"] = cpu
+        captured["dispatched"] = dispatched
+        return 0
+
+    schema = CommandSchema(
+        name="migrate",
+        summary="",
+        description="",
+        arguments=[ArgSchema(name="check", kind="flag", help="")],
+    )
+    rc = invoke_dispatcher(
+        ctx=None,
+        func=parent,
+        parent_kwargs={"cpu": "5000m"},
+        child_name="migrate",
+        child_args={"check": True},
+        child_schema=schema,
+    )
+
+    assert rc == 0
+    assert captured["cpu"] == "5000m"
+    assert isinstance(captured["dispatched"], DispatchCommand)
+    assert captured["dispatched"].command == "migrate"
+    assert captured["dispatched"].command_args == {"check": True}
+    assert captured["dispatched"].schema == schema
+
+
+def test_invoke_dispatcher_with_non_dispatcher_raises():
+    def parent(ctx, *, cpu: str = "1") -> int:
+        return 0
+
+    schema = CommandSchema(name="x", summary="", description="", arguments=[])
+    with pytest.raises(RuntimeError, match="DispatchCommand"):
+        invoke_dispatcher(
+            ctx=None,
+            func=parent,
+            parent_kwargs={},
+            child_name="x",
+            child_args={},
+            child_schema=schema,
+        )

--- a/tests/sources/test_types.py
+++ b/tests/sources/test_types.py
@@ -1,0 +1,32 @@
+"""Round-trip and field-default tests for toolr.sources schema types."""
+
+from __future__ import annotations
+
+import msgspec
+
+from toolr.sources import ArgSchema
+
+
+def test_arg_schema_positional_minimal():
+    arg = ArgSchema(name="app_label", kind="positional", help="Target app")
+    assert arg.name == "app_label"
+    assert arg.kind == "positional"
+    assert arg.help == "Target app"
+    assert arg.default is None
+    assert arg.choices is None
+    assert arg.metavar is None
+    assert arg.type_annotation is None
+    assert arg.nargs is None
+
+
+def test_arg_schema_round_trips_through_msgspec_json():
+    arg = ArgSchema(
+        name="database",
+        kind="optional",
+        help="Database to use",
+        default="default",
+        type_annotation="str",
+    )
+    payload = msgspec.json.encode(arg)
+    decoded = msgspec.json.decode(payload, type=ArgSchema)
+    assert decoded == arg

--- a/tests/sources/test_types.py
+++ b/tests/sources/test_types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import msgspec
 
 from toolr.sources import ArgSchema
+from toolr.sources import CommandSchema
 
 
 def test_arg_schema_positional_minimal():
@@ -30,3 +31,24 @@ def test_arg_schema_round_trips_through_msgspec_json():
     payload = msgspec.json.encode(arg)
     decoded = msgspec.json.decode(payload, type=ArgSchema)
     assert decoded == arg
+
+
+def test_command_schema_holds_args_and_help():
+    cmd = CommandSchema(
+        name="migrate",
+        summary="Updates database schema",
+        description="Migrates the database.\nSupports rolling back.",
+        arguments=[
+            ArgSchema(name="app_label", kind="positional", help="App"),
+            ArgSchema(name="check", kind="flag", help="Dry run"),
+        ],
+    )
+    assert cmd.name == "migrate"
+    assert len(cmd.arguments) == 2
+    assert cmd.arguments[1].kind == "flag"
+
+
+def test_command_schema_round_trips():
+    cmd = CommandSchema(name="x", summary="", description="", arguments=[])
+    decoded = msgspec.json.decode(msgspec.json.encode(cmd), type=CommandSchema)
+    assert decoded == cmd


### PR DESCRIPTION
Implements `specs/2026-05-19-external-command-sources-design.md` and Plan A at `specs/2026-05-19-external-command-sources-plan-a.md`.

## What's in the box

- **`toolr.sources` Python module** — public types: `ArgSchema`, `CommandSchema`, `DispatchCommand` (+ `.argv` reconstruction).
- **Dispatcher detection** — annotation-driven via `dispatched: DispatchCommand` keyword-only parameter; lives in `toolr.utils._signature.detect_dispatch_parameter`.
- **Manifest field** — `dispatched_from: Option<String>` on Rust `Command` (no schema version bump; pre-1.0).
- **Argparse AST scanner** — `crates/toolr-core/src/argparse/`: TOML config, ruff_python_parser-based AST walk with signature-shape filter (any receiver name, but call shape must match argparse), glob-expanded scan paths, common_args hoisting, attachment validation, child grafting, end-to-end `run_for_project` orchestrator.
- **Static-manifest integration** — `build_static_manifest` runs the scanner and grafts children alongside user-decorated commands.
- **Parser support for dispatchers** — `SourcesImports` tracks `from toolr.sources import DispatchCommand` (and aliases / qualified forms) so the static parser skips the dispatcher's reserved kwarg when extracting CLI args.
- **Runtime dispatch** — dispatch.rs branches on `dispatched_from`, packs the matched leaf's args, builds an `ExecutionSpec` with a `dispatch` payload (the toolr binary doesn't link pyo3; the JSON spec is the existing wire format). The Python runner constructs the `DispatchCommand` and calls `invoke_dispatcher(ctx, func, parent_kwargs, child_name, child_args, child_schema)`, which calls `func(ctx, **parent_kwargs, dispatched=DispatchCommand(...))`.

## Tests

- 21 sources/argparse-related test files cover the schema types, detection, scanner, validation, grafting, runtime injection.
- 4 E2E tests under `tests/sources/test_e2e.py`:
  - explicit `toolr project manifest rebuild` + dispatch via sidecar JSON ✅
  - same source attached to two parents ✅
  - collision across sources fails build ✅
  - auto-rebuild on missing manifest — **skipped**: not implemented in `main.rs` today; `load_or_empty` silently returns an empty manifest so clap rejects the user's command before any rebuild fires. Tracked as follow-up.
- All cargo + pytest + clippy green.

## Deferred / follow-up

- **Auto-rebuild on missing manifest**: needs main.rs to detect missing manifest and run `rebuild_manifest_full` before clap parsing.
- **Dispatcher's own CLI flags reachable via grafted children**: the spec's `toolr jenkins job --cpu 5000m migrate` invocation pattern requires the dispatcher command to host children as subcommands. Today grafted children are siblings of the dispatcher in the parent group, so the user invokes `toolr jenkins migrate ...` and the dispatcher's --cpu/--ram flags aren't reachable on that path. A separate task to merge dispatcher args into the parent group's clap command.
- **`toolr-django` reference plugin** is Plan B (still pending — argparse scanner now covers most of the Django case, so Plan B's scope is much narrower).