### PR TITLE
complete: drop spurious `--` in fish completion script

### DIFF
--- a/crates/toolr-core/src/complete/scripts/fish.fish
+++ b/crates/toolr-core/src/complete/scripts/fish.fish
@@ -11,7 +11,11 @@ function __toolr_complete
     set -l current (commandline -ct)
     # Drop the leading `toolr` token.
     set -l args $tokens[2..-1]
-    set -a args -- $current
+    # Append the in-progress word as the trailing token. Do NOT use `--`
+    # before it: fish's `set` builtin treats `--` as a literal value to
+    # append, not an end-of-options marker, which would inject a spurious
+    # `--` token into the call and trip clap's option-terminator logic.
+    set -a args $current
     toolr __complete "$PWD" $args 2>/dev/null
 end
 

--- a/crates/toolr-core/src/complete/tests.rs
+++ b/crates/toolr-core/src/complete/tests.rs
@@ -424,6 +424,20 @@ fn fish_script_invokes_toolr_complete() {
     assert!(script.contains("complete -c toolr"));
 }
 
+#[test]
+fn fish_script_does_not_inject_literal_dash_dash_into_args() {
+    // Regression: an earlier version used `set -a args -- $current` on
+    // the assumption that `--` was an end-of-options marker for fish's
+    // `set` builtin. It is not — fish appends `--` as a literal value,
+    // which then short-circuits clap's option parsing on the binary side
+    // and drops the trailing in-progress token.
+    let script = completion_script(Shell::Fish);
+    assert!(
+        !script.contains("set -a args --"),
+        "fish completion script must not append a literal `--` into args"
+    );
+}
+
 use crate::complete::install::{
     InstallOptions, InstallOutcome, install_path_for, install_script,
 };


### PR DESCRIPTION
## Summary

`set -a args -- $current` in the embedded fish completion script does not behave as an end-of-options marker. Fish's `set` builtin appends `--` as a literal value, so the generated call became:

```
toolr __complete "$PWD" <tokens> -- ""
```

clap consumed the `--` as its options-terminator and dropped the trailing empty token, so `toolr <group> <TAB>` (and `toolr <group> <leaf> <TAB>`) returned no candidates. Only the top-level `toolr <TAB>` worked because no extra tokens followed.

## Fix

Remove the `--`. Fish's `set` does not interpret the in-progress word as a flag, so the separator was never needed for safety either.

## Test plan

- [x] `cargo test -p toolr-core complete::` passes (39/39)
- [x] Manual repro: `fish -c 'complete --do-complete "toolr ci "'` now returns subcommands
- [x] Added regression test `fish_script_does_not_inject_literal_dash_dash_into_args`