### PR TITLE
runner: schema-version handshake — error message, upgrade verb, CI gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,6 +288,19 @@ pub fn greet(name: &str) -> String {
 - **Update docs/** when adding features
 - **Keep README.md** up to date
 
+### Runner schema version
+
+The toolr binary and the toolr-py Python package communicate over a
+versioned JSON spec. Two constants must stay in lock-step:
+
+- `RUNNER_SCHEMA_VERSION` in `crates/toolr-core/src/execute/spec.rs`
+- `SCHEMA_VERSION` in `crates/toolr-py/python/toolr/_runner.py`
+
+Both constants carry a doc-comment listing exactly which changes
+require a bump and which don't. Read those before changing either the
+Rust serde structs or the `RunnerSpec` Python class. A CI gate fails
+the build when the two values disagree.
+
 ### Pre-commit Hooks
 
 All formatting and linting is handled automatically by prek:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "termimad",
+ "toml",
  "toolr-core",
  "uuid",
  "which",

--- a/crates/toolr-core/src/execute/spec.rs
+++ b/crates/toolr-core/src/execute/spec.rs
@@ -8,7 +8,38 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-/// Schema version. Must match `toolr._runner.SCHEMA_VERSION` exactly.
+/// Schema version of the toolr ↔ toolr-py dispatch protocol.
+///
+/// This constant **must** match `toolr._runner.SCHEMA_VERSION` exactly; a
+/// CI gate enforces the lock-step (see
+/// `crates/toolr-core/tests/schema_version_lockstep.rs`).
+///
+/// # When to bump
+///
+/// Bump this **and** the Python counterpart by `+1` together when the
+/// two sides would no longer understand each other:
+///
+/// - Add, remove, or rename any field on `ExecutionSpec`, `DispatchSpec`,
+///   `ContextSpec`, or any other struct serialised into the spec JSON.
+/// - Change the meaning of any existing field (e.g. string-keyed to
+///   int-keyed, units changed, encoding changed).
+/// - Add, remove, or rename a required field on the manifest JSON that
+///   the runner consumes.
+/// - Change the env-var / stdin / stdout / exit-code conventions between
+///   the toolr binary and the Python runner.
+///
+/// # When *not* to bump
+///
+/// - Adding a new **optional** field on either side with a safe default
+///   (`serde(default)` on Rust, `msgspec` default on Python) — old
+///   spec files still decode and old runners still work against new
+///   binaries.
+/// - Internal Rust refactors that don't change the serialised shape.
+/// - Renaming variables, restructuring code, expanding tests.
+///
+/// Toolr is pre-1.0, so we don't carve out "major" / "minor" — bumps are
+/// monotonic integers tied 1:1 to "the protocol changed in a way an
+/// older peer can't handle".
 pub const RUNNER_SCHEMA_VERSION: u32 = 1;
 
 /// Reduced view of `toolr.Context` reconstructable from JSON.

--- a/crates/toolr-core/src/venv/mod.rs
+++ b/crates/toolr-core/src/venv/mod.rs
@@ -11,5 +11,5 @@ pub use config::{ToolrConfig, VenvLocation, load_toolr_config};
 pub use editable::{EditableOutcome, perform_editable_installs, warn_failures};
 pub use repo_key::{TOOLR_MAJOR, compute_repo_key};
 pub use resolve::{ResolvedVenv, resolve_venv_path};
-pub use sync::{Freshness, check_freshness, run_uv_sync, sync_if_needed};
+pub use sync::{Freshness, check_freshness, run_uv_lock_upgrade, run_uv_sync, sync_if_needed};
 pub use validate::{ValidationError, locate_toolr_package, validate_venv};

--- a/crates/toolr-core/src/venv/sync.rs
+++ b/crates/toolr-core/src/venv/sync.rs
@@ -69,6 +69,30 @@ pub fn run_uv_sync(
     Ok(status)
 }
 
+/// Run `uv lock --upgrade-package <package> --project <tools>` synchronously,
+/// inheriting stdio. Used by `toolr project deps upgrade` to bump a single
+/// package's pin in `tools/uv.lock` before re-syncing.
+pub fn run_uv_lock_upgrade(
+    uv: &UvBinary,
+    tools_dir: &Path,
+    resolved: &ResolvedVenv,
+    package: &str,
+) -> Result<ExitStatus> {
+    let mut cmd = Command::new(&uv.path);
+    cmd.arg("lock")
+        .arg("--upgrade-package")
+        .arg(package)
+        .arg("--project")
+        .arg(tools_dir)
+        .env("UV_PROJECT_ENVIRONMENT", &resolved.venv_dir)
+        .env_remove("VIRTUAL_ENV");
+    if let Some(version) = resolved.config.python_version.as_ref() {
+        cmd.arg("--python").arg(version);
+    }
+    cmd.status()
+        .with_context(|| format!("spawning uv at {}", uv.path.display()))
+}
+
 /// Convenience wrapper that maps a failure to `UvError::SyncFailed`.
 pub fn sync_if_needed(
     uv: &UvBinary,
@@ -267,6 +291,36 @@ mod tests {
         assert!(dump.contains("--python"));
         assert!(dump.contains("3.13"));
         assert!(dump.contains("--project"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_uv_lock_upgrade_passes_package_and_project_args() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let argdump = tmp.path().join("argdump");
+        let stub = tmp.path().join("uv");
+        let mut f = fs::File::create(&stub).unwrap();
+        writeln!(f, "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}", argdump.display()).unwrap();
+        drop(f);
+        fs::set_permissions(&stub, fs::Permissions::from_mode(0o755)).unwrap();
+        let uv = UvBinary {
+            path: stub,
+            version: (0, 4, 0),
+            source: crate::uv::UvSource::Path,
+        };
+
+        let venv = tmp.path().join("venv");
+        let resolved = dummy_resolved(venv);
+        run_uv_lock_upgrade(&uv, tmp.path(), &resolved, "toolr-py")
+            .expect("stub uv should succeed");
+
+        let dump = fs::read_to_string(&argdump).unwrap();
+        assert!(dump.contains("lock"), "args: {dump}");
+        assert!(dump.contains("--upgrade-package"), "args: {dump}");
+        assert!(dump.contains("toolr-py"), "args: {dump}");
+        assert!(dump.contains("--project"), "args: {dump}");
     }
 
     #[test]

--- a/crates/toolr-core/tests/schema_version_lockstep.rs
+++ b/crates/toolr-core/tests/schema_version_lockstep.rs
@@ -1,0 +1,89 @@
+//! CI gate: the Rust `RUNNER_SCHEMA_VERSION` and Python `SCHEMA_VERSION`
+//! constants must match exactly.
+//!
+//! The toolr binary and the toolr-py Python package communicate over a
+//! versioned JSON spec; a mismatch silently produces wrong-on-the-wire
+//! behaviour. We declare the version in two source-of-truth files (one
+//! per language); this test reads both at build time and refuses to
+//! pass when they diverge.
+//!
+//! See `crates/toolr-core/src/execute/spec.rs` for the bump policy.
+
+use std::fs;
+use std::path::PathBuf;
+
+use toolr_core::execute::spec::RUNNER_SCHEMA_VERSION;
+
+#[test]
+fn rust_and_python_schema_versions_match() {
+    let runner_py = locate_runner_py();
+    let text = fs::read_to_string(&runner_py)
+        .unwrap_or_else(|e| panic!("read {}: {e}", runner_py.display()));
+    let python_version = extract_python_schema_version(&text).unwrap_or_else(|| {
+        panic!(
+            "could not find `SCHEMA_VERSION: int = N` in {}",
+            runner_py.display()
+        )
+    });
+
+    assert_eq!(
+        RUNNER_SCHEMA_VERSION, python_version,
+        "schema-version mismatch: Rust RUNNER_SCHEMA_VERSION={RUNNER_SCHEMA_VERSION}, \
+         Python SCHEMA_VERSION={python_version}. Bump both in lock-step per the policy \
+         documented above each constant (see crates/toolr-core/src/execute/spec.rs and \
+         crates/toolr-py/python/toolr/_runner.py).",
+    );
+}
+
+fn locate_runner_py() -> PathBuf {
+    // `CARGO_MANIFEST_DIR` for this crate points at `crates/toolr-core/`.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent() // crates/
+        .expect("toolr-core lives under crates/")
+        .join("toolr-py")
+        .join("python")
+        .join("toolr")
+        .join("_runner.py")
+}
+
+/// Pull the integer literal out of a line like `SCHEMA_VERSION: int = 1`.
+/// Tolerates whitespace variations and trailing comments. Returns `None`
+/// if the line isn't present or the right-hand side isn't a `u32`.
+fn extract_python_schema_version(source: &str) -> Option<u32> {
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with("SCHEMA_VERSION") {
+            continue;
+        }
+        // Drop any trailing `# comment`.
+        let line_no_comment = trimmed.split('#').next().unwrap_or("");
+        // Split on `=` to get the RHS, then trim everything non-digit.
+        let rhs = line_no_comment.split('=').nth(1)?.trim();
+        // The line might be just the type-annotated declaration with no
+        // value (e.g. `SCHEMA_VERSION: int`) — skip those.
+        let digits: String = rhs.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if !digits.is_empty() {
+            return digits.parse().ok();
+        }
+    }
+    None
+}
+
+#[test]
+fn extract_python_schema_version_parses_canonical_form() {
+    let src = "SCHEMA_VERSION: int = 7\n";
+    assert_eq!(extract_python_schema_version(src), Some(7));
+}
+
+#[test]
+fn extract_python_schema_version_tolerates_trailing_comment() {
+    let src = "SCHEMA_VERSION: int = 42  # bumped 2026-01-15\n";
+    assert_eq!(extract_python_schema_version(src), Some(42));
+}
+
+#[test]
+fn extract_python_schema_version_returns_none_for_no_value() {
+    let src = "SCHEMA_VERSION: int\n";
+    assert_eq!(extract_python_schema_version(src), None);
+}

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -124,10 +124,18 @@ def load_spec(path: str | os.PathLike[str]) -> RunnerSpec:
         msg = f"toolr spec file is not valid JSON ({spec_path}): {exc}"
         raise SpecError(msg) from exc
     if spec.schema_version != SCHEMA_VERSION:
+        # The binary and toolr-py must agree on the dispatch wire format.
+        # Direct the user at the exact command that brings the venv back
+        # in sync; mention the pin-down-the-binary escape hatch for the
+        # rarer case where they need to stay on the older toolr-py.
         msg = (
-            f"toolr spec file declares schema_version={spec.schema_version}, "
-            f"but this toolr Python package only supports {SCHEMA_VERSION}. "
-            "Upgrade the toolr package in your tools venv."
+            f"toolr-py in this tools venv speaks schema {SCHEMA_VERSION}, "
+            f"but the toolr binary emitted schema {spec.schema_version}. "
+            "The venv is out of sync with the binary.\n\n"
+            "Run:\n"
+            "  toolr project deps upgrade toolr-py\n\n"
+            "Or pin the toolr binary to a version compatible with "
+            f"toolr-py schema {SCHEMA_VERSION}."
         )
         raise SpecError(msg)
     return spec

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -47,6 +47,35 @@ if TYPE_CHECKING:
 warnings.simplefilter("default", ToolrDeprecationWarning)
 
 SCHEMA_VERSION: int = 1
+"""Schema version of the toolr ↔ toolr-py dispatch protocol.
+
+This constant **must** match ``RUNNER_SCHEMA_VERSION`` in
+``crates/toolr-core/src/execute/spec.rs`` exactly; a CI gate enforces
+the lock-step.
+
+**When to bump**: bump this **and** the Rust counterpart by ``+1``
+together when the two sides would no longer understand each other:
+
+* Add, remove, or rename any field on ``RunnerSpec`` (or any struct it
+  nests) on either side.
+* Change the meaning of any existing field (e.g. string-keyed to
+  int-keyed, units changed, encoding changed).
+* Add, remove, or rename a required field on the manifest JSON that the
+  runner consumes.
+* Change the env-var / stdin / stdout / exit-code conventions between
+  the toolr binary and the Python runner.
+
+**When *not* to bump**:
+
+* Adding a new optional field on either side with a safe default
+  (``serde(default)`` on Rust, ``msgspec`` default on Python) — old
+  spec files still decode and old runners still work against new
+  binaries.
+* Internal refactors that don't change the serialised shape.
+
+Toolr is pre-1.0, so bumps are monotonic integers tied 1:1 to "the
+protocol changed in a way an older peer can't handle".
+"""
 
 _SPEC_ENV_VAR = "TOOLR_SPEC_FILE"
 

--- a/crates/toolr/Cargo.toml
+++ b/crates/toolr/Cargo.toml
@@ -22,6 +22,7 @@ humansize.workspace = true
 pep440_rs.workspace = true
 serde_json.workspace = true
 termimad.workspace = true
+toml.workspace = true
 uuid.workspace = true
 which.workspace = true
 

--- a/crates/toolr/src/cli.rs
+++ b/crates/toolr/src/cli.rs
@@ -276,7 +276,17 @@ pub fn build_command(manifest: &Manifest) -> Command {
                 Command::new("deps")
                     .about("Tools-venv dependency management")
                     .subcommand_required(true)
-                    .subcommand(Command::new("sync").about("Run `uv sync` against tools/")),
+                    .subcommand(Command::new("sync").about("Run `uv sync` against tools/"))
+                    .subcommand(
+                        Command::new("upgrade")
+                            .about("Bump a single package's pin via `uv lock --upgrade-package` + `uv sync`")
+                            .arg(
+                                Arg::new("package")
+                                    .value_name("PACKAGE")
+                                    .required(true)
+                                    .help("Name of the package to upgrade (must already appear in tools/pyproject.toml)"),
+                            ),
+                    ),
             )
             .subcommand(
                 Command::new("venv")

--- a/crates/toolr/src/project.rs
+++ b/crates/toolr/src/project.rs
@@ -13,6 +13,7 @@ pub fn dispatch_project(matches: &ArgMatches) -> Result<ExitCode> {
         Some(("init", init_m)) => project_init(init_m),
         Some(("deps", deps_m)) => match deps_m.subcommand() {
             Some(("sync", _)) => deps_sync(),
+            Some(("upgrade", upgrade_m)) => deps_upgrade(upgrade_m),
             _ => unreachable!("clap enforces subcommand_required"),
         },
         Some(("venv", venv_m)) => match venv_m.subcommand() {
@@ -138,6 +139,111 @@ fn deps_sync() -> Result<ExitCode> {
         uv.version.0, uv.version.1, uv.version.2,
     );
     Ok(ExitCode::SUCCESS)
+}
+
+fn deps_upgrade(matches: &ArgMatches) -> Result<ExitCode> {
+    let package = matches
+        .get_one::<String>("package")
+        .expect("clap marks this required")
+        .as_str();
+
+    let cwd = std::env::current_dir()?;
+    let repo_root = toolr_core::discovery::discover_project_root(&cwd)?;
+    let tools_dir = repo_root.join("tools");
+
+    // Guard: `uv lock --upgrade-package` silently no-ops if the package
+    // isn't part of the dependency graph. Catch typos and "I thought I
+    // had this declared" cases up front so the user sees a real error.
+    let pyproject = tools_dir.join("pyproject.toml");
+    if !pyproject_declares_dependency(&pyproject, package)? {
+        anyhow::bail!(
+            "package `{package}` is not declared in {} — add it to `[project] dependencies` first",
+            pyproject.display(),
+        );
+    }
+
+    let consent = toolr_core::uv::install::ConsentMode::from_env();
+    let (resolved, uv) =
+        toolr_core::project::ensure_venv_ready(&cwd, consent, /*force_sync=*/ false)?;
+
+    let lock_status = toolr_core::venv::run_uv_lock_upgrade(&uv, &tools_dir, &resolved, package)?;
+    if !lock_status.success() {
+        anyhow::bail!(
+            "`uv lock --upgrade-package {package}` failed with exit code {:?}",
+            lock_status.code(),
+        );
+    }
+
+    let sync_status = toolr_core::venv::run_uv_sync(&uv, &tools_dir, &resolved)?;
+    if !sync_status.success() {
+        anyhow::bail!(
+            "`uv sync` after upgrade failed with exit code {:?}",
+            sync_status.code(),
+        );
+    }
+
+    println!(
+        "toolr: upgraded `{package}` in {}",
+        resolved.venv_dir.display(),
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Light TOML inspection: does `[project].dependencies` (or any
+/// `[project.optional-dependencies.*]` list) name `package`?
+/// We only need to confirm presence — version pin / extras are uv's
+/// problem from here on.
+fn pyproject_declares_dependency(pyproject: &Path, package: &str) -> Result<bool> {
+    let text = std::fs::read_to_string(pyproject)
+        .map_err(|e| anyhow::anyhow!("reading {}: {e}", pyproject.display()))?;
+    let parsed: toml::Value = toml::from_str(&text)
+        .map_err(|e| anyhow::anyhow!("parsing {}: {e}", pyproject.display()))?;
+
+    let mut found = false;
+    if let Some(deps) = parsed
+        .get("project")
+        .and_then(|p| p.get("dependencies"))
+        .and_then(|v| v.as_array())
+    {
+        for dep in deps {
+            if let Some(s) = dep.as_str() {
+                if dep_name_matches(s, package) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+    }
+    if !found {
+        if let Some(opt) = parsed
+            .get("project")
+            .and_then(|p| p.get("optional-dependencies"))
+            .and_then(|v| v.as_table())
+        {
+            for (_extra, list) in opt {
+                if let Some(deps) = list.as_array() {
+                    for dep in deps {
+                        if let Some(s) = dep.as_str() {
+                            if dep_name_matches(s, package) {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(found)
+}
+
+/// PEP 508-light: `foo`, `foo[bar]`, `foo>=1.2`, `foo ==1.2; python_version < "3.13"`
+/// all parse to the name `foo`. We just peel the first identifier-ish token.
+fn dep_name_matches(spec: &str, package: &str) -> bool {
+    let name_end = spec
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '-' && c != '.')
+        .unwrap_or(spec.len());
+    spec[..name_end].eq_ignore_ascii_case(package)
 }
 
 fn venv_path() -> Result<ExitCode> {
@@ -289,6 +395,60 @@ mod tests {
         let bin = std::path::Path::new("/venv/bin");
         let result = prepend_to_path(bin, None).unwrap();
         assert_eq!(result, bin.as_os_str());
+    }
+
+    #[test]
+    fn dep_name_matches_strips_version_extras_and_markers() {
+        assert!(dep_name_matches("toolr-py", "toolr-py"));
+        assert!(dep_name_matches("toolr-py>=0.11", "toolr-py"));
+        assert!(dep_name_matches("toolr-py[extra]", "toolr-py"));
+        assert!(dep_name_matches("toolr-py==0.11.2; python_version < \"3.13\"", "toolr-py"));
+        assert!(!dep_name_matches("other", "toolr-py"));
+    }
+
+    #[test]
+    fn dep_name_matches_is_case_insensitive() {
+        assert!(dep_name_matches("Toolr-Py>=0.11", "toolr-py"));
+    }
+
+    #[test]
+    fn pyproject_declares_dependency_finds_direct_dep() {
+        let tmp = TempDir::new().unwrap();
+        let pyproject = tmp.path().join("pyproject.toml");
+        fs::write(
+            &pyproject,
+            r#"[project]
+name = "tools"
+dependencies = [
+    "toolr-py>=0.11",
+    "requests",
+]
+"#,
+        )
+        .unwrap();
+        assert!(pyproject_declares_dependency(&pyproject, "toolr-py").unwrap());
+        assert!(pyproject_declares_dependency(&pyproject, "requests").unwrap());
+        assert!(!pyproject_declares_dependency(&pyproject, "absent").unwrap());
+    }
+
+    #[test]
+    fn pyproject_declares_dependency_finds_optional_dep() {
+        let tmp = TempDir::new().unwrap();
+        let pyproject = tmp.path().join("pyproject.toml");
+        fs::write(
+            &pyproject,
+            r#"[project]
+name = "tools"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest", "ruff"]
+"#,
+        )
+        .unwrap();
+        assert!(pyproject_declares_dependency(&pyproject, "pytest").unwrap());
+        assert!(pyproject_declares_dependency(&pyproject, "ruff").unwrap());
+        assert!(!pyproject_declares_dependency(&pyproject, "absent").unwrap());
     }
 
     #[test]

--- a/crates/toolr/tests/project_deps_upgrade.rs
+++ b/crates/toolr/tests/project_deps_upgrade.rs
@@ -1,0 +1,90 @@
+//! Integration tests for `toolr project deps upgrade <pkg>`.
+//!
+//! These tests don't actually run uv — they exercise the input-validation
+//! and discovery paths that fire before the uv invocation, where the
+//! command surface is most likely to regress.
+
+use std::fs;
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+fn cargo_bin() -> Command {
+    Command::cargo_bin("toolr").unwrap()
+}
+
+/// Requesting a package that isn't declared in tools/pyproject.toml fails
+/// loudly instead of silently no-opping inside uv.
+#[test]
+fn upgrade_errors_when_package_not_declared() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir(tmp.path().join("tools")).unwrap();
+    fs::write(
+        tmp.path().join("tools/pyproject.toml"),
+        r#"[project]
+name = "tools"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "requests",
+]
+
+[tool.toolr]
+venv-location = "cache"
+"#,
+    )
+    .unwrap();
+
+    let output = cargo_bin()
+        .current_dir(tmp.path())
+        .args(["project", "deps", "upgrade", "nonexistent-package"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not declared"),
+        "expected validation error, stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("nonexistent-package"),
+        "stderr should name the package, stderr was:\n{stderr}"
+    );
+}
+
+/// `toolr project deps upgrade` with no package name fails clap arg parsing
+/// (not a runtime error).
+#[test]
+fn upgrade_requires_a_package_argument() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir(tmp.path().join("tools")).unwrap();
+    fs::write(tmp.path().join("tools/pyproject.toml"), "[project]\nname=\"tools\"\n").unwrap();
+
+    let output = cargo_bin()
+        .current_dir(tmp.path())
+        .args(["project", "deps", "upgrade"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("PACKAGE") || stderr.contains("required") || stderr.contains("usage"),
+        "expected clap usage error, stderr was:\n{stderr}"
+    );
+}
+
+/// `toolr project deps upgrade --help` lists the command and the PACKAGE
+/// positional, with a meaningful one-liner.
+#[test]
+fn upgrade_help_lists_package_positional() {
+    let output = cargo_bin()
+        .args(["project", "deps", "upgrade", "--help"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("PACKAGE"), "help missing PACKAGE: {stdout}");
+    assert!(stdout.contains("upgrade-package"), "help should reference the underlying uv verb: {stdout}");
+}

--- a/tests/runner/test_runner_coverage.py
+++ b/tests/runner/test_runner_coverage.py
@@ -159,8 +159,14 @@ def test_load_spec_type_mismatch_raises_schema_validation(tmp_path: Path, make_s
 
 def test_load_spec_rejects_unknown_schema_version(make_spec_file: Callable[..., Path]) -> None:
     spec_path = make_spec_file(schema_version=SCHEMA_VERSION + 99)
-    with pytest.raises(SpecError, match=r"schema_version=\d+"):
+    with pytest.raises(SpecError) as exc_info:
         load_spec(spec_path)
+    msg = str(exc_info.value)
+    # The error must tell the user exactly which command to run, and must
+    # name both schema versions so they understand which side is stale.
+    assert "toolr project deps upgrade toolr-py" in msg, msg
+    assert f"schema {SCHEMA_VERSION}" in msg, msg
+    assert f"schema {SCHEMA_VERSION + 99}" in msg, msg
 
 
 def test_load_spec_round_trip_preserves_fields(make_spec_file: Callable[..., Path]) -> None:


### PR DESCRIPTION
## Summary

Tightens the dispatch protocol contract between the `toolr` binary and `toolr-py` by making the existing `SCHEMA_VERSION` handshake actionable end-to-end.

The handshake itself already exists (`crates/toolr-core/src/execute/spec.rs::RUNNER_SCHEMA_VERSION` and `crates/toolr-py/python/toolr/_runner.py::SCHEMA_VERSION`); this PR fills in the missing pieces:

- **New verb:** `toolr project deps upgrade <pkg>` bumps a single package's pin in `tools/uv.lock` (`uv lock --upgrade-package <pkg>` + `uv sync`). Pre-validates that the package is declared in `tools/pyproject.toml` so typos surface as a real error instead of a silent uv no-op.
- **Better mismatch error:** the runner now names both schema versions and points at the exact `toolr project deps upgrade toolr-py` command (plus the "pin the binary" escape hatch). Previously it said only "Upgrade the toolr package in your tools venv".
- **Bump policy as code:** the doc-comment above both constants lists exactly which changes require a bump and which don't, so future contributors don't have to guess from context.
- **CI gate:** new integration test in `crates/toolr-core/tests/schema_version_lockstep.rs` reads `_runner.py`, parses out the literal, and asserts equality with the Rust constant. Refuses to pass when they diverge.

Discussion that led to this design is in the conversation that produced PR #227; key decisions were to **not** auto-install toolr-py (avoids fighting uv's destructive-sync model) and to rely on dual-release lock-step + protocol handshake instead.

## Test plan

- [x] `cargo test --workspace` — all 119 + ~400 tests pass
- [x] `cargo test -p toolr-core --test schema_version_lockstep` — new test passes and would fail if either constant drifted
- [x] `cargo test -p toolr --test project_deps_upgrade` — three new integration tests cover help, missing-package, and missing-argument cases
- [x] `uv run pytest tests/runner/test_runner_coverage.py::test_load_spec_rejects_unknown_schema_version` — updated Python test asserts the new error message names the upgrade command and both schema versions
- [x] Manual: ran the upgrade command against a scratch project and confirmed the validator catches typos in the package name
- [ ] Reviewer: confirm the new doc-comments on `RUNNER_SCHEMA_VERSION` / `SCHEMA_VERSION` cover every kind of change you'd expect to gate on a bump

_claude --resume 8723fcd0-674e-48e7-9241-d3e1ce07313c_