### PR TITLE
argparse: preserve literal long-flag spelling for dispatch round-trip

### DIFF
--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -243,6 +243,18 @@ fn build_argument(positionals: &[String], call: &ExprCall, warnings: &mut Vec<St
         metadata.metavar = Some(mv);
     }
 
+    // Preserve the literal long-flag spelling from the source. The
+    // scanner's canonical `name` strips the leading `--` and may pick
+    // between aliases (`add_argument("--user_ids", "--user-ids", ...)`
+    // ties on length and last-wins), so `name` alone isn't enough to
+    // round-trip the source's exact spelling. `long_flag` carries it
+    // verbatim for the dispatch path to emit unchanged.
+    let long_flag = if is_keyword_style {
+        Some(name_for_warning.clone())
+    } else {
+        None
+    };
+
     Argument {
         name,
         kind,
@@ -253,6 +265,7 @@ fn build_argument(positionals: &[String], call: &ExprCall, warnings: &mut Vec<St
         allowed_values: choices,
         path_constraints: None,
         metadata,
+        long_flag,
     }
 }
 
@@ -471,6 +484,10 @@ pub fn with_common_args(mut scanned: ScannedCommand, common: &[CommonArg]) -> Sc
             allowed_values: c.choices.clone().unwrap_or_default(),
             path_constraints: None,
             metadata: Default::default(),
+            // common_args declared in `[tool.toolr.argparse.<name>]`
+            // are toolr-config inputs, not scanned source — there's no
+            // upstream literal to preserve.
+            long_flag: None,
         })
         .collect();
     scanned.arguments.extend(extras);
@@ -586,6 +603,7 @@ def add_arguments(self, parser):
                 allowed_values: vec![],
                 path_constraints: None,
                 metadata: Default::default(),
+                long_flag: Some("--verbosity".into()),
             }],
             warnings: vec![],
         };

--- a/crates/toolr-core/src/complete/tests.rs
+++ b/crates/toolr-core/src/complete/tests.rs
@@ -41,6 +41,7 @@ fn fixture() -> Manifest {
                     resolved_type: None,
                     path_constraints: None,
                     metadata: crate::manifest::ArgMetadata::default(),
+                    long_flag: None,
                     allowed_values: vec![],
                 }],
                 imports: vec![],
@@ -64,6 +65,7 @@ fn fixture() -> Manifest {
                     resolved_type: None,
                     path_constraints: None,
                     metadata: crate::manifest::ArgMetadata::default(),
+                    long_flag: None,
                     allowed_values: vec!["staging".into(), "production".into()],
                 }],
                 imports: vec![],
@@ -87,6 +89,7 @@ fn fixture() -> Manifest {
                     resolved_type: None,
                     path_constraints: None,
                     metadata: crate::manifest::ArgMetadata::default(),
+                    long_flag: None,
                     allowed_values: vec!["wide".into(), "tall".into()],
                 }],
                 imports: vec![],
@@ -263,6 +266,7 @@ fn dispatcher_fixture() -> Manifest {
         resolved_type: None,
         path_constraints: None,
         metadata: crate::manifest::ArgMetadata::default(),
+        long_flag: None,
         allowed_values: values.iter().map(|s| (*s).to_string()).collect(),
     };
     Manifest {
@@ -412,6 +416,7 @@ fn flags_only_child_fixture() -> Manifest {
         resolved_type: None,
         path_constraints: None,
         metadata: crate::manifest::ArgMetadata::default(),
+        long_flag: Some(format!("--{}", name)),
         allowed_values: vec![],
     };
     Manifest {

--- a/crates/toolr-core/src/execute/spec.rs
+++ b/crates/toolr-core/src/execute/spec.rs
@@ -147,6 +147,12 @@ pub struct ArgSchemaSpec {
     /// nargs information isn't tracked yet.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nargs: Option<serde_json::Value>,
+    /// Literal long-flag spelling from the source (e.g. `"--user_ids"`).
+    /// `None` for positionals and for native toolr commands. Used by
+    /// `DispatchCommand.argv` to emit the upstream tool's exact flag
+    /// form even when toolr's CLI normalises display to `--user-ids`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub long_flag: Option<String>,
 }
 
 impl ExecutionSpec {

--- a/crates/toolr-core/src/manifest/model.rs
+++ b/crates/toolr-core/src/manifest/model.rs
@@ -129,6 +129,17 @@ pub struct Argument {
     /// serialisation when empty to keep manifests diffable.
     #[serde(default, skip_serializing_if = "ArgMetadata::is_empty")]
     pub metadata: ArgMetadata,
+    /// Literal long flag string as written in the source — including
+    /// the leading `--` — for arguments harvested from an external
+    /// source (currently the argparse scanner). Used at dispatch time
+    /// to re-emit the upstream tool's exact flag spelling: toolr's
+    /// CLI may normalise `--user_ids` to `--user-ids` for display, but
+    /// when dispatching back to argparse the literal form is required
+    /// unless the source also declared the hyphenated alias.
+    /// `None` for native toolr commands (no scanning involved) and for
+    /// positional args (no flag spelling).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub long_flag: Option<String>,
 }
 
 /// Optional clap-flavoured metadata harvested from `arg(...)`.

--- a/crates/toolr-core/src/parser/signatures.rs
+++ b/crates/toolr-core/src/parser/signatures.rs
@@ -100,6 +100,11 @@ fn build_argument(
         path_constraints: None,
         allowed_values,
         metadata: crate::manifest::ArgMetadata::default(),
+        // Native toolr commands built from Python function signatures
+        // don't have a source-literal flag spelling — the param name
+        // *is* the canonical form; the CLI hyphenates for display and
+        // there is no upstream argparse to dispatch to.
+        long_flag: None,
     }
 }
 

--- a/crates/toolr-core/src/third_party/merge.rs
+++ b/crates/toolr-core/src/third_party/merge.rs
@@ -113,5 +113,8 @@ fn argument_from_fragment(fa: FragmentArgument) -> Argument {
         path_constraints: None,
         allowed_values: fa.allowed_values,
         metadata: crate::manifest::ArgMetadata::default(),
+        // Third-party manifest fragments aren't argparse-grafted, so
+        // they have no source-literal flag to preserve.
+        long_flag: None,
     }
 }

--- a/crates/toolr-py/python/toolr/sources/_dispatch.py
+++ b/crates/toolr-py/python/toolr/sources/_dispatch.py
@@ -6,12 +6,33 @@ from typing import Any
 
 from msgspec import Struct
 
+from toolr.sources._types import ArgSchema  # noqa: TC001 — msgspec needs runtime annotations
 from toolr.sources._types import CommandSchema  # noqa: TC001 — msgspec needs runtime annotations
 
 
 def _flag_for(name: str) -> str:
-    """`dry_run` → `--dry-run`."""
+    """Fallback flag formatter for args with no recorded literal.
+
+    Native toolr commands don't dispatch via this code path, so callers
+    that hit this branch always have a discovered-source arg whose
+    long_flag should have been populated. Treat this as a defensive
+    last resort: hyphenate the param name into a CLI-friendly form so
+    the result is at least usable.
+    """
     return "--" + name.replace("_", "-")
+
+
+def _flag_for_arg(arg: ArgSchema) -> str:
+    """Return the literal long flag for `arg`, preferring the source-recorded form.
+
+    Falls back to `_flag_for(arg.name)` when `long_flag` is absent —
+    older manifests written before the field existed, native toolr
+    commands, or future non-argparse sources that haven't been
+    extended to track the source-literal spelling.
+    """
+    if arg.long_flag:
+        return arg.long_flag
+    return _flag_for(arg.name)
 
 
 class DispatchCommand(Struct, frozen=True):
@@ -49,12 +70,12 @@ class DispatchCommand(Struct, frozen=True):
                 out.append(str(value))
             elif arg.kind == "flag":
                 if value:
-                    out.append(_flag_for(arg.name))
+                    out.append(_flag_for_arg(arg))
             elif arg.kind == "optional":
                 if arg.default is not None and str(value) == arg.default:
                     continue
-                out.extend([_flag_for(arg.name), str(value)])
+                out.extend([_flag_for_arg(arg), str(value)])
             elif arg.kind == "repeated":
                 for element in value:
-                    out.extend([_flag_for(arg.name), str(element)])
+                    out.extend([_flag_for_arg(arg), str(element)])
         return out

--- a/crates/toolr-py/python/toolr/sources/_types.py
+++ b/crates/toolr-py/python/toolr/sources/_types.py
@@ -29,6 +29,14 @@ class ArgSchema(Struct, frozen=True):
     metavar: str | None = None
     type_annotation: str | None = None  # "str" / "int" / "float" / "bool"
     nargs: Literal["*", "+", "?"] | int | None = None
+    long_flag: str | None = None
+    """Literal long-flag spelling from the source (e.g. `"--user_ids"`).
+
+    Populated by the argparse scanner for keyword-style args; `None`
+    for positionals. `DispatchCommand.argv` uses this verbatim so the
+    upstream tool's exact spelling is preserved across the round-trip,
+    even when toolr's CLI normalises display to `--user-ids`.
+    """
 
 
 class CommandSchema(Struct, frozen=True):

--- a/crates/toolr/src/builtin_completions.rs
+++ b/crates/toolr/src/builtin_completions.rs
@@ -165,6 +165,7 @@ fn arg(name: &str, kind: ArgumentKind, allowed_values: Vec<String>) -> Argument 
         allowed_values,
         path_constraints: None,
         metadata: ArgMetadata::default(),
+        long_flag: None,
     }
 }
 

--- a/crates/toolr/src/cli.rs
+++ b/crates/toolr/src/cli.rs
@@ -637,6 +637,7 @@ mod cli_tree_tests {
             allowed_values: vec![],
             path_constraints: None,
             metadata: Default::default(),
+            long_flag: None,
         }
     }
 

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -190,6 +190,7 @@ fn argument_to_arg_schema(arg: &Argument) -> ArgSchemaSpec {
         metavar: arg.metadata.metavar.clone(),
         type_annotation: arg.type_annotation.clone(),
         nargs: None,
+        long_flag: arg.long_flag.clone(),
     }
 }
 
@@ -357,6 +358,7 @@ mod tests {
                 path_constraints: None,
                 allowed_values: vec![],
                 metadata: toolr_core::manifest::ArgMetadata::default(),
+                long_flag: None,
             }],
             imports: vec![],
             origin: Origin::Static,
@@ -424,6 +426,7 @@ mod tests {
                 path_constraints: None,
                 allowed_values: vec![],
                 metadata: toolr_core::manifest::ArgMetadata::default(),
+                long_flag: None,
             }],
             imports: vec![],
             origin: Origin::Static,
@@ -457,6 +460,7 @@ mod tests {
             path_constraints: None,
             allowed_values: vec![],
             metadata: toolr_core::manifest::ArgMetadata::default(),
+            long_flag: None,
         }
     }
 
@@ -709,6 +713,7 @@ mod dispatched_pack_tests {
                 allowed_values: vec![],
                 path_constraints: None,
                 metadata: Default::default(),
+                long_flag: None,
             }],
             imports: vec![],
             origin: Origin::Static,
@@ -809,6 +814,7 @@ mod dispatched_pack_tests {
                 allowed_values: vec![],
                 path_constraints: None,
                 metadata: Default::default(),
+                long_flag: None,
             }],
             ..migrate_cmd()
         };
@@ -850,6 +856,7 @@ mod dispatched_pack_tests {
                 allowed_values: vec![],
                 path_constraints: None,
                 metadata: Default::default(),
+                long_flag: None,
             }
         }
         let cases = [
@@ -882,6 +889,7 @@ mod dispatched_pack_tests {
             allowed_values: vec!["a".into(), "b".into()],
             path_constraints: None,
             metadata,
+            long_flag: None,
         };
         let schema = argument_to_arg_schema(&arg);
         assert_eq!(schema.name, "out");
@@ -909,6 +917,7 @@ mod dispatched_pack_tests {
                 allowed_values: vec![],
                 path_constraints: None,
                 metadata: Default::default(),
+                long_flag: None,
             }],
             ..migrate_cmd()
         };

--- a/tests/sources/test_dispatch.py
+++ b/tests/sources/test_dispatch.py
@@ -67,11 +67,40 @@ def test_dispatch_command_holds_match():
             [ArgSchema(name="exclude", kind="repeated", help="")],
             ["--exclude", "a", "--exclude", "b"],
         ),
-        # Underscores in the name become dashes on the wire.
+        # Underscores in the name become dashes on the wire when no
+        # source-literal long_flag was recorded (native commands or
+        # legacy manifests).
         (
             {"dry_run": True},
             [ArgSchema(name="dry_run", kind="flag", help="")],
             ["--dry-run"],
+        ),
+        # When `long_flag` IS recorded (argparse scanner picked the
+        # source's literal spelling), emit it verbatim regardless of
+        # whether toolr's CLI display normalised underscores away.
+        (
+            {"user-ids": 7},
+            [
+                ArgSchema(
+                    name="user-ids",
+                    kind="optional",
+                    help="",
+                    long_flag="--user_ids",
+                ),
+            ],
+            ["--user_ids", "7"],
+        ),
+        (
+            {"user-ids": [3, 4]},
+            [
+                ArgSchema(
+                    name="user-ids",
+                    kind="repeated",
+                    help="",
+                    long_flag="--user_ids",
+                ),
+            ],
+            ["--user_ids", "3", "--user_ids", "4"],
         ),
     ],
 )


### PR DESCRIPTION
## Summary

The scanner stripped `--` to produce a canonical `name` (e.g. `user-ids`) and `DispatchCommand.argv` then re-hyphenated it via `_flag_for(name)` (`name.replace("_", "-")`). That worked when the source declared a hyphenated long form (or aliased both spellings), but for Django commands that exposed **only** an underscored `--user_ids` the dispatched argv emitted `--user-ids`, which argparse on the receiving side wouldn't recognise.

dashtastic dodged the bug because every collision case in its tree happens to declare both spellings:

```python
user_selection.add_argument("--user_ids", "--user-ids", type=int, nargs="+", ...)
```

A Django command that only registered one underscored long form would have failed silently — toolr CLI looks fine, dispatch goes out with `--user-ids`, manage.py rejects it.

## Fix

Carry the source's literal long flag through the schema unchanged:

- Add `long_flag: Option<String>` to `manifest::Argument`. The argparse scanner populates it with the longest `--…` positional verbatim. `None` for positionals, native toolr commands, common-args supplied via `[tool.toolr.argparse.*]`, and third-party manifest fragments.
- Mirror the field on the wire (`ArgSchemaSpec`) and the Python schema (`ArgSchema`).
- Add `_flag_for_arg(arg)` in `_dispatch.py` — prefers `arg.long_flag` when present, falls back to `_flag_for(arg.name)` for legacy manifests / non-argparse sources. `DispatchCommand.argv` calls `_flag_for_arg` for every emitted flag.

toolr's CLI display still normalises to `--user-ids` for UX consistency; only the dispatched-to-argparse round-trip changes — and only for args whose source declared an underscored spelling.

## Test plan

- [x] New parametrised cases in `test_argv_reconstruction`:
  - `long_flag="--user_ids"` with `kind="optional"` → emits `["--user_ids", "7"]`
  - `long_flag="--user_ids"` with `kind="repeated"` → emits `["--user_ids", "3", "--user_ids", "4"]`
  - Existing `dry_run → --dry-run` case still passes (no `long_flag` → fallback hyphenation)
- [x] 393 toolr-core tests pass
- [x] 119 toolr binary tests pass
- [x] 10 sources tests pass
- [x] mypy clean
- [x] Verified end-to-end on dashtastic: `delete_companyuser` manifest now stores `long_flag` per arg; dispatch dry-run emits the literal spelling

## Stacks on

#231 (dispatcher completion + argparse skip-empty/dedup)

_claude --resume 5af343a7-1efb-43d2-80c3-0e1b01405f2e_