### PR TITLE
complete: ship completion for built-in `self` and `project` commands

### DIFF
--- a/crates/toolr/src/builtin_completions.rs
+++ b/crates/toolr/src/builtin_completions.rs
@@ -1,0 +1,290 @@
+//! Synthetic manifest entries for toolr's own built-in subcommands.
+//!
+//! The completion engine in [`toolr_core::complete`] is purely
+//! manifest-driven — it knows nothing about the binary's own subcommands
+//! (`self`, `project`). This module supplies the entries that mirror
+//! [`crate::cli::build_command`] so the engine can offer them as
+//! candidates. The synthetic [`Command`] entries are never invoked; only
+//! their `name`, `group`, `arguments[].name`, `arguments[].kind`, and
+//! `arguments[].allowed_values` matter for completion classification.
+//!
+//! When [`crate::cli::build_command`] grows or changes a built-in
+//! subcommand, mirror the change here. Tests in this module assert the
+//! structure matches at least at the names-and-shape level.
+//!
+//! Hidden internal helpers (`__complete`, `__build-static-manifest`,
+//! `__install-uv-now`) are intentionally omitted — they don't appear in
+//! `--help` and shouldn't be tab-completed either.
+
+use toolr_core::manifest::{
+    ArgMetadata, Argument, ArgumentKind, Command, Group, Origin,
+};
+
+/// Synthetic [`Group`] + [`Command`] entries that mirror the built-in
+/// subcommand tree wired up in [`crate::cli::build_command`]. Callers
+/// (currently only [`crate::dispatch::run_complete`]) merge these into a
+/// loaded manifest before delegating to
+/// [`toolr_core::complete::serve_completions`].
+pub fn built_in_completion_entries() -> (Vec<Group>, Vec<Command>) {
+    let groups = vec![
+        top_group("project", "Operations on the current repo's tools/ directory"),
+        child_group("deps", "project", "Tools-venv dependency management"),
+        child_group("venv", "project", "Inspect or activate the tools venv"),
+        child_group("manifest", "project", "Manage the project's toolr manifest"),
+        top_group("self", "Operations on toolr itself"),
+        child_group("cache", "self", "Manage the cache of per-repo virtualenvs"),
+        child_group("completion", "self", "Manage shell completion scripts"),
+    ];
+
+    let commands = vec![
+        // project ...
+        leaf(
+            "init",
+            "project",
+            "Scaffold tools/ in the current directory",
+            vec![
+                flag("force"),
+                flag("no-sync"),
+                opt_enum("venv-location", &["cache", "in-tree"]),
+                flag("no-example"),
+                opt("python"),
+                flag("quiet"),
+            ],
+        ),
+        leaf("sync", "project.deps", "Run `uv sync` against tools/", vec![]),
+        leaf("path", "project.venv", "Print the absolute path to the tools venv", vec![]),
+        leaf(
+            "shell",
+            "project.venv",
+            "Spawn a subshell with the tools venv activated",
+            vec![],
+        ),
+        leaf(
+            "rebuild",
+            "project.manifest",
+            "Regenerate the static + dynamic manifest in place",
+            vec![],
+        ),
+        // self ...
+        leaf(
+            "build-manifest",
+            "self",
+            "Generate a third-party manifest fragment for a package",
+            vec![
+                positional("package"),
+                opt("output"),
+                opt("python"),
+                opt("schema-version"),
+                flag("check"),
+            ],
+        ),
+        leaf(
+            "list",
+            "self.cache",
+            "List every cached virtualenv with size and last-use timestamp",
+            vec![],
+        ),
+        leaf(
+            "prune",
+            "self.cache",
+            "Remove orphan and stale cache entries",
+            vec![
+                flag("all"),
+                opt("stale-after-days"),
+                flag("dry-run"),
+                flag("yes"),
+            ],
+        ),
+        leaf(
+            "print",
+            "self.completion",
+            "Print the completion script for a shell to stdout",
+            vec![positional_enum("shell", &["bash", "zsh", "fish"])],
+        ),
+        leaf(
+            "install",
+            "self.completion",
+            "Install the completion script for a shell into its standard location",
+            vec![
+                positional_enum("shell", &["bash", "zsh", "fish"]),
+                flag("force"),
+            ],
+        ),
+    ];
+
+    (groups, commands)
+}
+
+fn top_group(name: &str, title: &str) -> Group {
+    Group {
+        name: name.into(),
+        title: title.into(),
+        description: String::new(),
+        parent: None,
+        origin: Origin::Static,
+    }
+}
+
+fn child_group(name: &str, parent: &str, title: &str) -> Group {
+    Group {
+        name: name.into(),
+        title: title.into(),
+        description: String::new(),
+        parent: Some(parent.into()),
+        origin: Origin::Static,
+    }
+}
+
+fn leaf(name: &str, group: &str, summary: &str, arguments: Vec<Argument>) -> Command {
+    Command {
+        name: name.into(),
+        group: group.into(),
+        // Synthetic entries are never invoked — the binary intercepts
+        // `self`/`project` before any manifest lookup happens. These
+        // fields just need to round-trip through the engine's classifier.
+        module: String::new(),
+        function: String::new(),
+        summary: summary.into(),
+        description: String::new(),
+        arguments,
+        imports: Vec::new(),
+        origin: Origin::Static,
+        dispatched_from: None,
+        is_dispatcher: false,
+    }
+}
+
+fn arg(name: &str, kind: ArgumentKind, allowed_values: Vec<String>) -> Argument {
+    Argument {
+        name: name.into(),
+        kind,
+        help: String::new(),
+        default: None,
+        type_annotation: None,
+        resolved_type: None,
+        allowed_values,
+        path_constraints: None,
+        metadata: ArgMetadata::default(),
+    }
+}
+
+fn flag(name: &str) -> Argument {
+    arg(name, ArgumentKind::Flag, Vec::new())
+}
+
+fn opt(name: &str) -> Argument {
+    arg(name, ArgumentKind::Optional, Vec::new())
+}
+
+fn opt_enum(name: &str, values: &[&str]) -> Argument {
+    arg(
+        name,
+        ArgumentKind::Optional,
+        values.iter().map(|v| (*v).to_string()).collect(),
+    )
+}
+
+fn positional(name: &str) -> Argument {
+    arg(name, ArgumentKind::Positional, Vec::new())
+}
+
+fn positional_enum(name: &str, values: &[&str]) -> Argument {
+    arg(
+        name,
+        ArgumentKind::Positional,
+        values.iter().map(|v| (*v).to_string()).collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toolr_core::complete::serve_completions;
+    use toolr_core::manifest::{Manifest, SCHEMA_VERSION};
+
+    fn merged_empty_manifest() -> Manifest {
+        let (groups, commands) = built_in_completion_entries();
+        Manifest {
+            schema_version: SCHEMA_VERSION,
+            static_hash: String::new(),
+            dynamic_hash: String::new(),
+            groups,
+            commands,
+        }
+    }
+
+    fn tokens(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn top_level_offers_self_and_project() {
+        let m = merged_empty_manifest();
+        let out = serve_completions(&m, &tokens(&[""]));
+        assert!(out.contains(&"self".to_string()), "candidates: {out:?}");
+        assert!(out.contains(&"project".to_string()), "candidates: {out:?}");
+    }
+
+    #[test]
+    fn self_offers_known_subcommands() {
+        let m = merged_empty_manifest();
+        let out = serve_completions(&m, &tokens(&["self", ""]));
+        for expected in ["build-manifest", "cache", "completion"] {
+            assert!(
+                out.contains(&expected.to_string()),
+                "missing {expected} in {out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn project_offers_known_subcommands() {
+        let m = merged_empty_manifest();
+        let out = serve_completions(&m, &tokens(&["project", ""]));
+        for expected in ["init", "deps", "venv", "manifest"] {
+            assert!(
+                out.contains(&expected.to_string()),
+                "missing {expected} in {out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn self_cache_offers_list_and_prune() {
+        let m = merged_empty_manifest();
+        let out = serve_completions(&m, &tokens(&["self", "cache", ""]));
+        assert_eq!(out, vec!["list".to_string(), "prune".to_string()]);
+    }
+
+    #[test]
+    fn self_completion_install_offers_shells() {
+        let m = merged_empty_manifest();
+        let out = serve_completions(&m, &tokens(&["self", "completion", "install", ""]));
+        assert_eq!(
+            out,
+            vec!["bash".to_string(), "fish".to_string(), "zsh".to_string()]
+        );
+    }
+
+    #[test]
+    fn self_cache_prune_offers_known_flags() {
+        let m = merged_empty_manifest();
+        let out = serve_completions(&m, &tokens(&["self", "cache", "prune", "--"]));
+        for expected in ["--all", "--stale-after-days", "--dry-run", "--yes"] {
+            assert!(
+                out.contains(&expected.to_string()),
+                "missing {expected} in {out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn project_init_offers_venv_location_values() {
+        let m = merged_empty_manifest();
+        let out = serve_completions(
+            &m,
+            &tokens(&["project", "init", "--venv-location", ""]),
+        );
+        assert_eq!(out, vec!["cache".to_string(), "in-tree".to_string()]);
+    }
+}

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -388,7 +388,15 @@ fn run_complete(matches: &clap::ArgMatches) -> anyhow::Result<ExitCode> {
     let Ok(resolved) = resolve_manifest_at_tab(&cwd) else {
         return Ok(ExitCode::from(1));
     };
-    for candidate in serve_completions(&resolved.manifest, &tokens) {
+    // The engine is purely manifest-driven, but the binary owns its own
+    // built-in `self` / `project` subtree. Inject synthetic entries that
+    // mirror `cli::build_command` so those subcommands also complete.
+    let mut manifest = resolved.manifest;
+    let (extra_groups, extra_commands) =
+        crate::builtin_completions::built_in_completion_entries();
+    manifest.groups.extend(extra_groups);
+    manifest.commands.extend(extra_commands);
+    for candidate in serve_completions(&manifest, &tokens) {
         println!("{candidate}");
     }
     Ok(ExitCode::SUCCESS)

--- a/crates/toolr/src/main.rs
+++ b/crates/toolr/src/main.rs
@@ -1,4 +1,5 @@
 mod bootstrap;
+mod builtin_completions;
 mod cli;
 mod dispatch;
 mod execute_build;


### PR DESCRIPTION
## Summary

The completion engine in `toolr_core::complete` is purely manifest-driven, so it only saw commands harvested from a project's `tools/` directory. The binary's own `self` and `project` subcommand trees never appeared as tab candidates.

This PR adds a binary-side `builtin_completions` module that produces synthetic `Group` + `Command` entries mirroring `cli::build_command`'s built-in tree. `run_complete` merges them into the loaded manifest before delegating to `serve_completions`. The synthetic entries are never invoked at dispatch time — `dispatch` intercepts `self` / `project` before any manifest lookup happens.

## Coverage

- Top-level: `toolr <TAB>` now offers `self` and `project` alongside user commands
- `toolr self <TAB>` → `build-manifest`, `cache`, `completion`
- `toolr project <TAB>` → `init`, `deps`, `venv`, `manifest`
- All leaf subcommands (`self cache prune`, `project venv path`, etc.)
- Flags for `self cache prune` (`--all`, `--stale-after-days`, `--dry-run`, `--yes`)
- Enum values for `self completion {install,print} <shell>` (bash/zsh/fish)
- Enum values for `project init --venv-location` (cache/in-tree)

## Maintenance

When `cli::build_command` grows a new built-in subcommand, mirror the change in `builtin_completions.rs`. The module's doc comment calls this out; future work could derive the synthetic entries from the clap tree directly.

## Test plan

- [x] 7 new unit tests in `builtin_completions::tests` exercise serve_completions against the merged manifest
- [x] Manual: `toolr __complete "$PWD" self ""` → `build-manifest\ncache\ncompletion`
- [x] Manual: `toolr __complete "$PWD" self cache prune --` → `--all --dry-run --stale-after-days --yes`
- [x] `cargo clippy -p toolr` clean

## Stacks on

#223 (fish completion separator fix)