### PR TITLE
cache: backfill meta.json on touch when sidecar is missing

### DIFF
--- a/crates/toolr-core/src/cache/mod.rs
+++ b/crates/toolr-core/src/cache/mod.rs
@@ -13,7 +13,7 @@ pub use enumerate::{CachedVenv, dir_size_bytes, enumerate_caches};
 pub use hint::{HintConfig, compute_hint};
 pub use init::write_meta_for_new_venv;
 pub use meta::{Meta, MetaError, SCHEMA_VERSION};
-pub use touch::touch_last_used;
+pub use touch::{touch_last_used, touch_or_backfill};
 
 #[cfg(test)]
 mod tests;

--- a/crates/toolr-core/src/cache/tests.rs
+++ b/crates/toolr-core/src/cache/tests.rs
@@ -103,7 +103,7 @@ fn write_meta_for_new_venv_overwrites_existing() {
     assert_eq!(loaded.python_version, "3.13.0");
 }
 
-use super::touch::touch_last_used;
+use super::touch::{touch_last_used, touch_or_backfill};
 
 #[test]
 fn touch_last_used_updates_only_last_used_at() {
@@ -136,6 +136,59 @@ fn touch_last_used_is_a_noop_when_sidecar_is_missing() {
     let tmp = TempDir::new().unwrap();
     let result = touch_last_used(tmp.path());
     assert!(result.is_ok());
+    assert!(
+        !tmp.path().join("meta.json").exists(),
+        "touch_last_used must not create a sidecar — use touch_or_backfill for that",
+    );
+}
+
+#[test]
+fn touch_or_backfill_updates_existing_sidecar() {
+    let tmp = TempDir::new().unwrap();
+    let cache_dir = tmp.path().join("repo-key");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+
+    let original = write_meta_for_new_venv(
+        &cache_dir,
+        "/abs/repo".as_ref(),
+        "1.0.0",
+        "3.13.1",
+    )
+    .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    touch_or_backfill(&cache_dir, "/different/repo".as_ref(), "9.9.9", "3.99.0")
+        .expect("touch_or_backfill");
+    let after = Meta::load(&cache_dir).expect("load");
+
+    // Existing sidecar must be respected; backfill context is ignored.
+    assert_eq!(after.created_at, original.created_at);
+    assert_eq!(after.repo_path, original.repo_path);
+    assert_eq!(after.toolr_version, original.toolr_version);
+    assert_eq!(after.python_version, original.python_version);
+    assert!(after.last_used_at > original.last_used_at);
+}
+
+#[test]
+fn touch_or_backfill_writes_sidecar_when_missing() {
+    // Regression for the user-visible inconsistency where
+    // `toolr project venv path` showed a venv directory but
+    // `toolr self cache list` reported nothing — the entry existed
+    // without a `meta.json` sidecar, so `enumerate_caches` skipped it.
+    let tmp = TempDir::new().unwrap();
+    let cache_dir = tmp.path().join("repo-key");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    assert!(!cache_dir.join("meta.json").exists());
+
+    touch_or_backfill(&cache_dir, "/abs/repo".as_ref(), "2.0.0", "3.13.1")
+        .expect("backfill");
+    let meta = Meta::load(&cache_dir).expect("load");
+
+    assert_eq!(meta.repo_path, std::path::PathBuf::from("/abs/repo"));
+    assert_eq!(meta.toolr_version, "2.0.0");
+    assert_eq!(meta.python_version, "3.13.1");
+    assert_eq!(meta.last_used_at, meta.created_at);
 }
 
 use super::enumerate::{CachedVenv, enumerate_caches};

--- a/crates/toolr-core/src/cache/touch.rs
+++ b/crates/toolr-core/src/cache/touch.rs
@@ -7,8 +7,10 @@ use chrono::Utc;
 use super::meta::{Meta, MetaError};
 
 /// Re-write `meta.json` with a fresh `last_used_at`. Missing sidecars
-/// are silently ignored — older cache entries that predate Plan 8 are
-/// allowed to exist without metadata.
+/// are silently ignored — this entry point intentionally has no context
+/// to backfill from. Call sites with access to the owning repo path
+/// should prefer [`touch_or_backfill`], which self-heals pre-Plan-8
+/// cache entries so they become visible to `toolr self cache list`.
 pub fn touch_last_used(cache_dir: &Path) -> Result<(), MetaError> {
     let mut meta = match Meta::load(cache_dir) {
         Ok(m) => m,
@@ -20,4 +22,39 @@ pub fn touch_last_used(cache_dir: &Path) -> Result<(), MetaError> {
     meta.last_used_at = Utc::now();
     meta.write(cache_dir)?;
     Ok(())
+}
+
+/// Update `last_used_at` if a sidecar exists; otherwise synthesise a
+/// fresh `meta.json` from the supplied context.
+///
+/// This is the entry point dispatch uses on every invocation against a
+/// cached venv. The backfill branch heals the inventory for cache
+/// entries created by an older toolr binary (or any path that produced
+/// the venv without writing the sidecar) so subsequent `toolr self
+/// cache list / prune` calls see them.
+///
+/// `created_at` on backfilled entries reflects the time of backfill,
+/// not the time the venv directory was actually materialised — the
+/// real birth time is not recoverable. Callers that care about
+/// historical accuracy should keep this in mind; everything in
+/// `cache list / prune` works fine with the approximation.
+pub fn touch_or_backfill(
+    cache_dir: &Path,
+    repo_path: &Path,
+    toolr_version: &str,
+    python_version: &str,
+) -> Result<(), MetaError> {
+    match Meta::load(cache_dir) {
+        Ok(mut meta) => {
+            meta.last_used_at = Utc::now();
+            meta.write(cache_dir)?;
+            Ok(())
+        }
+        Err(MetaError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            let meta = Meta::new(repo_path.to_path_buf(), toolr_version, python_version);
+            meta.write(cache_dir)?;
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
 }

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -145,17 +145,31 @@ pub fn dispatch(
     // Prefer the resolved tools-venv python (Plan 3). Fall back to the
     // PATH/TOOLR_PYTHON lookup only when there is no `tools/pyproject.toml`
     // — i.e. legacy projects that never opted into the venv layer.
-    let (python, venv_dir) = if repo_root.join("tools").join("pyproject.toml").is_file() {
-        let resolved = resolve_venv_path(&repo_root)?;
-        (resolved.python, Some(resolved.venv_dir))
-    } else {
-        (resolve_python()?, None)
-    };
+    let (python, venv_dir, python_version) =
+        if repo_root.join("tools").join("pyproject.toml").is_file() {
+            let resolved = resolve_venv_path(&repo_root)?;
+            (
+                resolved.python,
+                Some(resolved.venv_dir),
+                Some(resolved.python_version),
+            )
+        } else {
+            (resolve_python()?, None, None)
+        };
 
     // Plan 8: touch last_used_at on every invocation against a cached venv.
+    // Backfill a fresh `meta.json` for cache entries that predate the
+    // sidecar — without this, `toolr self cache list` would silently
+    // hide venvs created by older binaries.
     if let Some(venv) = &venv_dir {
         if let Some(cache_dir) = venv.parent() {
-            if let Err(e) = toolr_core::cache::touch_last_used(cache_dir) {
+            let py_ver = python_version.as_deref().unwrap_or("");
+            if let Err(e) = toolr_core::cache::touch_or_backfill(
+                cache_dir,
+                &repo_root,
+                env!("CARGO_PKG_VERSION"),
+                py_ver,
+            ) {
                 eprintln!("toolr: warning: failed to touch cache meta.json: {e}");
             }
         }


### PR DESCRIPTION
## Summary

`toolr project venv path` reports a venv path purely from `resolve_venv_path` (filesystem-derived, no existence check). `toolr self cache list` walks the cache root but [`enumerate_caches`](crates/toolr-core/src/cache/enumerate.rs#L67-L69) silently skips entries without a `meta.json` sidecar. Cache entries created by older toolr binaries — or any code path that produced a venv without writing the sidecar — therefore stay invisible to `list` / `prune` forever.

Reproduction:

```
$ toolr project venv path
/Users/pedro.algarvio/Library/Caches/toolr/f17b14b02ad081cd/venv
$ toolr self cache list
toolr: no cached virtualenvs found under /Users/pedro.algarvio/Library/Caches/toolr
```

Existing on disk:

```
~/Library/Caches/toolr/f17b14b02ad081cd/
└── venv/             # no meta.json
```

`touch_last_used` had the right shape to self-heal — it's called on every user-command dispatch — but it deliberately treated a missing sidecar as a noop because it had no context to write one from.

## Fix

Add `touch_or_backfill(cache_dir, repo_path, toolr_version, python_version)` next to `touch_last_used`:

- existing sidecar → update `last_used_at` (old behaviour)
- missing sidecar → synthesise a fresh `meta.json` from the supplied context (new)

Dispatch already has all three values at the call site — `resolve_venv_path` returns `python_version` — so plumbing is just keeping that field through the unpacking. The previous bind `(python, venv_dir)` becomes `(python, venv_dir, python_version)`.

The next user-command invocation against an unmetadata'd cache entry writes the sidecar; subsequent `cache list` calls then see it without any manual intervention. `touch_last_used` is preserved as the low-level update-only entry point.

## Caveats

- `created_at` on backfilled entries reflects the time of backfill, not the time the venv directory was actually materialised — the real birth time is not recoverable from on-disk state. Documented inline.
- Backfill only runs on a real *user-command* dispatch (the existing touch path). Running only `self` or `project` subcommands doesn't trigger it, but those are the very commands where the missing-sidecar UX bites; running any tools command once fixes both surfaces.

## Test plan

- [x] New `touch_or_backfill_writes_sidecar_when_missing` regression test
- [x] New `touch_or_backfill_updates_existing_sidecar` (existing-sidecar context is ignored)
- [x] Existing `touch_last_used_is_a_noop_when_sidecar_is_missing` updated to assert it does NOT create a sidecar (negative invariant)
- [x] Manual: `toolr version current` on my repo created the missing `meta.json`; `toolr self cache list` then showed the entry

## Stacks on

#225 (--force install fix), which stacks on #224 (built-in command completions), which stacks on #223 (fish script fix)