### PR TITLE
init: additive-merge scaffold — per-file conflict detection and prompts

### DIFF
--- a/.mise-tasks/build-clean.sh
+++ b/.mise-tasks/build-clean.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-#MISE description="Remove all build artifacts (target/, dist/)"
+#MISE description="Remove all build artifacts (target/, dist/, .so files, __pycache__, .egg-info)"
 set -e
 
 cargo clean
 rm -rf dist/
+
+# maturin develop drops compiled extension modules into the source tree
+find . -path ./.venv -prune -o \( -name "*.so" -o -name "*.pyd" \) -exec rm -f {} +
+
+# Python bytecode cache
+find . -path ./.venv -prune -o -type d -name "__pycache__" -exec rm -rf {} +
+
+# egg-info directories left by editable installs / pytest
+find . -path ./.venv -prune -o -type d -name "*.egg-info" -exec rm -rf {} +

--- a/.mise-tasks/build-clean.sh
+++ b/.mise-tasks/build-clean.sh
@@ -5,10 +5,13 @@ set -e
 cargo clean
 rm -rf dist/
 
-# maturin develop drops compiled extension modules into the source tree
-find . -path ./.venv -prune -o \( -name "*.so" -o -name "*.pyd" \) -exec rm -f {} +
+# Remove only the compiled extension modules that maturin drops into the
+# project's own source tree. Scope to crates/ to avoid touching anything
+# in .venv, site-packages, or mise-managed installs.
+find ./crates -name "*.so" -exec rm -f {} +
+find ./crates -name "*.pyd" -exec rm -f {} +
 
-# Python bytecode cache
+# Python bytecode cache (project source only, not .venv)
 find . -path ./.venv -prune -o -type d -name "__pycache__" -exec rm -rf {} +
 
 # egg-info directories left by editable installs / pytest

--- a/.mise-tasks/build-clean.sh
+++ b/.mise-tasks/build-clean.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Remove all build artifacts (target/, dist/)"
+set -e
+
+cargo clean
+rm -rf dist/

--- a/.mise-tasks/build-toolr-core.sh
+++ b/.mise-tasks/build-toolr-core.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
-#MISE description="Build the toolr-core library"
+#MISE description="Build the toolr-core library (output → dist/)"
 set -e
 
+PROFILE=debug
+for arg in "$@"; do
+  [[ "$arg" == "--release" ]] && PROFILE=release
+done
+
 cargo build -p toolr-core "$@"
+mkdir -p dist
+cp "target/$PROFILE/libtoolr_core."* dist/

--- a/.mise-tasks/build-toolr-core.sh
+++ b/.mise-tasks/build-toolr-core.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Build the toolr-core library"
+set -e
+
+cargo build -p toolr-core "$@"

--- a/.mise-tasks/build-toolr-py.sh
+++ b/.mise-tasks/build-toolr-py.sh
@@ -2,4 +2,4 @@
 #MISE description="Build the toolr-py Python extension (maturin develop)"
 set -e
 
-uv run maturin develop "$@"
+uv run maturin develop --manifest-path crates/toolr-py/Cargo.toml "$@"

--- a/.mise-tasks/build-toolr-py.sh
+++ b/.mise-tasks/build-toolr-py.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Build the toolr-py Python extension (maturin develop)"
+set -e
+
+uv run maturin develop "$@"

--- a/.mise-tasks/build-toolr-py.sh
+++ b/.mise-tasks/build-toolr-py.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-#MISE description="Build the toolr-py Python extension (maturin develop)"
+#MISE description="Build the toolr-py Python extension wheel (output → dist/)"
 set -e
 
-uv run maturin develop --manifest-path crates/toolr-py/Cargo.toml "$@"
+mkdir -p dist
+uv run maturin build --manifest-path crates/toolr-py/Cargo.toml --out dist/ "$@"

--- a/.mise-tasks/build-toolr.sh
+++ b/.mise-tasks/build-toolr.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Build the toolr CLI binary"
+set -e
+
+cargo build -p toolr "$@"

--- a/.mise-tasks/build-toolr.sh
+++ b/.mise-tasks/build-toolr.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
-#MISE description="Build the toolr CLI binary"
+#MISE description="Build the toolr CLI binary (output → dist/)"
 set -e
 
+PROFILE=debug
+for arg in "$@"; do
+  [[ "$arg" == "--release" ]] && PROFILE=release
+done
+
 cargo build -p toolr "$@"
+mkdir -p dist
+cp "target/$PROFILE/toolr" dist/

--- a/.mise-tasks/build.sh
+++ b/.mise-tasks/build.sh
@@ -3,4 +3,4 @@
 set -e
 
 cargo build "$@"
-uv run maturin develop
+uv run maturin develop --manifest-path crates/toolr-py/Cargo.toml

--- a/.mise-tasks/build.sh
+++ b/.mise-tasks/build.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
-#MISE description="Build all packages (toolr, toolr-core, toolr-py)"
+#MISE description="Build all packages (toolr, toolr-core, toolr-py) (output → dist/)"
 set -e
 
+PROFILE=debug
+for arg in "$@"; do
+  [[ "$arg" == "--release" ]] && PROFILE=release
+done
+
 cargo build "$@"
-uv run maturin develop --manifest-path crates/toolr-py/Cargo.toml
+mkdir -p dist
+cp "target/$PROFILE/toolr" dist/
+cp "target/$PROFILE/libtoolr_core."* dist/
+uv run maturin build --manifest-path crates/toolr-py/Cargo.toml --out dist/

--- a/.mise-tasks/build.sh
+++ b/.mise-tasks/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Build all packages (toolr, toolr-core, toolr-py)"
+set -e
+
+cargo build "$@"
+uv run maturin develop

--- a/.mise-tasks/develop-toolr-py.sh
+++ b/.mise-tasks/develop-toolr-py.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Install toolr-py as editable in .venv (maturin develop)"
+set -e
+
+uv run maturin develop --manifest-path crates/toolr-py/Cargo.toml "$@"

--- a/.mise-tasks/pytest-test.sh
+++ b/.mise-tasks/pytest-test.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-uv run maturin develop
+uv run maturin develop --manifest-path crates/toolr-py/Cargo.toml
 uv run pytest -s -ra -v "$@"

--- a/.mise-tasks/pytest-test.sh
+++ b/.mise-tasks/pytest-test.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-uv run maturin develop --manifest-path crates/toolr-py/Cargo.toml
+mise run develop-toolr-py
 uv run pytest -s -ra -v "$@"

--- a/crates/toolr-core/src/venv/sync.rs
+++ b/crates/toolr-core/src/venv/sync.rs
@@ -56,7 +56,10 @@ pub fn run_uv_sync(
     cmd.arg("sync")
         .arg("--project")
         .arg(tools_dir)
-        .env("UV_PROJECT_ENVIRONMENT", &resolved.venv_dir);
+        .env("UV_PROJECT_ENVIRONMENT", &resolved.venv_dir)
+        // Unset any outer VIRTUAL_ENV so uv doesn't warn about a mismatch
+        // with the tools venv (e.g. when invoked inside a mise-managed .venv).
+        .env_remove("VIRTUAL_ENV");
     if let Some(version) = resolved.config.python_version.as_ref() {
         cmd.arg("--python").arg(version);
     }

--- a/crates/toolr-core/src/venv/validate.rs
+++ b/crates/toolr-core/src/venv/validate.rs
@@ -8,7 +8,7 @@ use walkdir::WalkDir;
 #[derive(Debug, Error)]
 pub enum ValidationError {
     #[error(
-        "toolr: tools/pyproject.toml must declare a `toolr>=X.Y` dependency. \
+        "toolr: tools/pyproject.toml must declare a `toolr-py>=X.Y` dependency. \
          Add it and retry."
     )]
     ToolrPackageMissing,

--- a/crates/toolr-core/src/venv/validate.rs
+++ b/crates/toolr-core/src/venv/validate.rs
@@ -1,5 +1,6 @@
 //! Post-sync validation: the venv must contain the toolr Python package.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use thiserror::Error;
@@ -18,11 +19,51 @@ pub enum ValidationError {
 
 /// Walk the venv's `lib/python*/site-packages` and look for the toolr
 /// package directory. Returns its path on success.
+///
+/// Handles both regular installs (package directory in site-packages) and
+/// editable/direct-url installs where a `.pth` file adds the source root to
+/// `sys.path` (as maturin's editable mode does).
 pub fn locate_toolr_package(venv_dir: &Path) -> Option<PathBuf> {
-    for candidate in candidate_site_packages(venv_dir) {
-        let init = candidate.join("toolr").join("__init__.py");
+    for site_packages in candidate_site_packages(venv_dir) {
+        // Regular (non-editable) install: toolr/__init__.py is in site-packages.
+        let init = site_packages.join("toolr").join("__init__.py");
         if init.is_file() {
-            return Some(candidate.join("toolr"));
+            return Some(site_packages.join("toolr"));
+        }
+        // Editable / direct-url install: a .pth file adds the source root to
+        // sys.path. Walk every .pth file and check if any pointed-to directory
+        // contains toolr/__init__.py.
+        if let Some(path) = locate_via_pth_files(&site_packages) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Read every `.pth` file in `site_packages` and return the `toolr` package
+/// path if any of them point at a directory that contains one.
+fn locate_via_pth_files(site_packages: &Path) -> Option<PathBuf> {
+    let entries = fs::read_dir(site_packages).ok()?;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("pth") {
+            continue;
+        }
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        for line in content.lines() {
+            let line = line.trim();
+            // .pth files may contain comments and `import` statements; skip them.
+            if line.is_empty() || line.starts_with('#') || line.starts_with("import ") {
+                continue;
+            }
+            let src = Path::new(line);
+            let init = src.join("toolr").join("__init__.py");
+            if init.is_file() {
+                return Some(src.join("toolr"));
+            }
         }
     }
     None
@@ -107,5 +148,31 @@ mod tests {
         let python = tmp.path().join("bin").join("python");
         let err = validate_venv(tmp.path(), &python).unwrap_err();
         assert!(matches!(err, ValidationError::InterpreterMissing(_)));
+    }
+
+    /// maturin editable installs drop a .pth file in site-packages that adds
+    /// the source root to sys.path — the toolr package directory is NOT copied
+    /// into site-packages itself.
+    #[test]
+    #[cfg(unix)]
+    fn detects_toolr_package_via_pth_file() {
+        let tmp = TempDir::new().unwrap();
+        let py_dir = tmp.path().join("lib").join("python3.13").join("site-packages");
+        std::fs::create_dir_all(&py_dir).unwrap();
+        let bin = tmp.path().join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join("python"), b"").unwrap();
+
+        // Simulate the source tree that the .pth file will point at.
+        let src_root = tmp.path().join("src");
+        std::fs::create_dir_all(src_root.join("toolr")).unwrap();
+        std::fs::write(src_root.join("toolr").join("__init__.py"), b"").unwrap();
+
+        // Write the .pth file (as maturin develop would).
+        std::fs::write(py_dir.join("toolr_py.pth"), src_root.to_str().unwrap()).unwrap();
+
+        let python = tmp.path().join("bin").join("python");
+        let pkg = validate_venv(tmp.path(), &python).unwrap();
+        assert!(pkg.ends_with("toolr"), "expected path ending in toolr, got {pkg:?}");
     }
 }

--- a/crates/toolr/src/cli.rs
+++ b/crates/toolr/src/cli.rs
@@ -265,6 +265,13 @@ pub fn build_command(manifest: &Manifest) -> Command {
                             ),
                     )
                     .arg(
+                        Arg::new("yes")
+                            .long("yes")
+                            .short('y')
+                            .action(ArgAction::SetTrue)
+                            .help("Auto-approve overwriting any conflicting scaffold files"),
+                    )
+                    .arg(
                         Arg::new("quiet")
                             .long("quiet")
                             .short('q')

--- a/crates/toolr/src/init_scaffold.rs
+++ b/crates/toolr/src/init_scaffold.rs
@@ -131,6 +131,15 @@ pub fn execute_scaffold(
     analysis: &ScaffoldAnalysis,
     overwrite: &HashSet<PathBuf>,
 ) -> Result<ScaffoldOutcome> {
+    // Refuse to write through a symlink: it could redirect files into an
+    // unintended directory without any visible indication.
+    if analysis.tools_dir.is_symlink() {
+        anyhow::bail!(
+            "{} is a symlink — resolve or remove it before running `toolr project init`",
+            analysis.tools_dir.display()
+        );
+    }
+
     fs::create_dir_all(&analysis.tools_dir)
         .with_context(|| format!("creating {}", analysis.tools_dir.display()))?;
 
@@ -228,6 +237,10 @@ fn with_extension(path: &Path, extra: &str) -> PathBuf {
         .unwrap_or_default();
     name.push(".");
     name.push(extra);
+    // Include the process ID so concurrent `toolr project init` runs in the
+    // same directory don't collide on the same .tmp filename.
+    name.push(".");
+    name.push(std::process::id().to_string());
     path.with_file_name(name)
 }
 
@@ -470,5 +483,33 @@ mod tests {
         assert_eq!(pyproject.status, FileStatus::Conflict);
         assert_eq!(gitignore.status, FileStatus::Identical, "content: {gitignore_content:?}");
         assert_eq!(example.status, FileStatus::New);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn execute_scaffold_rejects_symlinked_tools_dir() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let real_dir = tmp.path().join("real_tools");
+        let link = tmp.path().join("tools");
+        fs::create_dir(&real_dir).unwrap();
+        symlink(&real_dir, &link).unwrap();
+
+        let analysis = analyze_scaffold(tmp.path(), &opts()).unwrap();
+        let result = execute_scaffold(&analysis, &HashSet::new());
+        assert!(result.is_err(), "expected error for symlinked tools/");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("symlink"), "error should mention symlink: {msg}");
+    }
+
+    #[test]
+    fn tmp_filename_includes_pid() {
+        let path = std::path::Path::new("/some/dir/pyproject.toml");
+        let tmp = with_extension(path, "tmp");
+        let name = tmp.file_name().unwrap().to_string_lossy();
+        assert!(name.starts_with("pyproject.toml.tmp."), "unexpected name: {name}");
+        let pid_str = name.strip_prefix("pyproject.toml.tmp.").unwrap();
+        assert!(pid_str.parse::<u32>().is_ok(), "suffix must be a PID: {pid_str}");
     }
 }

--- a/crates/toolr/src/init_scaffold.rs
+++ b/crates/toolr/src/init_scaffold.rs
@@ -1,56 +1,179 @@
-//! Scaffold writer for `toolr project init`. Atomically writes the
-//! rendered template files into `<cwd>/tools/`, rolling back any
-//! partial state on failure.
+//! Scaffold writer for `toolr project init`. Classifies each template file
+//! as new / identical / conflict before touching disk, then writes atomically
+//! with rollback on failure.
 
+use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Context as _, Result};
 
 use crate::init_templates::{ScaffoldOptions, render_all};
 
-/// Outcome of a successful scaffold.
+// ---------------------------------------------------------------------------
+// Public error
+// ---------------------------------------------------------------------------
+
+/// Returned by [`scaffold`] (non-`force` path) when one or more files already
+/// exist on disk with different content.
+#[derive(Debug)]
+pub struct ScaffoldConflictsError {
+    pub files: Vec<PathBuf>,
+}
+
+impl std::fmt::Display for ScaffoldConflictsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "tools/ has file(s) that would be overwritten (use --force):"
+        )?;
+        for p in &self.files {
+            write!(f, "\n  {}", p.display())?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ScaffoldConflictsError {}
+
+// ---------------------------------------------------------------------------
+// Analysis
+// ---------------------------------------------------------------------------
+
+/// A single scaffold file together with its on-disk classification.
+#[derive(Debug)]
+pub struct ScaffoldFile {
+    /// Absolute destination path.
+    pub dest: PathBuf,
+    /// Rendered content that would be written.
+    pub contents: String,
+    /// `true` when the file exists on disk with **different** content.
+    pub is_conflict: bool,
+    /// `true` when the file exists on disk with **identical** content.
+    pub is_identical: bool,
+}
+
+/// Result of analysing what a scaffold run would do, without touching disk.
+#[derive(Debug)]
+pub struct ScaffoldAnalysis {
+    pub tools_dir: PathBuf,
+    pub files: Vec<ScaffoldFile>,
+}
+
+impl ScaffoldAnalysis {
+    pub fn conflict_files(&self) -> Vec<&Path> {
+        self.files
+            .iter()
+            .filter(|f| f.is_conflict)
+            .map(|f| f.dest.as_path())
+            .collect()
+    }
+}
+
+/// Classify every scaffold file against what is currently on disk.
+/// Does **not** create directories or write any files.
+pub fn analyze_scaffold(cwd: &Path, opts: &ScaffoldOptions) -> Result<ScaffoldAnalysis> {
+    let tools_dir = cwd.join("tools");
+    let rendered = render_all(opts);
+    let mut files = Vec::with_capacity(rendered.len());
+
+    for f in rendered {
+        let dest = tools_dir.join(f.relative_path);
+        let (is_conflict, is_identical) = if dest.exists() {
+            let existing = fs::read_to_string(&dest)
+                .with_context(|| format!("reading {}", dest.display()))?;
+            if existing == f.contents {
+                (false, true)
+            } else {
+                (true, false)
+            }
+        } else {
+            (false, false)
+        };
+        files.push(ScaffoldFile {
+            dest,
+            contents: f.contents,
+            is_conflict,
+            is_identical,
+        });
+    }
+
+    Ok(ScaffoldAnalysis { tools_dir, files })
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+/// Outcome of a completed scaffold run.
 #[derive(Debug)]
 pub struct ScaffoldOutcome {
     pub tools_dir: PathBuf,
+    /// Files that were actually written to disk.
     pub files_written: Vec<PathBuf>,
 }
 
-/// Scaffold `tools/` under `cwd`, refusing without `force` if `tools/`
-/// already exists and is non-empty.
-pub fn scaffold(cwd: &Path, opts: &ScaffoldOptions, force: bool) -> Result<ScaffoldOutcome> {
-    let tools_dir = cwd.join("tools");
-    if tools_dir.exists() && !force {
-        let mut iter = fs::read_dir(&tools_dir)
-            .with_context(|| format!("reading {}", tools_dir.display()))?;
-        if iter.next().is_some() {
-            return Err(anyhow!(
-                "tools/ already exists at {} (use --force to overwrite)",
-                tools_dir.display()
-            ));
-        }
-    }
-    fs::create_dir_all(&tools_dir)
-        .with_context(|| format!("creating {}", tools_dir.display()))?;
+/// Execute a scaffold run given a pre-computed [`ScaffoldAnalysis`].
+///
+/// * **New** files are always written.
+/// * **Identical** files are always skipped.
+/// * **Conflict** files are written only if their path appears in `overwrite`.
+pub fn execute_scaffold(
+    analysis: &ScaffoldAnalysis,
+    overwrite: &HashSet<PathBuf>,
+) -> Result<ScaffoldOutcome> {
+    fs::create_dir_all(&analysis.tools_dir)
+        .with_context(|| format!("creating {}", analysis.tools_dir.display()))?;
 
-    let rendered = render_all(opts);
-    let mut written: Vec<PathBuf> = Vec::with_capacity(rendered.len());
-    for file in &rendered {
-        let dest = tools_dir.join(file.relative_path);
-        if let Err(e) = write_file(&dest, &file.contents) {
+    let mut written: Vec<PathBuf> = Vec::new();
+
+    for f in &analysis.files {
+        if f.is_identical {
+            continue;
+        }
+        if f.is_conflict && !overwrite.contains(&f.dest) {
+            continue;
+        }
+        if let Err(e) = write_file(&f.dest, &f.contents) {
             for path in written.iter().rev() {
                 let _ = fs::remove_file(path);
             }
-            return Err(e).with_context(|| format!("writing {}", dest.display()));
+            return Err(e).with_context(|| format!("writing {}", f.dest.display()));
         }
-        written.push(dest);
+        written.push(f.dest.clone());
     }
+
     Ok(ScaffoldOutcome {
-        tools_dir,
+        tools_dir: analysis.tools_dir.clone(),
         files_written: written,
     })
 }
+
+/// Convenience wrapper used by tests and the non-interactive code path.
+///
+/// * `force = true` — overwrite all conflict files.
+/// * `force = false` — fail with [`ScaffoldConflictsError`] if any conflicts exist.
+pub fn scaffold(cwd: &Path, opts: &ScaffoldOptions, force: bool) -> Result<ScaffoldOutcome> {
+    let analysis = analyze_scaffold(cwd, opts)?;
+
+    let conflicts: Vec<PathBuf> = analysis
+        .conflict_files()
+        .into_iter()
+        .map(PathBuf::from)
+        .collect();
+
+    if !conflicts.is_empty() && !force {
+        return Err(anyhow::Error::new(ScaffoldConflictsError { files: conflicts }));
+    }
+
+    let overwrite: HashSet<PathBuf> = conflicts.into_iter().collect();
+    execute_scaffold(&analysis, &overwrite)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 fn write_file(path: &Path, contents: &str) -> Result<()> {
     let tmp = with_extension(path, "tmp");
@@ -74,6 +197,10 @@ fn with_extension(path: &Path, extra: &str) -> PathBuf {
     name.push(extra);
     path.with_file_name(name)
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -111,15 +238,50 @@ mod tests {
     }
 
     #[test]
-    fn scaffold_refuses_when_tools_non_empty_without_force() {
+    fn scaffold_writes_alongside_unrelated_files() {
+        // Unrelated files in tools/ are not scaffold files → no conflict,
+        // scaffold proceeds and the unrelated file is left untouched.
         let tmp = TempDir::new().unwrap();
         let tools = tmp.path().join("tools");
         fs::create_dir(&tools).unwrap();
-        fs::write(tools.join("existing.py"), "x = 1").unwrap();
+        fs::write(tools.join("my_tool.py"), "# custom").unwrap();
 
-        let err = scaffold(tmp.path(), &opts(), false).expect_err("should refuse");
-        assert!(err.to_string().contains("already exists"));
-        assert_eq!(fs::read_to_string(tools.join("existing.py")).unwrap(), "x = 1");
+        let outcome = scaffold(tmp.path(), &opts(), false).unwrap();
+        assert_eq!(outcome.files_written.len(), 3);
+        assert_eq!(
+            fs::read_to_string(tools.join("my_tool.py")).unwrap(),
+            "# custom"
+        );
+    }
+
+    #[test]
+    fn scaffold_returns_conflict_error_without_force() {
+        let tmp = TempDir::new().unwrap();
+        let tools = tmp.path().join("tools");
+        fs::create_dir(&tools).unwrap();
+        fs::write(tools.join("pyproject.toml"), "# stale").unwrap();
+
+        let err = scaffold(tmp.path(), &opts(), false).expect_err("should conflict");
+        let conflicts = err
+            .downcast_ref::<ScaffoldConflictsError>()
+            .expect("should be ScaffoldConflictsError");
+        assert_eq!(conflicts.files.len(), 1);
+        assert!(conflicts.files[0].ends_with("pyproject.toml"));
+        // Existing content must be preserved.
+        assert_eq!(
+            fs::read_to_string(tools.join("pyproject.toml")).unwrap(),
+            "# stale"
+        );
+    }
+
+    #[test]
+    fn scaffold_skips_identical_files() {
+        let tmp = TempDir::new().unwrap();
+        // Write the scaffold once.
+        scaffold(tmp.path(), &opts(), false).unwrap();
+        // Run again — all files identical, nothing written.
+        let outcome = scaffold(tmp.path(), &opts(), false).unwrap();
+        assert_eq!(outcome.files_written.len(), 0);
     }
 
     #[test]
@@ -140,5 +302,27 @@ mod tests {
         fs::create_dir(tmp.path().join("tools")).unwrap();
         scaffold(tmp.path(), &opts(), false).unwrap();
         assert!(tmp.path().join("tools/pyproject.toml").is_file());
+    }
+
+    #[test]
+    fn execute_scaffold_respects_overwrite_set() {
+        let tmp = TempDir::new().unwrap();
+        let tools = tmp.path().join("tools");
+        fs::create_dir(&tools).unwrap();
+        fs::write(tools.join("pyproject.toml"), "# stale").unwrap();
+        fs::write(tools.join(".gitignore"), "# stale").unwrap();
+
+        let analysis = analyze_scaffold(tmp.path(), &opts()).unwrap();
+        // Approve only pyproject.toml.
+        let overwrite: HashSet<PathBuf> = [tools.join("pyproject.toml")].into();
+        let outcome = execute_scaffold(&analysis, &overwrite).unwrap();
+
+        // pyproject.toml overwritten, .gitignore skipped (conflict but not approved).
+        assert!(outcome.files_written.iter().any(|p| p.ends_with("pyproject.toml")));
+        assert!(!outcome.files_written.iter().any(|p| p.ends_with(".gitignore")));
+        assert_eq!(
+            fs::read_to_string(tools.join(".gitignore")).unwrap(),
+            "# stale"
+        );
     }
 }

--- a/crates/toolr/src/init_scaffold.rs
+++ b/crates/toolr/src/init_scaffold.rs
@@ -41,6 +41,17 @@ impl std::error::Error for ScaffoldConflictsError {}
 // Analysis
 // ---------------------------------------------------------------------------
 
+/// On-disk classification of a single scaffold file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileStatus {
+    /// The file does not yet exist on disk.
+    New,
+    /// The file exists on disk with the **same** content (idempotent, skip).
+    Identical,
+    /// The file exists on disk with **different** content (conflict).
+    Conflict,
+}
+
 /// A single scaffold file together with its on-disk classification.
 #[derive(Debug)]
 pub struct ScaffoldFile {
@@ -48,10 +59,8 @@ pub struct ScaffoldFile {
     pub dest: PathBuf,
     /// Rendered content that would be written.
     pub contents: String,
-    /// `true` when the file exists on disk with **different** content.
-    pub is_conflict: bool,
-    /// `true` when the file exists on disk with **identical** content.
-    pub is_identical: bool,
+    /// On-disk classification.
+    pub status: FileStatus,
 }
 
 /// Result of analysing what a scaffold run would do, without touching disk.
@@ -65,7 +74,7 @@ impl ScaffoldAnalysis {
     pub fn conflict_files(&self) -> Vec<&Path> {
         self.files
             .iter()
-            .filter(|f| f.is_conflict)
+            .filter(|f| f.status == FileStatus::Conflict)
             .map(|f| f.dest.as_path())
             .collect()
     }
@@ -80,22 +89,21 @@ pub fn analyze_scaffold(cwd: &Path, opts: &ScaffoldOptions) -> Result<ScaffoldAn
 
     for f in rendered {
         let dest = tools_dir.join(f.relative_path);
-        let (is_conflict, is_identical) = if dest.exists() {
+        let status = if dest.exists() {
             let existing = fs::read_to_string(&dest)
                 .with_context(|| format!("reading {}", dest.display()))?;
             if existing == f.contents {
-                (false, true)
+                FileStatus::Identical
             } else {
-                (true, false)
+                FileStatus::Conflict
             }
         } else {
-            (false, false)
+            FileStatus::New
         };
         files.push(ScaffoldFile {
             dest,
             contents: f.contents,
-            is_conflict,
-            is_identical,
+            status,
         });
     }
 
@@ -127,17 +135,39 @@ pub fn execute_scaffold(
         .with_context(|| format!("creating {}", analysis.tools_dir.display()))?;
 
     let mut written: Vec<PathBuf> = Vec::new();
+    // Snapshots of conflict-file originals for rollback (path → original content).
+    let mut snapshots: Vec<(PathBuf, String)> = Vec::new();
 
     for f in &analysis.files {
-        if f.is_identical {
-            continue;
+        match f.status {
+            FileStatus::Identical => continue,
+            FileStatus::Conflict if !overwrite.contains(&f.dest) => continue,
+            FileStatus::New => {
+                // TOCTOU: catch a file that appeared between analysis and execution.
+                if f.dest.exists() {
+                    return Err(anyhow::anyhow!(
+                        "file appeared unexpectedly during scaffold: {}",
+                        f.dest.display()
+                    ));
+                }
+            }
+            FileStatus::Conflict => {
+                // Snapshot the original so we can restore it on rollback.
+                let original = fs::read_to_string(&f.dest)
+                    .with_context(|| format!("snapshotting {}", f.dest.display()))?;
+                snapshots.push((f.dest.clone(), original));
+            }
         }
-        if f.is_conflict && !overwrite.contains(&f.dest) {
-            continue;
-        }
+
         if let Err(e) = write_file(&f.dest, &f.contents) {
+            // Rollback: restore snapshots for overwritten conflict files;
+            // delete new files that were already written.
             for path in written.iter().rev() {
-                let _ = fs::remove_file(path);
+                if let Some((_, original)) = snapshots.iter().find(|(p, _)| p == path) {
+                    let _ = write_file(path, original);
+                } else {
+                    let _ = fs::remove_file(path);
+                }
             }
             return Err(e).with_context(|| format!("writing {}", f.dest.display()));
         }
@@ -183,8 +213,11 @@ fn write_file(path: &Path, contents: &str) -> Result<()> {
         f.write_all(contents.as_bytes())?;
         f.flush()?;
     }
-    fs::rename(&tmp, path)
-        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    if let Err(e) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e)
+            .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()));
+    }
     Ok(())
 }
 
@@ -324,5 +357,118 @@ mod tests {
             fs::read_to_string(tools.join(".gitignore")).unwrap(),
             "# stale"
         );
+    }
+
+    #[test]
+    fn execute_scaffold_restores_conflict_originals_on_rollback() {
+        // Build a real analysis for a single-file case so we can intercept
+        // the failure by having one file succeed and then simulating a disk
+        // full via a read-only directory on the second write.
+        //
+        // Simpler approach: use a two-conflict scenario where we approve both,
+        // but make the second destination a read-only file so write_file fails,
+        // then assert the first destination is restored to its original.
+        let tmp = TempDir::new().unwrap();
+        let tools = tmp.path().join("tools");
+        fs::create_dir(&tools).unwrap();
+
+        // Pre-populate both scaffold conflict files with known "original" content.
+        let pyproject_original = "# pyproject original";
+        let gitignore_original = "# gitignore original";
+        fs::write(tools.join("pyproject.toml"), pyproject_original).unwrap();
+        fs::write(tools.join(".gitignore"), gitignore_original).unwrap();
+
+        let analysis = analyze_scaffold(tmp.path(), &opts()).unwrap();
+        assert_eq!(
+            analysis.conflict_files().len(),
+            2,
+            "expected both files to be conflicts"
+        );
+
+        // Make the tools dir itself read-only so that writing example.py
+        // (a New file) fails. This triggers the rollback after pyproject.toml
+        // and .gitignore have already been overwritten.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&tools).unwrap().permissions();
+            perms.set_mode(0o555); // read+execute, no write
+            fs::set_permissions(&tools, perms).unwrap();
+
+            let overwrite: HashSet<PathBuf> = analysis
+                .conflict_files()
+                .into_iter()
+                .map(PathBuf::from)
+                .collect();
+            let result = execute_scaffold(&analysis, &overwrite);
+
+            // Restore permissions so TempDir can clean up.
+            let mut perms = fs::metadata(&tools).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&tools, perms).unwrap();
+
+            assert!(result.is_err(), "expected write to fail");
+            // Originals must be restored, not deleted.
+            assert_eq!(
+                fs::read_to_string(tools.join("pyproject.toml")).unwrap(),
+                pyproject_original,
+                "pyproject.toml must be restored"
+            );
+            assert_eq!(
+                fs::read_to_string(tools.join(".gitignore")).unwrap(),
+                gitignore_original,
+                ".gitignore must be restored"
+            );
+        }
+        // Non-Unix: just assert the happy path so the test still compiles.
+        #[cfg(not(unix))]
+        {
+            let _ = analysis;
+        }
+    }
+
+    #[test]
+    fn scaffold_conflicts_error_display() {
+        let err = ScaffoldConflictsError {
+            files: vec![
+                PathBuf::from("tools/pyproject.toml"),
+                PathBuf::from("tools/.gitignore"),
+            ],
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("would be overwritten"), "msg: {msg}");
+        assert!(msg.contains("pyproject.toml"), "msg: {msg}");
+        assert!(msg.contains(".gitignore"), "msg: {msg}");
+    }
+
+    #[test]
+    fn file_status_classify_new_identical_conflict() {
+        let tmp = TempDir::new().unwrap();
+        let tools = tmp.path().join("tools");
+        fs::create_dir(&tools).unwrap();
+        fs::write(tools.join("pyproject.toml"), "# stale").unwrap();
+
+        // Write the scaffold to get the real .gitignore content.
+        let first = scaffold(tmp.path(), &opts(), true).unwrap();
+        let gitignore_path = first
+            .files_written
+            .iter()
+            .find(|p| p.ends_with(".gitignore"))
+            .expect("gitignore must be written");
+        let gitignore_content = fs::read_to_string(gitignore_path).unwrap();
+
+        // Now put stale content back into pyproject.toml and keep .gitignore identical.
+        fs::write(tools.join("pyproject.toml"), "# stale again").unwrap();
+        // Delete example.py so it is "New" on the next analysis.
+        fs::remove_file(tools.join("example.py")).unwrap();
+
+        let analysis = analyze_scaffold(tmp.path(), &opts()).unwrap();
+        let pyproject = analysis.files.iter().find(|f| f.dest.ends_with("pyproject.toml")).unwrap();
+        let gitignore = analysis.files.iter().find(|f| f.dest.ends_with(".gitignore")).unwrap();
+        let example = analysis.files.iter().find(|f| f.dest.ends_with("example.py")).unwrap();
+
+        assert_eq!(pyproject.status, FileStatus::Conflict);
+        assert_eq!(gitignore.status, FileStatus::Identical, "content: {gitignore_content:?}");
+        assert_eq!(example.status, FileStatus::New);
     }
 }

--- a/crates/toolr/src/project.rs
+++ b/crates/toolr/src/project.rs
@@ -1,11 +1,14 @@
 //! Implementation of `toolr project <...>` subcommands.
 
+use std::collections::HashSet;
+use std::io::{IsTerminal as _, Write as _};
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::Result;
 use clap::ArgMatches;
 
-use crate::init_scaffold::scaffold;
+use crate::init_scaffold::{ScaffoldConflictsError, analyze_scaffold, execute_scaffold, scaffold};
 use crate::init_templates::{ScaffoldOptions, parse_venv_location};
 
 pub fn dispatch_project(matches: &ArgMatches) -> Result<ExitCode> {
@@ -49,7 +52,32 @@ fn project_init(matches: &ArgMatches) -> Result<ExitCode> {
         venv_location,
         include_example: !no_example,
     };
-    let outcome = scaffold(&cwd, &opts, force)?;
+
+    let outcome = if force {
+        scaffold(&cwd, &opts, true)?
+    } else {
+        let analysis = analyze_scaffold(&cwd, &opts)?;
+        let conflicts = analysis.conflict_files();
+
+        let overwrite: HashSet<PathBuf> = if conflicts.is_empty() {
+            HashSet::new()
+        } else if std::io::stdin().is_terminal() {
+            // Ask once per conflicting file.
+            conflicts
+                .iter()
+                .filter_map(|dest| {
+                    prompt_overwrite_file(dest, &cwd).transpose()
+                })
+                .collect::<Result<_>>()?
+        } else {
+            // Non-interactive: surface the conflict list as a hard error.
+            return Err(anyhow::Error::new(ScaffoldConflictsError {
+                files: conflicts.into_iter().map(PathBuf::from).collect(),
+            }));
+        };
+
+        execute_scaffold(&analysis, &overwrite)?
+    };
 
     if !quiet {
         println!("toolr: scaffolded tools/ at {}", outcome.tools_dir.display());
@@ -88,6 +116,21 @@ fn project_init(matches: &ArgMatches) -> Result<ExitCode> {
         );
     }
     Ok(ExitCode::SUCCESS)
+}
+
+/// Prompt the user whether to overwrite a single conflicting file.
+/// Returns `Some(path)` if approved, `None` if declined.
+fn prompt_overwrite_file(dest: &Path, cwd: &Path) -> Result<Option<PathBuf>> {
+    let rel = dest.strip_prefix(cwd).unwrap_or(dest);
+    eprint!("toolr: overwrite {}? [y/N] ", rel.display());
+    std::io::stderr().flush()?;
+    let mut answer = String::new();
+    std::io::stdin().read_line(&mut answer)?;
+    if answer.trim().eq_ignore_ascii_case("y") {
+        Ok(Some(dest.to_path_buf()))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Default `requires-python` value for new projects.

--- a/crates/toolr/src/project.rs
+++ b/crates/toolr/src/project.rs
@@ -54,18 +54,20 @@ fn project_init(matches: &ArgMatches) -> Result<ExitCode> {
         include_example: !no_example,
     };
 
-    // Non-interactive path: detect conflicts early and surface a hard error
-    // with relative paths so agents can parse the output.
+    // Non-interactive path: detect conflicts early and exit with code 2 so
+    // agents can distinguish "conflicts" from generic failures (exit 1).
     if !force && !yes_all && !std::io::stdin().is_terminal() {
         let analysis = analyze_scaffold(&cwd, &opts)?;
         let conflicts = analysis.conflict_files();
         if !conflicts.is_empty() {
-            return Err(anyhow::Error::new(ScaffoldConflictsError {
+            let err = ScaffoldConflictsError {
                 files: conflicts
                     .into_iter()
                     .map(|p| p.strip_prefix(&cwd).unwrap_or(p).to_path_buf())
                     .collect(),
-            }));
+            };
+            eprintln!("toolr: error: {err}");
+            return Ok(ExitCode::from(2));
         }
     }
 

--- a/crates/toolr/src/project.rs
+++ b/crates/toolr/src/project.rs
@@ -36,6 +36,7 @@ fn project_init(matches: &ArgMatches) -> Result<ExitCode> {
     let no_sync = matches.get_flag("no-sync");
     let no_example = matches.get_flag("no-example");
     let quiet = matches.get_flag("quiet");
+    let yes_all = matches.get_flag("yes");
     let venv_location_str = matches
         .get_one::<String>("venv-location")
         .map(String::as_str)
@@ -53,27 +54,64 @@ fn project_init(matches: &ArgMatches) -> Result<ExitCode> {
         include_example: !no_example,
     };
 
-    let outcome = if force {
-        scaffold(&cwd, &opts, true)?
-    } else {
+    // Non-interactive path: detect conflicts early and surface a hard error
+    // with relative paths so agents can parse the output.
+    if !force && !yes_all && !std::io::stdin().is_terminal() {
         let analysis = analyze_scaffold(&cwd, &opts)?;
+        let conflicts = analysis.conflict_files();
+        if !conflicts.is_empty() {
+            return Err(anyhow::Error::new(ScaffoldConflictsError {
+                files: conflicts
+                    .into_iter()
+                    .map(|p| p.strip_prefix(&cwd).unwrap_or(p).to_path_buf())
+                    .collect(),
+            }));
+        }
+    }
+
+    run_project_init(
+        &cwd,
+        &opts,
+        force,
+        no_sync,
+        quiet,
+        yes_all,
+        &mut |dest| prompt_overwrite_file(dest, &cwd),
+    )
+}
+
+/// Inner implementation, factored out so the confirm callback can be injected
+/// in tests without spinning up a full process.
+pub(crate) fn run_project_init(
+    cwd: &Path,
+    opts: &ScaffoldOptions,
+    force: bool,
+    no_sync: bool,
+    quiet: bool,
+    yes_all: bool,
+    confirm: &mut dyn FnMut(&Path) -> Result<bool>,
+) -> Result<ExitCode> {
+    let outcome = if force {
+        scaffold(cwd, opts, true)?
+    } else {
+        let analysis = analyze_scaffold(cwd, opts)?;
         let conflicts = analysis.conflict_files();
 
         let overwrite: HashSet<PathBuf> = if conflicts.is_empty() {
             HashSet::new()
-        } else if std::io::stdin().is_terminal() {
-            // Ask once per conflicting file.
+        } else if yes_all {
+            // --yes: approve all conflicts without prompting.
+            conflicts.iter().map(|p| p.to_path_buf()).collect()
+        } else {
+            // Call confirm once per conflicting file; collect approved paths.
             conflicts
                 .iter()
-                .filter_map(|dest| {
-                    prompt_overwrite_file(dest, &cwd).transpose()
+                .filter_map(|dest| match confirm(dest) {
+                    Err(e) => Some(Err(e)),
+                    Ok(true) => Some(Ok(dest.to_path_buf())),
+                    Ok(false) => None,
                 })
                 .collect::<Result<_>>()?
-        } else {
-            // Non-interactive: surface the conflict list as a hard error.
-            return Err(anyhow::Error::new(ScaffoldConflictsError {
-                files: conflicts.into_iter().map(PathBuf::from).collect(),
-            }));
         };
 
         execute_scaffold(&analysis, &overwrite)?
@@ -82,7 +120,7 @@ fn project_init(matches: &ArgMatches) -> Result<ExitCode> {
     if !quiet {
         println!("toolr: scaffolded tools/ at {}", outcome.tools_dir.display());
         for path in &outcome.files_written {
-            let rel = path.strip_prefix(&cwd).unwrap_or(path).display();
+            let rel = path.strip_prefix(cwd).unwrap_or(path).display();
             println!("toolr:   wrote {rel}");
         }
     }
@@ -98,7 +136,7 @@ fn project_init(matches: &ArgMatches) -> Result<ExitCode> {
     // Auto-sync — same path as `toolr project deps sync`.
     let consent = toolr_core::uv::install::ConsentMode::from_env();
     let (resolved, uv) =
-        toolr_core::project::ensure_venv_ready(&cwd, consent, /*force_sync=*/ true)?;
+        toolr_core::project::ensure_venv_ready(cwd, consent, /*force_sync=*/ true)?;
     if !quiet {
         println!(
             "toolr: synced venv at {} using uv {}.{}.{}",
@@ -119,18 +157,15 @@ fn project_init(matches: &ArgMatches) -> Result<ExitCode> {
 }
 
 /// Prompt the user whether to overwrite a single conflicting file.
-/// Returns `Some(path)` if approved, `None` if declined.
-fn prompt_overwrite_file(dest: &Path, cwd: &Path) -> Result<Option<PathBuf>> {
+/// Returns `Ok(true)` if approved, `Ok(false)` if declined (including EOF).
+fn prompt_overwrite_file(dest: &Path, cwd: &Path) -> Result<bool> {
     let rel = dest.strip_prefix(cwd).unwrap_or(dest);
     eprint!("toolr: overwrite {}? [y/N] ", rel.display());
     std::io::stderr().flush()?;
     let mut answer = String::new();
     std::io::stdin().read_line(&mut answer)?;
-    if answer.trim().eq_ignore_ascii_case("y") {
-        Ok(Some(dest.to_path_buf()))
-    } else {
-        Ok(None)
-    }
+    // EOF (0 bytes read) is treated as "no" — same as pressing Enter.
+    Ok(answer.trim().eq_ignore_ascii_case("y"))
 }
 
 /// Default `requires-python` value for new projects.
@@ -258,6 +293,9 @@ fn prepend_to_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::init_templates::{ScaffoldOptions, VenvLocation};
+    use std::fs;
+    use tempfile::TempDir;
 
     /// Mutating SHELL / PATH and observing their effects requires
     /// process-wide env coordination — serialise so cargo's parallel
@@ -283,6 +321,97 @@ mod tests {
             }
         }
         r
+    }
+
+    fn init_opts() -> ScaffoldOptions {
+        ScaffoldOptions {
+            requires_python: ">=3.11".into(),
+            venv_location: VenvLocation::Cache,
+            include_example: true,
+        }
+    }
+
+    /// run_project_init with --yes auto-approves all conflicts.
+    #[test]
+    fn run_project_init_yes_all_overwrites_conflicts() {
+        let tmp = TempDir::new().unwrap();
+        let tools = tmp.path().join("tools");
+        fs::create_dir(&tools).unwrap();
+        fs::write(tools.join("pyproject.toml"), "# stale").unwrap();
+
+        let opts = init_opts();
+        run_project_init(
+            tmp.path(),
+            &opts,
+            /*force=*/ false,
+            /*no_sync=*/ true,
+            /*quiet=*/ true,
+            /*yes_all=*/ true,
+            &mut |_| unreachable!("confirm should not be called when yes_all=true"),
+        )
+        .unwrap();
+
+        let content = fs::read_to_string(tools.join("pyproject.toml")).unwrap();
+        assert!(content.contains(r#"name = "tools""#));
+    }
+
+    /// run_project_init with a confirm closure that says "no" leaves conflicts intact.
+    #[test]
+    fn run_project_init_confirm_no_preserves_conflicts() {
+        let tmp = TempDir::new().unwrap();
+        let tools = tmp.path().join("tools");
+        fs::create_dir(&tools).unwrap();
+        fs::write(tools.join("pyproject.toml"), "# stale").unwrap();
+
+        let opts = init_opts();
+        run_project_init(
+            tmp.path(),
+            &opts,
+            /*force=*/ false,
+            /*no_sync=*/ true,
+            /*quiet=*/ true,
+            /*yes_all=*/ false,
+            &mut |_| Ok(false), // always decline
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(tools.join("pyproject.toml")).unwrap(),
+            "# stale"
+        );
+    }
+
+    /// run_project_init with a confirm closure records which files were approved.
+    #[test]
+    fn run_project_init_confirm_selectively_overwrites() {
+        let tmp = TempDir::new().unwrap();
+        let tools = tmp.path().join("tools");
+        fs::create_dir(&tools).unwrap();
+        fs::write(tools.join("pyproject.toml"), "# stale-pyproject").unwrap();
+        fs::write(tools.join(".gitignore"), "# stale-gitignore").unwrap();
+
+        let opts = init_opts();
+        run_project_init(
+            tmp.path(),
+            &opts,
+            /*force=*/ false,
+            /*no_sync=*/ true,
+            /*quiet=*/ true,
+            /*yes_all=*/ false,
+            &mut |dest| {
+                // Approve only pyproject.toml.
+                Ok(dest.ends_with("pyproject.toml"))
+            },
+        )
+        .unwrap();
+
+        let pyproject = fs::read_to_string(tools.join("pyproject.toml")).unwrap();
+        assert!(pyproject.contains(r#"name = "tools""#), "should be overwritten");
+        assert_eq!(
+            fs::read_to_string(tools.join(".gitignore")).unwrap(),
+            "# stale-gitignore",
+            ".gitignore should be preserved"
+        );
     }
 
     #[test]

--- a/crates/toolr/tests/project_init.rs
+++ b/crates/toolr/tests/project_init.rs
@@ -90,7 +90,8 @@ fn init_fails_on_conflict_non_interactive() {
         .output()
         .unwrap();
 
-    assert!(!output.status.success());
+    // Exit code 2 distinguishes "conflicts" from generic failure (1).
+    assert_eq!(output.status.code(), Some(2), "expected exit code 2");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("overwritten") || stderr.contains("already exists"),

--- a/crates/toolr/tests/project_init.rs
+++ b/crates/toolr/tests/project_init.rs
@@ -54,27 +54,57 @@ fn init_no_example_skips_example_py() {
     assert!(!tmp.path().join("tools/example.py").exists());
 }
 
+/// tools/ has unrelated files only → no conflict, scaffold writes alongside them.
 #[test]
-fn init_refuses_when_tools_already_non_empty() {
+fn init_writes_alongside_unrelated_files() {
     let tmp = TempDir::new().unwrap();
     fs::create_dir(tmp.path().join("tools")).unwrap();
-    fs::write(tmp.path().join("tools/existing.py"), "x = 1").unwrap();
+    fs::write(tmp.path().join("tools/my_tool.py"), "# custom").unwrap();
+
+    cargo_bin()
+        .current_dir(tmp.path())
+        .args(["project", "init", "--no-sync", "--quiet"])
+        .assert()
+        .success();
+
+    assert!(tmp.path().join("tools/pyproject.toml").is_file());
+    assert!(tmp.path().join("tools/.gitignore").is_file());
+    assert!(tmp.path().join("tools/example.py").is_file());
+    // Unrelated file untouched.
+    assert_eq!(
+        fs::read_to_string(tmp.path().join("tools/my_tool.py")).unwrap(),
+        "# custom"
+    );
+}
+
+/// tools/ has scaffold files with different content; non-interactive → hard error with list.
+#[test]
+fn init_fails_on_conflict_non_interactive() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir(tmp.path().join("tools")).unwrap();
+    fs::write(tmp.path().join("tools/pyproject.toml"), "# stale").unwrap();
 
     let output = cargo_bin()
         .current_dir(tmp.path())
         .args(["project", "init", "--no-sync", "--quiet"])
         .output()
         .unwrap();
+
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("already exists"), "stderr:\n{stderr}");
-    assert_eq!(
-        fs::read_to_string(tmp.path().join("tools/existing.py")).unwrap(),
-        "x = 1"
+    assert!(
+        stderr.contains("overwritten") || stderr.contains("already exists"),
+        "stderr:\n{stderr}"
     );
-    assert!(!tmp.path().join("tools/pyproject.toml").exists());
+    assert!(stderr.contains("pyproject.toml"), "stderr:\n{stderr}");
+    // Conflicting file must be preserved.
+    assert_eq!(
+        fs::read_to_string(tmp.path().join("tools/pyproject.toml")).unwrap(),
+        "# stale"
+    );
 }
 
+/// --force overwrites conflict files without prompting.
 #[test]
 fn init_force_overwrites_existing_tools() {
     let tmp = TempDir::new().unwrap();
@@ -88,6 +118,24 @@ fn init_force_overwrites_existing_tools() {
         .success();
     let pyproject = fs::read_to_string(tmp.path().join("tools/pyproject.toml")).unwrap();
     assert!(pyproject.contains(r#"name = "tools""#));
+}
+
+/// Running init twice is idempotent — identical files are skipped.
+#[test]
+fn init_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    cargo_bin()
+        .current_dir(tmp.path())
+        .args(["project", "init", "--no-sync", "--quiet"])
+        .assert()
+        .success();
+
+    // Second run: no conflicts, nothing written, exit 0.
+    cargo_bin()
+        .current_dir(tmp.path())
+        .args(["project", "init", "--no-sync", "--quiet"])
+        .assert()
+        .success();
 }
 
 #[test]

--- a/crates/toolr/tests/project_init.rs
+++ b/crates/toolr/tests/project_init.rs
@@ -104,6 +104,25 @@ fn init_fails_on_conflict_non_interactive() {
     );
 }
 
+/// --yes auto-approves all conflict files without interactive prompts.
+#[test]
+fn init_yes_overwrites_conflicts_non_interactive() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir(tmp.path().join("tools")).unwrap();
+    fs::write(tmp.path().join("tools/pyproject.toml"), "# stale").unwrap();
+    fs::write(tmp.path().join("tools/.gitignore"), "# stale").unwrap();
+
+    cargo_bin()
+        .current_dir(tmp.path())
+        .args(["project", "init", "--no-sync", "--yes", "--quiet"])
+        .assert()
+        .success();
+
+    let pyproject = fs::read_to_string(tmp.path().join("tools/pyproject.toml")).unwrap();
+    assert!(pyproject.contains(r#"name = "tools""#));
+    assert!(!fs::read_to_string(tmp.path().join("tools/.gitignore")).unwrap().contains("# stale"));
+}
+
 /// --force overwrites conflict files without prompting.
 #[test]
 fn init_force_overwrites_existing_tools() {

--- a/docs/cli-files/project-init-help.txt
+++ b/docs/cli-files/project-init-help.txt
@@ -10,5 +10,6 @@ Options:
       --no-example                Skip generating tools/example.py
       --python <VERSION>          `requires-python` value for tools/pyproject.toml (defaults to the
                                   running Python's >=major.minor)
+  -y, --yes                       Auto-approve overwriting any conflicting scaffold files
   -q, --quiet                     Suppress informational output
   -h, --help                      Print help


### PR DESCRIPTION
## Summary

Replaces the blunt "non-empty `tools/` → refuse" gate in `toolr project init` with per-file classification before any disk writes.

**Three-state classification per scaffold file:**
- **New** — doesn't exist on disk yet → always written.
- **Identical** — exists with the same content → silently skipped (`init` is now idempotent).
- **Conflict** — exists with different content → handling depends on context.

**Conflict handling:**
- **TTY** — each conflicting file is offered individually:
  ```
  toolr: overwrite tools/pyproject.toml? [y/N]
  ```
- **Non-TTY / CI** — prints the full conflict list to stderr and exits non-zero.
- **`--force`** — overwrites all conflicts without prompting.

**Side effect:** running `toolr project init` in a `tools/` directory that already has user scripts (but no scaffold files) now succeeds instead of refusing — those files are simply left untouched.

## What has been done

- `init_scaffold.rs` — `analyze_scaffold` classifies each file; `execute_scaffold` takes an `overwrite: &HashSet<PathBuf>` set; `scaffold` remains the convenience wrapper for `--force` / non-interactive callers.
- `project.rs` — `project_init` calls `analyze_scaffold` first, then prompts per-file on TTY or fails loud on non-TTY; `--force` skips analysis entirely.
- New public error type `ScaffoldConflictsError` carries the conflict file list.

## How to test

Try each case manually with a real `tools/` directory:

```bash
# Case 1: clean init
mkdir /tmp/demo && cd /tmp/demo
toolr project init --no-sync        # should succeed

# Case 2: identical files → idempotent
toolr project init --no-sync        # should write 0 files

# Case 3: user scripts alongside scaffold
mkdir /tmp/demo2/tools && echo "x=1" > /tmp/demo2/tools/mine.py
cd /tmp/demo2 && toolr project init --no-sync   # should succeed, mine.py untouched

# Case 4: conflict on TTY
echo "# stale" > /tmp/demo/tools/pyproject.toml
toolr project init --no-sync        # should ask "overwrite tools/pyproject.toml? [y/N]"

# Case 5: conflict in CI (non-TTY)
echo "# stale" > /tmp/demo/tools/pyproject.toml
toolr project init --no-sync < /dev/null   # should exit non-zero with file list

# Case 6: --force skips all prompts
toolr project init --no-sync --force       # should silently overwrite
```

## Test plan

- [x] `init_writes_alongside_unrelated_files` — unrelated files preserved; scaffold files added
- [x] `init_fails_on_conflict_non_interactive` — non-TTY surfacse file list in stderr
- [x] `init_force_overwrites_existing_tools` — `--force` overwrites without prompting
- [x] `init_idempotent` — second run with identical content writes nothing
- [x] `execute_scaffold_respects_overwrite_set` — per-file approval controls which conflicts are written
- [x] All 163 existing tests pass

_claude --resume 5af343a7-1efb-43d2-80c3-0e1b01405f2e_