### PR TITLE
complete: honour `--force` literally + distinguish install outcomes

### DIFF
--- a/crates/toolr-core/src/complete/install.rs
+++ b/crates/toolr-core/src/complete/install.rs
@@ -27,9 +27,28 @@ pub struct InstallOptions {
 
 #[derive(Debug)]
 pub enum InstallOutcome {
-    Wrote { path: PathBuf },
+    /// The embedded script is now on disk at `path`. `prior` describes
+    /// what (if anything) was there before the write so the caller can
+    /// distinguish a fresh install, a forced re-write of identical
+    /// content, and a forced replacement of differing content.
+    Wrote { path: PathBuf, prior: PriorState },
+    /// `--force` was not set and the on-disk content already matched
+    /// the embedded payload; nothing was written.
     AlreadyInstalled { path: PathBuf },
+    /// `--force` was not set and the on-disk content differs from the
+    /// embedded payload; nothing was written.
     SkippedNeedsForce { path: PathBuf },
+}
+
+#[derive(Debug)]
+pub enum PriorState {
+    /// No file existed at the target path before the write.
+    None,
+    /// A file existed and matched the new payload byte-for-byte. The
+    /// caller passed `--force`, so the file was overwritten anyway.
+    Identical,
+    /// A file existed and its content differed from the new payload.
+    Differed,
 }
 
 /// Compute the target install path for `shell`.
@@ -75,18 +94,30 @@ pub fn install_script(opts: &InstallOptions) -> Result<InstallOutcome> {
         ));
     }
 
-    if let Ok(existing) = std::fs::read_to_string(&path) {
-        if existing == payload {
-            return Ok(InstallOutcome::AlreadyInstalled { path });
+    let prior = match std::fs::read_to_string(&path) {
+        Ok(existing) if existing == payload => {
+            // File matches the embedded payload. Honour `--force`
+            // literally and rewrite anyway (useful when the caller
+            // wants to refresh mtime or recover from a manual edit
+            // that happened to round-trip back to the canonical
+            // content); otherwise treat as a no-op.
+            if !opts.force {
+                return Ok(InstallOutcome::AlreadyInstalled { path });
+            }
+            PriorState::Identical
         }
-        if !opts.force {
-            return Ok(InstallOutcome::SkippedNeedsForce { path });
+        Ok(_) => {
+            if !opts.force {
+                return Ok(InstallOutcome::SkippedNeedsForce { path });
+            }
+            PriorState::Differed
         }
-    }
+        Err(_) => PriorState::None,
+    };
 
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(&path, payload)?;
-    Ok(InstallOutcome::Wrote { path })
+    Ok(InstallOutcome::Wrote { path, prior })
 }

--- a/crates/toolr-core/src/complete/mod.rs
+++ b/crates/toolr-core/src/complete/mod.rs
@@ -19,7 +19,7 @@ pub mod scripts;
 
 pub use engine::serve_completions;
 pub use freshness::{ResolvedManifest, resolve_manifest_at_tab};
-pub use install::{InstallOptions, InstallOutcome, install_path_for, install_script};
+pub use install::{InstallOptions, InstallOutcome, PriorState, install_path_for, install_script};
 pub use scripts::{Shell, completion_script};
 
 #[cfg(test)]

--- a/crates/toolr-core/src/complete/tests.rs
+++ b/crates/toolr-core/src/complete/tests.rs
@@ -439,7 +439,7 @@ fn fish_script_does_not_inject_literal_dash_dash_into_args() {
 }
 
 use crate::complete::install::{
-    InstallOptions, InstallOutcome, install_path_for, install_script,
+    InstallOptions, InstallOutcome, PriorState, install_path_for, install_script,
 };
 
 #[test]
@@ -477,7 +477,13 @@ fn install_creates_file_when_absent() {
         interactive: false,
     };
     let outcome = install_script(&opts).unwrap();
-    assert!(matches!(outcome, InstallOutcome::Wrote { .. }));
+    assert!(matches!(
+        outcome,
+        InstallOutcome::Wrote {
+            prior: PriorState::None,
+            ..
+        }
+    ));
     let target = tmp.path().join("data/bash-completion/completions/toolr");
     assert!(target.exists());
 }
@@ -515,8 +521,54 @@ fn install_is_idempotent_when_content_matches() {
     };
     let first = install_script(&opts).unwrap();
     let second = install_script(&opts).unwrap();
-    assert!(matches!(first, InstallOutcome::Wrote { .. }));
+    assert!(matches!(
+        first,
+        InstallOutcome::Wrote {
+            prior: PriorState::None,
+            ..
+        }
+    ));
     assert!(matches!(second, InstallOutcome::AlreadyInstalled { .. }));
+}
+
+#[test]
+fn install_with_force_overwrites_even_when_content_matches() {
+    // Regression: a stale binary that ships a buggy completion script
+    // would write the same buggy script to disk, then refuse to refresh
+    // because the on-disk content matched the (still buggy) payload.
+    // `--force` must be honoured literally so users can re-deploy
+    // unconditionally.
+    let tmp = TempDir::new().unwrap();
+    let bootstrap = InstallOptions {
+        shell: Shell::Bash,
+        xdg_data_home: Some(tmp.path().join("data")),
+        xdg_config_home: None,
+        home: tmp.path().to_path_buf(),
+        force: false,
+        interactive: false,
+    };
+    assert!(matches!(
+        install_script(&bootstrap).unwrap(),
+        InstallOutcome::Wrote {
+            prior: PriorState::None,
+            ..
+        }
+    ));
+    let forced = InstallOptions {
+        shell: Shell::Bash,
+        xdg_data_home: Some(tmp.path().join("data")),
+        xdg_config_home: None,
+        home: tmp.path().to_path_buf(),
+        force: true,
+        interactive: false,
+    };
+    assert!(matches!(
+        install_script(&forced).unwrap(),
+        InstallOutcome::Wrote {
+            prior: PriorState::Identical,
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -534,7 +586,13 @@ fn install_with_force_overwrites_existing() {
         interactive: false,
     };
     let outcome = install_script(&opts).unwrap();
-    assert!(matches!(outcome, InstallOutcome::Wrote { .. }));
+    assert!(matches!(
+        outcome,
+        InstallOutcome::Wrote {
+            prior: PriorState::Differed,
+            ..
+        }
+    ));
     let contents = std::fs::read_to_string(&target).unwrap();
     assert!(contents.contains("toolr __complete"));
 }

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -4,7 +4,8 @@ use std::process::ExitCode;
 use clap::ArgMatches;
 
 use toolr_core::complete::{
-    InstallOptions, InstallOutcome, Shell as CompletionShell, completion_script, install_script,
+    InstallOptions, InstallOutcome, PriorState, Shell as CompletionShell, completion_script,
+    install_script,
     resolve_manifest_at_tab, serve_completions,
 };
 use toolr_core::discovery::discover_project_root;
@@ -298,12 +299,25 @@ fn run_completion_install(matches: &clap::ArgMatches) -> anyhow::Result<ExitCode
 
     let outcome = install_script(&opts)?;
     match outcome {
-        InstallOutcome::Wrote { path } => {
-            println!(
-                "toolr: wrote {} completion script to {}",
-                shell,
-                path.display()
-            );
+        InstallOutcome::Wrote { path, prior } => {
+            let msg = match prior {
+                PriorState::None => format!(
+                    "toolr: wrote {} completion script to {}",
+                    shell,
+                    path.display()
+                ),
+                PriorState::Identical => format!(
+                    "toolr: rewrote {} completion script at {} (--force; content unchanged)",
+                    shell,
+                    path.display()
+                ),
+                PriorState::Differed => format!(
+                    "toolr: replaced existing {} completion script at {}",
+                    shell,
+                    path.display()
+                ),
+            };
+            println!("{msg}");
             if matches!(shell, CompletionShell::Zsh) {
                 println!(
                     "toolr: ensure your ~/.zshrc includes `fpath=(~/.zfunc $fpath)` and \
@@ -314,7 +328,7 @@ fn run_completion_install(matches: &clap::ArgMatches) -> anyhow::Result<ExitCode
         }
         InstallOutcome::AlreadyInstalled { path } => {
             println!(
-                "toolr: {} completion already installed at {}",
+                "toolr: {} completion already up to date at {}",
                 shell,
                 path.display()
             );


### PR DESCRIPTION
## Summary

Previously `install_script` short-circuited to `AlreadyInstalled` whenever the on-disk content matched the embedded payload, **regardless of `--force`**. The check happened before `--force` was even consulted:

```rust
if let Ok(existing) = std::fs::read_to_string(&path) {
    if existing == payload {
        return Ok(InstallOutcome::AlreadyInstalled { path });   // shortcuts before --force check
    }
    if !opts.force {
        return Ok(InstallOutcome::SkippedNeedsForce { path });
    }
}
```

This bit users running a stale binary that shipped a buggy completion script: the bug got written to disk, then refreshing with the same (still buggy) binary said "already installed" without writing, even with `--force`. The bug source was hiding itself on both sides of the equality check.

## Behaviour change

`--force` now writes unconditionally. When the on-disk content already matched the new payload, the outcome distinguishes the no-op-but-forced rewrite from a fresh install via a new `PriorState` discriminant on `InstallOutcome::Wrote`. The dispatcher renders five distinct messages:

| --force | on disk | outcome | message |
|---|---|---|---|
| any | absent | `Wrote { prior: None }` | `wrote {shell} completion script to {path}` |
| true | identical | `Wrote { prior: Identical }` | `rewrote {shell} completion script at {path} (--force; content unchanged)` |
| true | differed | `Wrote { prior: Differed }` | `replaced existing {shell} completion script at {path}` |
| false | identical | `AlreadyInstalled` | `{shell} completion already up to date at {path}` (was: "already installed") |
| false | differed | `SkippedNeedsForce` | `refusing to overwrite {path} (use --force to replace)` |

## Test plan

- [x] New `install_with_force_overwrites_even_when_content_matches` regression test covers the stale-binary scenario.
- [x] Existing install tests updated to assert the new `PriorState` discriminant.
- [x] All 40 completion tests pass.
- [x] Manual: `toolr self completion install fish` → up-to-date message; with `--force` → rewrote-content-unchanged message.

## Stacks on

#224 (built-in command completions), which stacks on #223 (fish script fix)