### PR TITLE
argparse: skip empty files, warn on dups, complete through dispatchers

### DIFF
--- a/crates/toolr-core/src/argparse/attach.rs
+++ b/crates/toolr-core/src/argparse/attach.rs
@@ -72,6 +72,47 @@ pub fn validate_no_collisions(
     Ok(())
 }
 
+/// Drop intra-source duplicates from each parent's child list, returning
+/// a warning string per duplicate that was discarded.
+///
+/// Two files matched by the same source can share a stem when an app
+/// layout puts a command of the same name in multiple Django apps, or
+/// when a glob is too broad. The historical behaviour was to silently
+/// pass them through to clap, which then panicked at startup with a
+/// "command name is duplicated" assert. Keeping the first occurrence
+/// and warning preserves the build while telling the user exactly which
+/// child name collided so they can tighten their scan glob or rename
+/// one of the files.
+///
+/// Cross-source collisions remain a hard error — they're a structural
+/// configuration problem that needs the user's resolution before any
+/// build can produce a stable manifest. See [`validate_no_collisions`].
+pub fn dedup_intra_source(
+    children_by_parent: &mut HashMap<String, Vec<Command>>,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for (parent, children) in children_by_parent.iter_mut() {
+        let mut seen: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        let original = std::mem::take(children);
+        for child in original {
+            let source = child.dispatched_from.clone().unwrap_or_default();
+            let key = (child.name.clone(), source.clone());
+            if seen.contains(&key) {
+                warnings.push(format!(
+                    "argparse source {source:?} grafted child {:?} multiple times under {parent:?}; \
+                     keeping the first occurrence — tighten the scan glob or rename one of the files",
+                    child.name
+                ));
+                continue;
+            }
+            seen.insert(key);
+            children.push(child);
+        }
+    }
+    warnings
+}
+
 fn closest_parent_hint(
     target: &str,
     candidates: &std::collections::BTreeSet<&str>,
@@ -202,6 +243,65 @@ mod tests {
             AttachError::Collision { name, .. } => assert_eq!(name, "migrate"),
             other => panic!("unexpected error variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn dedup_intra_source_keeps_first_and_warns() {
+        // Two files with the same stem (`sync.py` in two Django apps)
+        // both grafted under one parent from the same source. The
+        // pre-fix behaviour would let clap explode at startup. Now we
+        // keep the first and warn loudly.
+        let cmd = |module: &str| Command {
+            name: "sync".into(),
+            group: "django".into(),
+            module: module.into(),
+            function: "django".into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: Some("argparse:django".into()),
+            is_dispatcher: false,
+        };
+        let mut children: HashMap<String, Vec<Command>> = HashMap::from([(
+            "django".into(),
+            vec![cmd("apps.billing"), cmd("apps.invoicing"), cmd("apps.subs")],
+        )]);
+        let warnings = dedup_intra_source(&mut children);
+        assert_eq!(children["django"].len(), 1);
+        assert_eq!(children["django"][0].module, "apps.billing", "first wins");
+        assert_eq!(warnings.len(), 2, "one warning per discarded duplicate");
+        for w in &warnings {
+            assert!(w.contains("sync"), "warning {w:?} should name the duplicate");
+            assert!(w.contains("django"), "warning {w:?} should name the parent");
+            assert!(
+                w.contains("argparse:django"),
+                "warning {w:?} should name the source"
+            );
+        }
+    }
+
+    #[test]
+    fn dedup_intra_source_is_a_noop_when_no_duplicates() {
+        let mk = |name: &str| Command {
+            name: name.into(),
+            group: "django".into(),
+            module: format!("apps.{name}"),
+            function: "django".into(),
+            summary: String::new(),
+            description: String::new(),
+            arguments: vec![],
+            imports: vec![],
+            origin: Origin::Static,
+            dispatched_from: Some("argparse:django".into()),
+            is_dispatcher: false,
+        };
+        let mut children: HashMap<String, Vec<Command>> =
+            HashMap::from([("django".into(), vec![mk("sync"), mk("migrate")])]);
+        let warnings = dedup_intra_source(&mut children);
+        assert_eq!(children["django"].len(), 2);
+        assert!(warnings.is_empty());
     }
 
     #[test]

--- a/crates/toolr-core/src/argparse/mod.rs
+++ b/crates/toolr-core/src/argparse/mod.rs
@@ -75,6 +75,20 @@ pub fn run_for_project(
             out.entry(parent).or_default().extend(children);
         }
     }
+    // Intra-source duplicates (e.g. multiple Django apps each shipping a
+    // `sync.py` swept up by the same glob) get a warning and the first
+    // occurrence wins. Cross-source collisions remain a hard error.
+    let warnings = attach::dedup_intra_source(&mut out);
+    for w in &warnings {
+        eprintln!("toolr: warning: {w}");
+    }
+    // Recompute `dispatchers` to drop any parent whose only child was a
+    // dedup victim (rare in practice but keeps the bookkeeping honest).
+    dispatchers.retain(|p| {
+        out.get(p)
+            .map(|children| !children.is_empty())
+            .unwrap_or(false)
+    });
     attach::validate_no_collisions(&out)?;
     Ok(GraftResult {
         children_by_parent: out,

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -422,7 +422,19 @@ pub fn scan_block_paths(
             }
         };
         match scan_source(&stem, &text) {
-            Ok(cmd) => out.push(cmd),
+            Ok(cmd) => {
+                // A file with no `add_argument` calls is almost always a
+                // helper module (`_setup_*.py`, `__init__.py`, shared
+                // utilities) that happens to live inside the scan glob.
+                // Grafting it as a child would either collide on common
+                // stems (e.g. multiple `__init__.py` files under one
+                // parent — a clap startup panic) or surface a no-arg
+                // ghost command the user never wrote. Skip silently.
+                if cmd.arguments.is_empty() {
+                    continue;
+                }
+                out.push(cmd);
+            }
             Err(ScanError::Parse { message, .. }) => {
                 let mut placeholder = ScannedCommand {
                     name: stem,
@@ -623,5 +635,49 @@ def add_arguments(self, parser):
         // failure recorded in its `warnings` field — confirm at least one ScannedCommand
         // carries a warning mentioning "broken".
         assert!(scanned.iter().any(|s| s.warnings.iter().any(|w| w.contains("broken"))));
+    }
+
+    #[test]
+    fn scan_paths_skips_files_with_no_add_argument_calls() {
+        // Regression: helper modules (`__init__.py`, `_setup_*.py`, shared
+        // utilities) parse fine but contain zero `add_argument` calls.
+        // They must not become commands — multiple `__init__.py` files
+        // under one parent would collide on the stem and crash clap with
+        // a "command name is duplicated" panic at startup.
+        let project = tempfile::tempdir().unwrap();
+        let cmds = project.path().join("apps/x/management/commands");
+        std::fs::create_dir_all(&cmds).unwrap();
+
+        std::fs::write(
+            cmds.join("real_command.py"),
+            "def add_arguments(self, parser):\n    parser.add_argument('app_label')\n",
+        )
+        .unwrap();
+        // `__init__.py` parses fine but has no add_argument calls.
+        std::fs::write(cmds.join("__init__.py"), "# package marker\n").unwrap();
+        // `_setup_paddle_utils.py` — a private helper with no add_argument calls.
+        std::fs::write(
+            cmds.join("_setup_paddle_utils.py"),
+            "def configure(parser):\n    pass\n",
+        )
+        .unwrap();
+
+        let scanned = scan_block_paths(
+            project.path(),
+            &["apps/*/management/commands/*.py".to_string()],
+        )
+        .unwrap();
+
+        let names: std::collections::BTreeSet<_> =
+            scanned.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains("real_command"), "real command must scan");
+        assert!(
+            !names.contains("__init__"),
+            "__init__.py has no add_argument calls — must not become a command",
+        );
+        assert!(
+            !names.contains("_setup_paddle_utils"),
+            "helper module has no add_argument calls — must not become a command",
+        );
     }
 }

--- a/crates/toolr-core/src/complete/engine.rs
+++ b/crates/toolr-core/src/complete/engine.rs
@@ -118,6 +118,21 @@ fn classify<'a>(manifest: &'a Manifest, tokens: &[String]) -> Slot<'a> {
     // Everything after the command name is the argument zone.
     let arg_tokens = &committed[cursor + 1..];
 
+    if command.is_dispatcher {
+        return classify_dispatcher(manifest, command, &group_full_path, arg_tokens, prefix);
+    }
+
+    classify_leaf_args(command, arg_tokens, prefix)
+}
+
+/// Token-classification for a regular (non-dispatcher) leaf command.
+/// Factored out so the dispatcher branch can reuse it after recursing
+/// into a chosen grafted child.
+fn classify_leaf_args<'a>(
+    command: &'a Command,
+    arg_tokens: &[String],
+    prefix: String,
+) -> Slot<'a> {
     // If the previous committed token was a `--flag`, we're completing
     // that flag's value.
     if let Some(prev) = arg_tokens.last() {
@@ -171,6 +186,116 @@ fn classify<'a>(manifest: &'a Manifest, tokens: &[String]) -> Slot<'a> {
     }
 
     Slot::None
+}
+
+/// Token-classification for a dispatcher command: the dispatcher's
+/// children are grafted at its dotted path (`<group>.<name>`), so
+/// completing the "next positional" against a dispatcher means
+/// suggesting a child command name. Once a child is chosen, completion
+/// re-enters that child as a regular leaf.
+fn classify_dispatcher<'a>(
+    manifest: &'a Manifest,
+    command: &'a Command,
+    group_full_path: &str,
+    arg_tokens: &[String],
+    prefix: String,
+) -> Slot<'a> {
+    let dispatcher_path = if group_full_path.is_empty() {
+        command.name.clone()
+    } else {
+        format!("{}.{}", group_full_path, command.name)
+    };
+
+    // Dispatcher-flag completions (`--flag <TAB>`, `--<TAB>`) reuse the
+    // leaf logic against the dispatcher's own arguments.
+    if let Some(prev) = arg_tokens.last() {
+        if let Some(flag_name) = prev.strip_prefix("--") {
+            if let Some(arg) = command.arguments.iter().find(|a| a.name == flag_name) {
+                if !matches!(arg.kind, ArgumentKind::Flag) {
+                    return Slot::FlagValue {
+                        argument: arg,
+                        prefix,
+                    };
+                }
+            }
+        }
+    }
+    if prefix.starts_with("--") || prefix == "-" {
+        return Slot::Flag { command, prefix };
+    }
+
+    // Positional slot. Index 0 is occupied by the child command name;
+    // index >= 1 means the user has chosen a child and we recurse into
+    // that child's argument zone.
+    let positional_index = count_positionals_consumed(command, arg_tokens);
+    if positional_index == 0 {
+        return Slot::Command {
+            group: dispatcher_path,
+            prefix,
+        };
+    }
+
+    let Some(child_name) = first_positional_value(command, arg_tokens) else {
+        return Slot::None;
+    };
+    let Some(child) = manifest
+        .commands
+        .iter()
+        .find(|c| c.group == dispatcher_path && c.name == child_name)
+    else {
+        return Slot::None;
+    };
+    let child_arg_tokens = drop_through_first_positional(command, arg_tokens);
+    classify_leaf_args(child, &child_arg_tokens, prefix)
+}
+
+/// Return the first positional value in `arg_tokens`, skipping flags
+/// and their values per the command's argument schema. Mirrors the
+/// counting logic in [`count_positionals_consumed`].
+fn first_positional_value<'a>(command: &Command, arg_tokens: &'a [String]) -> Option<&'a str> {
+    let mut i = 0usize;
+    while i < arg_tokens.len() {
+        let t = &arg_tokens[i];
+        if let Some(flag_name) = t.strip_prefix("--") {
+            if let Some(arg) = command.arguments.iter().find(|a| a.name == flag_name) {
+                if matches!(arg.kind, ArgumentKind::Flag) {
+                    i += 1;
+                    continue;
+                }
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        return Some(t.as_str());
+    }
+    None
+}
+
+/// Return the slice of `arg_tokens` that comes after the first
+/// positional value (flag/value pairs in between are preserved).
+fn drop_through_first_positional(command: &Command, arg_tokens: &[String]) -> Vec<String> {
+    let mut i = 0usize;
+    while i < arg_tokens.len() {
+        let t = &arg_tokens[i];
+        if let Some(flag_name) = t.strip_prefix("--") {
+            if let Some(arg) = command.arguments.iter().find(|a| a.name == flag_name) {
+                if matches!(arg.kind, ArgumentKind::Flag) {
+                    i += 1;
+                    continue;
+                }
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        // i points at the first positional; everything after it belongs
+        // to the child's arg zone.
+        return arg_tokens[i + 1..].to_vec();
+    }
+    Vec::new()
 }
 
 fn count_positionals_consumed(command: &Command, arg_tokens: &[String]) -> usize {

--- a/crates/toolr-core/src/complete/engine.rs
+++ b/crates/toolr-core/src/complete/engine.rs
@@ -185,6 +185,21 @@ fn classify_leaf_args<'a>(
         }
     }
 
+    // No positional candidate to suggest. If the command has any flags,
+    // fall back to flag-name completion so the user has SOMETHING to
+    // Tab into — particularly useful for argparse-style commands whose
+    // entire surface is `--flag value` pairs (no positionals at all),
+    // and for the trailing position past every fixed positional.
+    let has_flags = command.arguments.iter().any(|a| {
+        !matches!(
+            a.kind,
+            ArgumentKind::Positional | ArgumentKind::VarPositional
+        )
+    });
+    if has_flags {
+        return Slot::Flag { command, prefix };
+    }
+
     Slot::None
 }
 
@@ -206,8 +221,29 @@ fn classify_dispatcher<'a>(
         format!("{}.{}", group_full_path, command.name)
     };
 
-    // Dispatcher-flag completions (`--flag <TAB>`, `--<TAB>`) reuse the
-    // leaf logic against the dispatcher's own arguments.
+    // If the user has already committed a positional value (the child
+    // command name), recurse fully into that child's arg zone — flags,
+    // flag values, and positional completions from here on belong to
+    // the *child*, not the dispatcher. Checking this first prevents
+    // the dispatcher's flag-name fallback from masking the child's.
+    let positional_index = count_positionals_consumed(command, arg_tokens);
+    if positional_index >= 1 {
+        let Some(child_name) = first_positional_value(command, arg_tokens) else {
+            return Slot::None;
+        };
+        let Some(child) = manifest
+            .commands
+            .iter()
+            .find(|c| c.group == dispatcher_path && c.name == child_name)
+        else {
+            return Slot::None;
+        };
+        let child_arg_tokens = drop_through_first_positional(command, arg_tokens);
+        return classify_leaf_args(child, &child_arg_tokens, prefix);
+    }
+
+    // No child chosen yet — completion targets the dispatcher's own
+    // surface (`--flag <TAB>`, `--<TAB>`) or the child-name slot.
     if let Some(prev) = arg_tokens.last() {
         if let Some(flag_name) = prev.strip_prefix("--") {
             if let Some(arg) = command.arguments.iter().find(|a| a.name == flag_name) {
@@ -224,29 +260,10 @@ fn classify_dispatcher<'a>(
         return Slot::Flag { command, prefix };
     }
 
-    // Positional slot. Index 0 is occupied by the child command name;
-    // index >= 1 means the user has chosen a child and we recurse into
-    // that child's argument zone.
-    let positional_index = count_positionals_consumed(command, arg_tokens);
-    if positional_index == 0 {
-        return Slot::Command {
-            group: dispatcher_path,
-            prefix,
-        };
+    Slot::Command {
+        group: dispatcher_path,
+        prefix,
     }
-
-    let Some(child_name) = first_positional_value(command, arg_tokens) else {
-        return Slot::None;
-    };
-    let Some(child) = manifest
-        .commands
-        .iter()
-        .find(|c| c.group == dispatcher_path && c.name == child_name)
-    else {
-        return Slot::None;
-    };
-    let child_arg_tokens = drop_through_first_positional(command, arg_tokens);
-    classify_leaf_args(child, &child_arg_tokens, prefix)
 }
 
 /// Return the first positional value in `arg_tokens`, skipping flags

--- a/crates/toolr-core/src/complete/tests.rs
+++ b/crates/toolr-core/src/complete/tests.rs
@@ -398,6 +398,111 @@ fn dispatcher_recurses_through_parent_flag_value_pair() {
     assert_eq!(out, vec!["all".to_string(), "stale".to_string()]);
 }
 
+fn flags_only_child_fixture() -> Manifest {
+    // Mirrors the dashtastic `delete_companyuser` shape: every grafted
+    // arg is `--flag value` style (no positionals at all). Tab on an
+    // empty prefix after the child name must surface the available
+    // flag names rather than returning nothing.
+    let opt = |name: &str, help: &str| Argument {
+        name: name.into(),
+        kind: ArgumentKind::Optional,
+        help: help.into(),
+        default: None,
+        type_annotation: Some("int".into()),
+        resolved_type: None,
+        path_constraints: None,
+        metadata: crate::manifest::ArgMetadata::default(),
+        allowed_values: vec![],
+    };
+    Manifest {
+        schema_version: SCHEMA_VERSION,
+        static_hash: "h".into(),
+        dynamic_hash: String::new(),
+        groups: vec![Group {
+            name: "jenkins".into(),
+            title: "Jenkins".into(),
+            description: String::new(),
+            parent: None,
+            origin: Origin::Static,
+        }],
+        commands: vec![
+            Command {
+                name: "job".into(),
+                group: "jenkins".into(),
+                module: "tools.job".into(),
+                function: "job".into(),
+                summary: "Dispatcher.".into(),
+                description: String::new(),
+                arguments: vec![],
+                imports: vec![],
+                origin: Origin::Static,
+                dispatched_from: None,
+                is_dispatcher: true,
+            },
+            Command {
+                name: "delete_companyuser".into(),
+                group: "jenkins.job".into(),
+                module: "tools.job".into(),
+                function: "job".into(),
+                summary: "Delete a CompanyUser.".into(),
+                description: String::new(),
+                arguments: vec![
+                    opt("company-id", "Company ID"),
+                    opt("user-ids", "User IDs"),
+                    opt("user-emails", "User emails"),
+                ],
+                imports: vec![],
+                origin: Origin::Static,
+                dispatched_from: Some("argparse:django".into()),
+                is_dispatcher: false,
+            },
+        ],
+    }
+}
+
+#[test]
+fn child_with_only_optional_flags_offers_flags_on_empty_prefix() {
+    // Regression for dashtastic `toolr jenkins job delete_companyuser <TAB>`:
+    // the child has no positional schema, so the engine used to return
+    // `Slot::None` and the shell saw nothing. Now we fall back to the
+    // child's flag names.
+    let out = serve_completions(
+        &flags_only_child_fixture(),
+        &tokens(&["jenkins", "job", "delete_companyuser", ""]),
+    );
+    assert_eq!(
+        out,
+        vec![
+            "--company-id".to_string(),
+            "--user-emails".to_string(),
+            "--user-ids".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn child_flag_fallback_filters_by_prefix() {
+    // `toolr jenkins job delete_companyuser --user<TAB>` must filter
+    // to flags starting with `--user`.
+    let out = serve_completions(
+        &flags_only_child_fixture(),
+        &tokens(&["jenkins", "job", "delete_companyuser", "--user"]),
+    );
+    assert_eq!(
+        out,
+        vec!["--user-emails".to_string(), "--user-ids".to_string()]
+    );
+}
+
+#[test]
+fn leaf_with_only_flags_offers_flags_on_empty_prefix() {
+    // The fallback should also apply to regular (non-dispatcher) leaf
+    // commands. `toolr ci hello <TAB>` where `hello` has only `--name`
+    // should suggest `--name`, not nothing.
+    let out = serve_completions(&fixture(), &tokens(&["ci", "hello", ""]));
+    assert_eq!(out, vec!["--name".to_string()]);
+}
+
 use crate::complete::{ResolvedManifest, resolve_manifest_at_tab};
 use crate::manifest::{write_manifest};
 use tempfile::TempDir;

--- a/crates/toolr-core/src/complete/tests.rs
+++ b/crates/toolr-core/src/complete/tests.rs
@@ -250,6 +250,154 @@ fn nested_command_completion_filters_by_prefix() {
     assert_eq!(out, vec!["start".to_string()]);
 }
 
+fn dispatcher_fixture() -> Manifest {
+    // Mirrors the dashtastic shape: `jenkins job` is a dispatcher with
+    // a couple of its own flags (`--dry-run`, `--cpu`) plus grafted
+    // children at `group = "jenkins.job"`.
+    let str_arg = |name: &str, kind, default: Option<&str>, values: &[&str]| Argument {
+        name: name.into(),
+        kind,
+        help: String::new(),
+        default: default.map(str::to_string),
+        type_annotation: Some("str".into()),
+        resolved_type: None,
+        path_constraints: None,
+        metadata: crate::manifest::ArgMetadata::default(),
+        allowed_values: values.iter().map(|s| (*s).to_string()).collect(),
+    };
+    Manifest {
+        schema_version: SCHEMA_VERSION,
+        static_hash: "h".into(),
+        dynamic_hash: String::new(),
+        groups: vec![Group {
+            name: "jenkins".into(),
+            title: "Jenkins".into(),
+            description: String::new(),
+            parent: None,
+            origin: Origin::Static,
+        }],
+        commands: vec![
+            // The dispatcher itself — its `is_dispatcher` flag is what
+            // tells the completion engine to look for grafted children
+            // at `group == "jenkins.job"`.
+            Command {
+                name: "job".into(),
+                group: "jenkins".into(),
+                module: "tools.job".into(),
+                function: "job".into(),
+                summary: "Trigger Jenkins.".into(),
+                description: String::new(),
+                arguments: vec![
+                    str_arg("cpu", ArgumentKind::Optional, Some("200m"), &[]),
+                    str_arg("dry-run", ArgumentKind::Flag, None, &[]),
+                ],
+                imports: vec![],
+                origin: Origin::Static,
+                dispatched_from: None,
+                is_dispatcher: true,
+            },
+            // Two grafted children under `jenkins.job`. The leaf
+            // command's own argument (a positional with allowed values)
+            // is what we expect to see after the child name is chosen.
+            Command {
+                name: "delete_orphans".into(),
+                group: "jenkins.job".into(),
+                module: "tools.job".into(),
+                function: "job".into(),
+                summary: "Delete orphans.".into(),
+                description: String::new(),
+                arguments: vec![str_arg(
+                    "scope",
+                    ArgumentKind::Positional,
+                    None,
+                    &["all", "stale"],
+                )],
+                imports: vec![],
+                origin: Origin::Static,
+                dispatched_from: Some("argparse:django".into()),
+                is_dispatcher: false,
+            },
+            Command {
+                name: "delete_stale".into(),
+                group: "jenkins.job".into(),
+                module: "tools.job".into(),
+                function: "job".into(),
+                summary: "Delete stale entries.".into(),
+                description: String::new(),
+                arguments: vec![],
+                imports: vec![],
+                origin: Origin::Static,
+                dispatched_from: Some("argparse:django".into()),
+                is_dispatcher: false,
+            },
+        ],
+    }
+}
+
+#[test]
+fn dispatcher_completion_lists_grafted_children() {
+    // Regression for the dashtastic case: `toolr jenkins job <TAB>`
+    // returned nothing even though `--help` showed the children.
+    let out = serve_completions(&dispatcher_fixture(), &tokens(&["jenkins", "job", ""]));
+    assert_eq!(
+        out,
+        vec!["delete_orphans".to_string(), "delete_stale".to_string()]
+    );
+}
+
+#[test]
+fn dispatcher_completion_filters_children_by_prefix() {
+    let out = serve_completions(&dispatcher_fixture(), &tokens(&["jenkins", "job", "delete_"]));
+    assert_eq!(
+        out,
+        vec!["delete_orphans".to_string(), "delete_stale".to_string()]
+    );
+}
+
+#[test]
+fn dispatcher_flag_prefix_lists_dispatcher_flags_not_children() {
+    // `toolr jenkins job --<TAB>` must offer the dispatcher's own
+    // flags, not the grafted child names.
+    let out = serve_completions(&dispatcher_fixture(), &tokens(&["jenkins", "job", "--"]));
+    assert_eq!(out, vec!["--cpu".to_string(), "--dry-run".to_string()]);
+}
+
+#[test]
+fn dispatcher_completion_offers_children_after_parent_flag() {
+    // `toolr jenkins job --dry-run <TAB>` should still suggest children
+    // — the parent flag was consumed but no child has been picked yet.
+    let out = serve_completions(
+        &dispatcher_fixture(),
+        &tokens(&["jenkins", "job", "--dry-run", ""]),
+    );
+    assert_eq!(
+        out,
+        vec!["delete_orphans".to_string(), "delete_stale".to_string()]
+    );
+}
+
+#[test]
+fn dispatcher_recurses_into_child_args_once_child_is_chosen() {
+    // `toolr jenkins job delete_orphans <TAB>` — the child has a
+    // positional with allowed values; surface them.
+    let out = serve_completions(
+        &dispatcher_fixture(),
+        &tokens(&["jenkins", "job", "delete_orphans", ""]),
+    );
+    assert_eq!(out, vec!["all".to_string(), "stale".to_string()]);
+}
+
+#[test]
+fn dispatcher_recurses_through_parent_flag_value_pair() {
+    // `toolr jenkins job --cpu 200m delete_orphans <TAB>` must skip
+    // both `--cpu` and its value when locating the chosen child.
+    let out = serve_completions(
+        &dispatcher_fixture(),
+        &tokens(&["jenkins", "job", "--cpu", "200m", "delete_orphans", ""]),
+    );
+    assert_eq!(out, vec!["all".to_string(), "stale".to_string()]);
+}
+
 use crate::complete::{ResolvedManifest, resolve_manifest_at_tab};
 use crate::manifest::{write_manifest};
 use tempfile::TempDir;


### PR DESCRIPTION
## Summary

Three related fixes for the cases where a scan glob picks up files clap can't handle, plus completion through dispatchers.

### 1. Skip files with no `add_argument` calls

`scan_source` emitted a `ScannedCommand` for **every** file matched by the glob, regardless of whether the file actually contained any `add_argument` calls. `__init__.py` and private helpers (`_setup_*.py`) parse fine but contain zero add_argument calls — they got registered as ghost commands with empty argument lists.

When multiple `__init__.py` files were swept up by one glob (one per Django app under `web/**/management/commands/*.py`), they collided on the stem `__init__` and crashed clap at startup:

```
thread 'main' panicked at clap_builder-4.6.0/src/builder/debug_asserts.rs:353:9:
Command job: command name `__init__` is duplicated
```

Fix: in `scan_block_paths`, when a file parses successfully but produces no arguments, drop it silently. Files that fail to parse still surface as warning placeholders.

### 2. Complain loudly on intra-source duplicates

`validate_no_collisions` already errored on cross-source name clashes but silently passed intra-source duplicates through to clap. Add `dedup_intra_source` that keeps the first occurrence and emits one warning per discarded duplicate:

```
toolr: warning: argparse source "argparse:django" grafted child "sync" multiple times under "jenkins.job"; keeping the first occurrence — tighten the scan glob or rename one of the files
```

Cross-source collisions remain a hard error.

### 3. Tab completion walks through dispatchers

`toolr jenkins job <TAB>` returned nothing even though `--help` rendered the grafted children: the completion engine landed on the dispatcher Command and asked for its own positional values (it had none) instead of looking up the grafted children at `group == "jenkins.job"`.

Add a dispatcher-aware branch to `classify`:

- Dispatcher's own flag completions (`--<TAB>`, `--flag <TAB>`) still target the dispatcher's arguments.
- Positional slot 0 against a dispatcher → completing the child command name → `Slot::Command { group: <dispatcher dotted path>, prefix }`.
- Positional slot >= 1 → child chosen → recurse into that child's arg zone via the extracted `classify_leaf_args`.

Helpers `first_positional_value` and `drop_through_first_positional` walk `arg_tokens` the same way `count_positionals_consumed` does, so a parent `--cpu 200m` value pair before the child name is skipped correctly.

## Verified on dashtastic (355 grafted children)

- `toolr jenkins job delete_<TAB>` → 8 `delete_*` commands
- `toolr jenkins job --dry-run <TAB>` → still suggests children after consuming the parent flag
- `toolr jenkins job --<TAB>` → dispatcher's own flags (`--cpu`, `--dry-run`, `--job-name`, ...)
- Loose `web/**/management/commands/*.py` glob no longer panics clap
- 0 duplicate child names in the manifest

## Test plan

- [x] `scan_paths_skips_files_with_no_add_argument_calls` regression test
- [x] `dedup_intra_source_keeps_first_and_warns` + `dedup_intra_source_is_a_noop_when_no_duplicates`
- [x] 6 new dispatcher completion tests (`dispatcher_completion_lists_grafted_children`, `dispatcher_completion_filters_children_by_prefix`, `dispatcher_flag_prefix_lists_dispatcher_flags_not_children`, `dispatcher_completion_offers_children_after_parent_flag`, `dispatcher_recurses_into_child_args_once_child_is_chosen`, `dispatcher_recurses_through_parent_flag_value_pair`)
- [x] Existing `collision_is_detected` still passes (cross-source still errors)
- [x] All argparse + completion tests pass; clippy clean

## Stacks on

#230 (bootstrap rebuild on --help + DispatchCommand re-export)

_claude --resume 5af343a7-1efb-43d2-80c3-0e1b01405f2e_