### PR TITLE
docs: rewrite README + CONTRIBUTING around the actual value-prop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,527 +1,114 @@
 # Contributing to ToolR
 
-First off, thank you for considering contributing to ToolR! It's people like you that make ToolR such a great tool.
+Thanks for considering a contribution. ToolR is a small project with a focused surface; bug reports, doc fixes, and well-scoped feature PRs are all welcome.
 
-## Table of Contents
+## Repo layout
 
-- [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [Development Setup](#development-setup)
-- [How to Contribute](#how-to-contribute)
-- [Pull Request Process](#pull-request-process)
-- [Coding Standards](#coding-standards)
-- [Testing Guidelines](#testing-guidelines)
-- [Commit Message Guidelines](#commit-message-guidelines)
-- [Security](#security)
-- [Development Workflow](#development-workflow)
-- [Code Review Guidelines](#code-review-guidelines)
+A Cargo workspace with three crates plus the Python source:
 
-## Code of Conduct
+| Crate                | What it is                                                                                                              |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `crates/toolr-core/` | Pure-Rust library. Parser, manifest, freshness, argparse scanner, completion engine, cache. No `pyo3`.                  |
+| `crates/toolr/`      | The binary. `clap` CLI, dispatch, subprocess control.                                                                   |
+| `crates/toolr-py/`   | `pyo3` dynlib + the Python source at `crates/toolr-py/python/toolr/`. Ships as the `toolr-py` wheel.                    |
 
-This project and everyone participating in it is governed by respect, professionalism, and inclusivity.
-By participating, you are expected to uphold these values. Please report unacceptable behavior by opening
-a [GitHub Issue](https://github.com/s0undt3ch/ToolR/issues/new) or contacting the project maintainers.
+CI builds two PyPI wheels at the same workspace version:
 
-### Our Standards
+- `toolr` — maturin `bindings = "bin"`. The Rust binary, no Python.
+- `toolr-py` — maturin `bindings = "pyo3"`. The Python package plus the `_rust_utils` extension module.
 
-**Positive behaviors include:**
+A GitHub release archive of the standalone binary ships alongside.
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+## Dev setup
 
-**Unacceptable behaviors include:**
+You need [mise](https://mise.jdx.dev/). Everything else (Rust, Python, `uv`, `prek`) installs from the repo's `mise.toml`:
 
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Getting Started
-
-### Prerequisites
-
-Before contributing, make sure you have:
-
-- **Python 3.11+** installed
-- **Rust toolchain** (for building native extensions)
-- **mise** - Development environment manager
-- **gh** CLI (optional, for GitHub Actions utilities)
-- **git** for version control
-
-### First-time Contributors
-
-New to open source? Here are some resources:
-
-- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
-- [First Timers Only](https://www.firsttimersonly.com/)
-- [GitHub's Guide to Contributing](https://guides.github.com/activities/contributing-to-open-source/)
-
-Look for issues labeled [`good first issue`](https://github.com/s0undt3ch/ToolR/labels/good%20first%20issue)
-or [`help wanted`](https://github.com/s0undt3ch/ToolR/labels/help%20wanted).
-
-## Development Setup
-
-### 1. Fork and Clone
-
-```bash
-# Fork the repository on GitHub, then clone your fork
-git clone https://github.com/YOUR_USERNAME/ToolR.git
-cd ToolR
-
-# Add upstream remote
-git remote add upstream https://github.com/s0undt3ch/ToolR.git
+```sh
+curl https://mise.run | sh        # if you don't have mise yet
+mise install                      # pinned tool versions
+uv sync --all-extras --dev        # Python deps
+prek install --install-hooks      # pre-commit hooks
 ```
 
-### 2. Install mise
+Run the dev binary against the dogfood `tools/` directory:
 
-[mise](https://mise.jdx.dev/) manages our development environment, including Python, Rust, and other tools
-(see <https://mise.jdx.dev/getting-started.html>).
-
-```bash
-curl https://mise.run | sh
-
-# Install project tools
-mise install
-
-# Activate the environment
-mise activate
+```sh
+cargo run -p toolr -- --help
+cargo run -p toolr -- self build-manifest toolr_example_plugin
 ```
 
-This will automatically:
+For the release-shaped binary (used by benchmarks and the install smoke tests):
 
-- Install the correct Python version
-- Install the Rust toolchain
-- Install uv package manager
-- Set up other project dependencies
-
-### 3. Install Dependencies
-
-```bash
-# Sync Python dependencies and create virtual environment
-uv sync --all-extras --dev
+```sh
+cargo build -p toolr --release
+./target/release/toolr --help
 ```
 
-### 4. Install prek (Pre-commit Hooks)
+## Tests
 
-We use [prek](https://github.com/j178/prek) instead of standard pre-commit:
+| Suite                                  | Run with                          | Lives at                               |
+| -------------------------------------- | --------------------------------- | -------------------------------------- |
+| Rust unit tests                        | `cargo test -p toolr-core`        | `crates/toolr-core/src/**/*.rs`        |
+| Rust integration tests                 | `cargo test -p toolr --test '*'`  | `crates/toolr/tests/*.rs` (`assert_cmd`) |
+| Python unit tests                      | `uv run pytest`                   | `tests/**/*.py`                        |
+| Distribution lock-tests (opt-in, slow) | `uv run pytest -m distribution`   | `tests/distribution/`                  |
 
-```bash
-# Install prek hooks
-prek install --install-hooks
-```
+The Rust integration tests spawn the built `toolr` binary via `assert_cmd`. Don't shadow them with Python-level subprocess tests unless the behaviour can't be exercised in Rust.
 
-### 5. Verify Setup
+## RUNNER_SCHEMA_VERSION ↔ SCHEMA_VERSION lock-step
 
-```bash
-# Run tests
-uv run pytest
-
-# Run all pre-commit checks
-prek run --all-files
-```
-
-## How to Contribute
-
-### Reporting Bugs
-
-GitHub Issues are used for bug tracking. Before creating a bug report:
-
-- **Search existing issues** to avoid duplicates
-- **Use the latest version** of ToolR
-- **Collect information** about your environment
-
-When filing a bug report, include:
-
-- **Clear title and description**
-- **Steps to reproduce** the issue
-- **Expected vs actual behavior**
-- **Environment details** (OS, Python version, ToolR version)
-- **Error messages** (full stack traces)
-- **Screenshots** if applicable
-
-[Create a new issue](https://github.com/s0undt3ch/ToolR/issues/new) to report bugs.
-
-### Suggesting Enhancements
-
-Feature requests are also tracked as GitHub Issues. When creating an enhancement suggestion:
-
-- **Use a clear title** describing the enhancement
-- **Provide a detailed description** of the proposed functionality
-- **Explain why this would be useful** to most ToolR users
-- **List examples** of how the enhancement would be used
-- **Note any alternatives** you've considered
-
-[Create a new issue](https://github.com/s0undt3ch/ToolR/issues/new) to suggest features.
-
-### Pull Requests
-
-GitHub Pull Requests are used for code contributions. Follow the [pull request process](#pull-request-process) below.
-
-### Your First Code Contribution
-
-1. **Find an issue** to work on (or create one)
-2. **Comment** on the issue to let others know you're working on it
-3. **Create a branch** from `main`:
-
-   ```bash
-   git checkout -b feature/your-feature-name
-   # or
-   git checkout -b fix/your-bug-fix
-   ```
-
-4. **Make your changes** following our coding standards
-5. **Write/update tests** to cover your changes
-6. **Run the test suite** to ensure nothing breaks
-7. **Commit your changes** with descriptive messages
-8. **Push to your fork** and submit a pull request
-
-## Pull Request Process
-
-### Before Submitting
-
-- [ ] **Run all tests** and ensure they pass
-- [ ] **Run prek** to check linting, formatting, and types
-- [ ] **Update documentation** if needed
-- [ ] **Add tests** for new functionality
-- [ ] **Ensure commits** follow our commit message guidelines
-- [ ] **Rebase on latest main** if needed
-
-**Note:** Do NOT manually update `CHANGELOG.md` - it's automatically generated from commit messages using [git-cliff](https://git-cliff.org/).
-
-### Submitting
-
-1. **Push your branch** to your fork
-2. **Open a pull request** against the `main` branch
-3. **Write a clear PR description**:
-   - What changes were made
-   - Why the changes are needed
-   - Any breaking changes
-4. **Link related issues** (e.g., "Closes #123")
-5. **Respond to feedback** and update as needed
-
-### PR Review Process
-
-- Maintainers will review your PR within a few days
-- You may be asked to make changes
-- Once approved, maintainers will merge your PR
-- Your contribution will be included in the next release!
-
-### CI Checks
-
-All PRs must pass:
-
-- ✅ **Tests** (pytest on Linux/macOS/Windows)
-- ✅ **Linting** (ruff, via prek)
-- ✅ **Type checking** (mypy, via prek)
-- ✅ **Formatting** (ruff format, via prek)
-- ✅ **Rust checks** (cargo clippy, cargo check, via prek)
-- ✅ **GitHub Actions** (actionlint, via prek)
-- ✅ **Shell scripts** (shellcheck, via prek)
-- ✅ **Security** (CodeQL, dependency review)
-- ✅ **Spelling** (codespell, typos, via prek)
-- ✅ **Markdown** (markdownlint, via prek)
-- ✅ **Documentation** (builds without errors)
-
-All these checks run automatically via prek hooks and CI.
-
-## Coding Standards
-
-### Python Code
-
-- **Follow PEP 8** for style (enforced by ruff)
-- **Use type hints** for all function signatures
-- **Use `from __future__ import annotations`** at the top of files
-- **Maximum line length**: 120 characters
-- **Use ruff** for linting and formatting (automated by prek)
-- **Use mypy** for type checking (automated by prek)
-
-```python
-from __future__ import annotations
-
-from typing import Any
-
-def greet(name: str, *, enthusiastic: bool = False) -> str:
-    """Greet someone by name.
-
-    Args:
-        name: The name of the person to greet.
-        enthusiastic: Whether to add extra enthusiasm.
-
-    Returns:
-        A greeting message.
-    """
-    greeting = f"Hello, {name}"
-    return f"{greeting}!" if enthusiastic else greeting
-```
-
-### Rust Code
-
-- **Follow Rust style guidelines**
-- **Use `cargo fmt`** for formatting (automated by prek)
-- **Use `cargo clippy`** for linting (automated by prek)
-- **Write doc comments** for public APIs
-- **Add tests** for new functionality
-
-```rust
-/// Greet someone by name.
-///
-/// # Arguments
-///
-/// * `name` - The name of the person to greet
-///
-/// # Returns
-///
-/// A greeting message
-pub fn greet(name: &str) -> String {
-    format!("Hello, {}", name)
-}
-```
-
-### Documentation
-
-- **Use Google-style docstrings** for Python
-- **Use Rustdoc** for Rust code
-- **Include examples** in docstrings
-- **Update docs/** when adding features
-- **Keep README.md** up to date
-
-### Runner schema version
-
-The toolr binary and the toolr-py Python package communicate over a
-versioned JSON spec. Two constants must stay in lock-step:
+The Rust binary and the `toolr-py` Python runtime communicate over a versioned JSON spec. Two constants must stay in lock-step:
 
 - `RUNNER_SCHEMA_VERSION` in `crates/toolr-core/src/execute/spec.rs`
 - `SCHEMA_VERSION` in `crates/toolr-py/python/toolr/_runner.py`
 
-Both constants carry a doc-comment listing exactly which changes
-require a bump and which don't. Read those before changing either the
-Rust serde structs or the `RunnerSpec` Python class. A CI gate fails
-the build when the two values disagree.
+Both carry doc comments listing which changes require a bump and which don't. Read those before changing either the Rust serde structs or the Python `RunnerSpec` class. A CI gate fails the build when the two values disagree.
 
-### Pre-commit Hooks
+## Commits
 
-All formatting and linting is handled automatically by prek:
+[Conventional Commits](https://www.conventionalcommits.org/). Examples:
 
-```bash
-# Run all checks
+- `feat(cli): add --quiet flag to project deps sync`
+- `fix(parser): skip dot-prefixed dirs in list_python_files`
+- `docs(internals): correct the third_party_hash File-shape bullet`
+
+Repo policies:
+
+- **Don't `--no-verify`** without a stated reason in the commit body. Pre-commit failures are signals, not obstacles.
+- **Don't manually edit `CHANGELOG.md`** — `git-cliff` generates it on release from the conventional-commit history.
+
+## Pre-commit hooks
+
+`prek install --install-hooks` (above) wires the gate. Manually:
+
+```sh
 prek run --all-files
-
-# Run specific hook
-prek run ruff-format
-
-# Bypass hooks (use sparingly!)
-git commit --no-verify
+prek run rumdl --files docs/internals/manifest.md
 ```
 
-## Testing Guidelines
+Hooks include `ruff`, `mypy`, `clippy`, `cargo check`, `rumdl`, `codespell`, `typos`, `actionlint`, `shellcheck`, plus the project-local hooks (`pin-github-actions`, `regen-doc-snippets`).
 
-### Writing Tests
+## Benchmarking
 
-- **Write tests** for all new functionality
-- **Update tests** when changing behavior
-- **Test edge cases** and error conditions
-- **Use descriptive test names**
-- **Keep tests focused** (one concept per test)
+`toolr bench compare` measures `<tool> -h` startup latency for every task-runner CLI it finds on `$PATH` (`toolr`, `invoke`, `python-tools-scripts`, `duty`, `doit`, `nox`). Add `--install` to let it `uv tool install` missing Python tools on demand, and `--markdown` to render the result as a table:
 
-### Running Tests
-
-```bash
-# Run all tests
-uv run pytest
-
-# Run specific test file
-uv run pytest tests/test_version.py
-
-# Run with coverage
-uv run coverage run -m pytest
-uv run coverage report
-
-# Run Rust tests
-cargo test
-
-# Run specific Rust test
-cargo test test_name
+```sh
+toolr bench compare --install --markdown
 ```
 
-### Test Organization
+The README's headline benchmark table comes from this command. Re-run it on a fresh hardware target before changing the README's numbers.
 
-```text
-tests/
-├── cli/                 # CLI argument parsing tests
-├── context/             # Context and runtime tests
-├── parser/              # Parser tests
-├── registry/            # Command discovery and registry tests
-├── utils/               # Utility function tests
-├── support/             # Test fixtures and support files
-├── conftest.py          # Shared fixtures
-└── test_*.py            # Additional test modules
-```
+## Filing bugs
 
-### Property-Based Testing
+Open a [GitHub issue](https://github.com/s0undt3ch/ToolR/issues/new) with:
 
-ToolR uses [Hypothesis](https://hypothesis.works/) for property-based testing (fuzzing):
+- ToolR version (`toolr --version`)
+- OS + shell
+- Minimal `tools/*.py` (or repro repo URL) that triggers the bug
+- Expected vs actual output
 
-```python
-from hypothesis import given
-from hypothesis import strategies as st
+For suspected security issues, use [GitHub Security Advisories](https://github.com/s0undt3ch/ToolR/security/advisories/new) instead of a public issue.
 
-@given(st.text())
-def test_handles_any_input(text: str) -> None:
-    """Test that the function handles any text input."""
-    result = process_text(text)
-    assert isinstance(result, str)
-```
+## License
 
-## Commit Message Guidelines
-
-We follow [Conventional Commits](https://www.conventionalcommits.org/) for clear commit history and automated changelogs.
-
-### Format
-
-```commit
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-### Types
-
-- **feat**: New feature
-- **fix**: Bug fix
-- **docs**: Documentation changes
-- **style**: Code style changes (formatting, etc.)
-- **refactor**: Code refactoring
-- **perf**: Performance improvements
-- **test**: Adding or updating tests
-- **build**: Build system changes
-- **ci**: CI configuration changes
-- **chore**: Other changes (dependencies, etc.)
-
-### Examples
-
-```bash
-feat(cli): add --verbose flag for detailed output
-
-Add a --verbose flag to enable detailed logging output.
-This helps users debug issues with command execution.
-
-Closes #123
-
----
-
-fix(version): correct git describe pattern for multi-digit versions
-
-The pattern v[0-9].[0-9].[0-9] only matched single digits.
-Changed to v[0-9]*.[0-9]*.[0-9]* to support versions like v0.11.0.
-
-Fixes #456
-
----
-
-docs: update contributing guidelines with commit conventions
-```
-
-### Breaking Changes
-
-For breaking changes, add `BREAKING CHANGE:` in the footer:
-
-```bash
-feat(api)!: remove deprecated get_version function
-
-BREAKING CHANGE: The get_version() function has been removed.
-Use version.current() instead.
-```
-
-### Why Conventional Commits?
-
-- **Automated changelog** generation using git-cliff
-- **Semantic versioning** automation
-- **Clear history** for understanding project evolution
-- **Better collaboration** through standardized messages
-
-## Security
-
-### Reporting Vulnerabilities
-
-**DO NOT** open a public issue for security vulnerabilities.
-
-Instead, use [GitHub Security Advisories](https://github.com/s0undt3ch/ToolR/security/advisories/new) to privately report security issues.
-
-See our [Security Policy](https://github.com/s0undt3ch/ToolR/security/policy) for more details.
-
-### Security Best Practices
-
-When contributing:
-
-- **Never commit secrets** (API keys, passwords, tokens)
-- **Pin action versions** to commit SHAs in workflows
-- **Validate user input** to prevent injection attacks
-- **Use secure defaults** in configurations
-- **Review dependencies** for known vulnerabilities
-
-## Development Workflow
-
-### Branch Naming
-
-- `feature/description` - New features
-- `fix/description` - Bug fixes
-- `docs/description` - Documentation updates
-- `refactor/description` - Code refactoring
-- `test/description` - Test additions/updates
-
-### Daily Development
-
-```bash
-# Update your fork
-git checkout main
-git pull upstream main
-git push origin main
-
-# Create feature branch
-git checkout -b feature/my-feature
-
-# Make changes, commit often
-git add .
-git commit -m "feat: add my feature"
-
-# Run checks before pushing
-prek run --all-files
-
-# Push to your fork
-git push origin feature/my-feature
-
-# Open a pull request on GitHub
-```
-
-### Keeping Your Branch Updated
-
-```bash
-# Fetch latest changes
-git fetch upstream
-
-# Rebase your branch
-git rebase upstream/main
-
-# Force push if already pushed
-git push --force-with-lease origin feature/my-feature
-```
-
-## Code Review Guidelines
-
-### For Contributors
-
-- **Respond promptly** to review feedback
-- **Ask questions** if feedback is unclear
-- **Make requested changes** or explain why not
-- **Mark conversations** as resolved when addressed
-- **Be respectful** and professional
-
-### For Reviewers
-
-- **Review thoroughly** but constructively
-- **Provide specific feedback
+[Apache-2.0](https://github.com/s0undt3ch/ToolR/blob/main/LICENSE). No sign-off required.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 <h1 align="center">
-  <img width="240px" src="https://raw.githubusercontent.com/s0undt3ch/Toolr/main/docs/imgs/toolr.png" alt="ToolR">
+  <img width="240px" src="https://raw.githubusercontent.com/s0undt3ch/Toolr/main/docs/imgs/toolr.png" alt="ToolR - AI Generated Logo">
 </h1>
 
-<h2 align="center"><em>In-project CLI tooling, with a Rust front-end.</em></h2>
+<h2 align="center">
+  <em>In-project CLI tooling, with a Rust front-end.</em>
+</h2>
+
+<p align="center">
+  <em>Pronounced <tt>/ˈtuːlər/</tt> (tool-er)</em>
+</p>
 
 ToolR is a Python task runner that boots in milliseconds because the front-end is a Rust binary. Python only runs when you invoke a command, inside a per-repo `uv`-managed venv.
 
@@ -45,16 +51,15 @@ mise plugin add toolr https://github.com/s0undt3ch/ToolR.git#installation/mise
 mise use --global toolr@latest
 ```
 
-For projects that already pin tool versions via `.mise.toml`, this is the most-natural fit — toolr's version becomes part of your project's reproducible tool set. See [docs/installation/mise/](https://s0undt3ch.github.io/ToolR/installation/mise/).
+For projects that already pin tool versions via `.mise.toml`, this is the most-natural fit — toolr's version becomes part of your project's reproducible tool set. See [docs/installation/mise/](https://toolr.readthedocs.io/latest/installation/mise/).
 
 ### pip
 
 ```sh
-pip install toolr      # Rust CLI binary
-pip install toolr-py   # Python runtime your tools/*.py import
+pip install toolr   # Rust CLI binary
 ```
 
-The `toolr` wheel ships only the binary; the `toolr-py` wheel ships the `import toolr` surface (`Context`, `command_group`, the `_rust_utils` extension module). Most projects want both, in different venvs — see "Two wheels, two roles" above.
+This installs the `toolr` binary into whatever venv `pip` is pointing at. **Do not `pip install toolr-py`** into that same venv — `toolr-py` is the Python runtime your `tools/*.py` files import, and it belongs in the per-repo tools venv that `toolr project init` scaffolds for you (where it's declared in `tools/pyproject.toml` and materialised via `uv sync`). See "Two wheels, two roles" above for the split.
 
 ### curl | sh (Linux + macOS)
 
@@ -84,15 +89,16 @@ toolr example hello                 # run the generated example
 toolr self completion install bash  # or zsh / fish
 ```
 
-The full install matrix (per-OS notes, attestation flags, prefix overrides) lives in [docs/installation/](https://s0undt3ch.github.io/ToolR/installation/).
+The full install matrix (per-OS notes, attestation flags, prefix overrides) lives in [docs/installation/](https://toolr.readthedocs.io/latest/installation/).
 
 ## What you write
 
 ```python
 # tools/example.py
+"""Example commands."""
 from toolr import Context, command_group
 
-example = command_group("example", title="Example", description="Sample commands.")
+example = command_group("example", title="Example", description=__doc__)
 
 
 @example.command
@@ -114,11 +120,11 @@ Hello, Pedro!
 
 ## Where to go next
 
-- [Quickstart](https://s0undt3ch.github.io/ToolR/quickstart/)
-- [Writing commands](https://s0undt3ch.github.io/ToolR/writing-commands/)
-- [Third-party packages](https://s0undt3ch.github.io/ToolR/third-party/)
-- [Internals (manifest, freshness, cache)](https://s0undt3ch.github.io/ToolR/internals/)
-- [CLI reference](https://s0undt3ch.github.io/ToolR/cli/)
+- [Quickstart](https://toolr.readthedocs.io/latest/quickstart/)
+- [Writing commands](https://toolr.readthedocs.io/latest/writing-commands/)
+- [Third-party packages](https://toolr.readthedocs.io/latest/third-party/)
+- [Internals (manifest, freshness, cache)](https://toolr.readthedocs.io/latest/internals/)
+- [CLI reference](https://toolr.readthedocs.io/latest/cli/)
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -1,230 +1,133 @@
 <h1 align="center">
-  <img width="240px" src="https://raw.githubusercontent.com/s0undt3ch/Toolr/main/docs/imgs/toolr.png" alt="ToolR - AI Generated Logo">
+  <img width="240px" src="https://raw.githubusercontent.com/s0undt3ch/Toolr/main/docs/imgs/toolr.png" alt="ToolR">
 </h1>
 
-<h2 align="center">
-  <em>In-project CLI tooling support</em>
-</h2>
+<h2 align="center"><em>In-project CLI tooling, with a Rust front-end.</em></h2>
 
-<p align="center">
-  <em>Pronounced <tt>/ˈtuːlər/</tt> (tool-er)</em>
-</p>
+ToolR is a Python task runner that boots in milliseconds because the front-end is a Rust binary. Python only runs when you invoke a command, inside a per-repo `uv`-managed venv.
 
-ToolR is a tool similar to [invoke](https://www.pyinvoke.org/) and the next generation of [python-tools-scripts](https://github.com/saltstack/python-tools-scripts).
+| Tool runner          | `-h` steady-state | First run | Second run |
+| -------------------- | ----------------: | --------: | ---------: |
+| **toolr**            |       **10.4 ms** |  277.0 ms |    21.8 ms |
+| doit                 |           83.4 ms |  143.0 ms |    88.9 ms |
+| invoke               |           84.6 ms |  101.7 ms |    77.4 ms |
+| nox                  |           91.8 ms |  395.9 ms |   115.3 ms |
+| duty                 |          166.4 ms |  188.5 ms |   252.4 ms |
+| python-tools-scripts |          252.2 ms |  340.3 ms |   189.0 ms |
 
-The goal is to quickly enable projects to write a Python module under the project's `tools/` sub-directory and it automatically becomes a sub command to the `toolr` CLI.
+`<tool> -h`, 20 runs, steady-state = mean of last 18. Measured on Apple M3 Pro / macOS 26.5 / arm64. Reproduce locally with `toolr bench compare` (add `--markdown` for the table above).
 
-## Key Features
+## Why ToolR
 
-### Automatic Command Discovery
+- **Sub-millisecond discovery.** The CLI is a Rust binary. `--help` and Tab completion read a cached static manifest; Python never boots for non-execute paths.
+- **No system-Python dependency.** Toolr resolves a per-repo Python venv via `uv` on first invocation. The host OS doesn't need Python at all to install toolr — it's a single static binary.
+- **Write Python, not framework boilerplate.** Drop a `tools/*.py` file with a `command_group` and a `@command` decorator. Type hints become CLI arguments; Google-style docstrings become `--help` text.
+- **First-class third-party command packages.** Plugins ship a static `toolr-manifest.json` inside the wheel. Discovery is a glob + JSON parse; no Python import to find them.
+- **Signed releases.** Every release archive ships with a SLSA build-provenance attestation. The install scripts verify it automatically when `gh` is on PATH.
 
-ToolR automatically discovers and registers commands from your project's `tools/` directory, making it easy to organize and maintain your project's CLI tools.
+## Two wheels, two roles
 
-### Simple Command Definition
+| Package    | What it is                                   | Where it lives                  |
+| ---------- | -------------------------------------------- | ------------------------------- |
+| `toolr`    | The Rust CLI binary you run from the shell.  | On `$PATH`, installed once.     |
+| `toolr-py` | The Python runtime your `tools/*.py` import. | In your `tools/pyproject.toml`. |
 
-Define commands using simple Python functions with type hints. ToolR automatically generates argument parsing based on your function signatures.
+Most projects want both: the CLI installed globally, `toolr-py` declared in the per-repo `tools/pyproject.toml` so `from toolr import Context, command_group` works when your commands run.
 
-### Nested Command Groups
+## Install
 
-Organize commands into logical groups and subgroups using dot notation, providing a clean and intuitive CLI structure.
+Five first-class install paths.
 
-### Rich Help System
+### mise
 
-Built-in support for rich text formatting and automatic help generation from docstrings and type annotations.
+```sh
+mise plugin add toolr https://github.com/s0undt3ch/ToolR.git#installation/mise
+mise use --global toolr@latest
+```
 
-### Third-Party Command Support
+For projects that already pin tool versions via `.mise.toml`, this is the most-natural fit — toolr's version becomes part of your project's reproducible tool set. See [docs/installation/mise/](https://s0undt3ch.github.io/ToolR/installation/mise/).
 
-Extend ToolR's functionality by installing packages that provide additional commands through Python entry points.
+### pip
 
-## Installation
+```sh
+pip install toolr      # Rust CLI binary
+pip install toolr-py   # Python runtime your tools/*.py import
+```
 
-`toolr` ships in two complementary PyPI packages:
+The `toolr` wheel ships only the binary; the `toolr-py` wheel ships the `import toolr` surface (`Context`, `command_group`, the `_rust_utils` extension module). Most projects want both, in different venvs — see "Two wheels, two roles" above.
 
-- **`toolr`** — the Rust CLI binary you run as `toolr` from the
-  shell. Installs via pip, curl, mise, or a release archive. No
-  Python source, no `import toolr`.
-- **`toolr-py`** — the Python runtime your `tools/*.py` scripts
-  import (`from toolr import Context, command_group`). Provides the
-  `toolr` import name and the `_rust_utils` extension module the
-  framework runs under the hood.
-
-For a typical project you'll want **both**, in different venvs: the
-CLI installed once on PATH, and `toolr-py` added to your
-`tools/pyproject.toml` so it's resolved into your tools venv.
-
-### Install the CLI binary (`toolr`)
-
-Pick whichever method matches your environment.
-
-#### `curl ... | sh` (Linux + macOS)
+### curl | sh (Linux + macOS)
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/s0undt3ch/ToolR/main/installation/install.sh | sh
 ```
 
-Pass `--version X.Y.Z` after `sh -s --` to pin a specific release, or
-`--prefix /custom/bin` to choose an install directory. Default prefix
-is `$XDG_BIN_HOME` (or `~/.local/bin`).
+Verifies the SLSA attestation when `gh` is on PATH. Pin a version with `sh -s -- --version X.Y.Z`. Custom prefix: `sh -s -- --prefix /opt/toolr/bin`.
 
-#### PowerShell (Windows)
+### PowerShell (Windows)
 
 ```powershell
 irm https://raw.githubusercontent.com/s0undt3ch/ToolR/main/installation/install.ps1 | iex
 ```
 
-#### mise
+### GitHub release archives
 
-If you use [mise](https://mise.jdx.dev/) for tool version management:
+Download `toolr-<version>-<target-triple>.tar.gz` (or `.zip` for Windows) from <https://github.com/s0undt3ch/ToolR/releases>, verify the `.sha256` sibling and the SLSA attestation, drop the binary on `$PATH`. Useful in locked-down environments that audit binaries before allowing them on a machine.
 
-```sh
-mise plugin add toolr https://github.com/s0undt3ch/ToolR.git#installation/mise
-mise install toolr@latest
-mise use --global toolr@latest
-```
+### Scaffold your repo
 
-See the [mise installation guide](https://s0undt3ch.github.io/ToolR/installation/mise/)
-for `.mise.toml` integration and project-level pinning.
-
-#### pip
+After the binary is on `$PATH`:
 
 ```sh
-pip install toolr
+toolr project init                  # writes tools/{pyproject.toml,.gitignore,example.py}
+toolr example hello                 # run the generated example
+toolr self completion install bash  # or zsh / fish
 ```
 
-The `toolr` wheel ships only the Rust CLI binary; there's no Python
-source and no `import toolr` inside it. `python -m toolr` was removed
-in the rust front-end rewrite — use the `toolr` executable instead.
+The full install matrix (per-OS notes, attestation flags, prefix overrides) lives in [docs/installation/](https://s0undt3ch.github.io/ToolR/installation/).
 
-#### GitHub release archives
+## What you write
 
-Download `toolr-<version>-<target-triple>.tar.gz` (or `.zip` for
-Windows) from <https://github.com/s0undt3ch/ToolR/releases> and
-extract it onto `$PATH` manually. Each archive ships with a `.sha256`
-sibling for verification.
+```python
+# tools/example.py
+from toolr import Context, command_group
 
-### Enable `import toolr` in your tool scripts (`toolr-py`)
+example = command_group("example", title="Example", description="Sample commands.")
 
-Add `toolr-py` to your project's `tools/pyproject.toml` so the
-import surface is available when toolr executes your commands:
 
-```toml
-# tools/pyproject.toml
-[project]
-dependencies = ["toolr-py"]
+@example.command
+def hello(ctx: Context, name: str = "world") -> None:
+    """Say hello to <name>.
+
+    Args:
+        name: who to greet.
+    """
+    ctx.print(f"Hello, {name}!")
 ```
-
-`toolr-py` provides the `toolr` package (`Context`, `command_group`,
-helpers in `toolr.utils`, …) and the `_rust_utils` extension module.
-See [docs/installation/index.md](https://s0undt3ch.github.io/ToolR/installation/)
-for the longer write-up.
-
-### Supply-chain verification (SLSA attestations)
-
-Every release archive is signed with a SLSA build-provenance
-attestation produced by the GitHub-hosted release workflow. The
-`install.sh` and `install.ps1` scripts will verify the attestation
-automatically when the `gh` CLI is on PATH. To require verification:
 
 ```sh
-sh installation/install.sh --verify-attestation=require   # POSIX
-./installation/install.ps1 -VerifyAttestation require     # Windows
+$ toolr example hello --name Pedro
+Hello, Pedro!
 ```
 
-You can also verify a downloaded archive manually:
+`toolr project init` writes a richer four-command starter than this two-liner — open it and edit, or delete it and start from scratch.
 
-```sh
-gh attestation verify toolr-1.2.3-aarch64-apple-darwin.tar.gz \
-  --repo s0undt3ch/ToolR
-```
+## Where to go next
 
-## Quick Start
+- [Quickstart](https://s0undt3ch.github.io/ToolR/quickstart/)
+- [Writing commands](https://s0undt3ch.github.io/ToolR/writing-commands/)
+- [Third-party packages](https://s0undt3ch.github.io/ToolR/third-party/)
+- [Internals (manifest, freshness, cache)](https://s0undt3ch.github.io/ToolR/internals/)
+- [CLI reference](https://s0undt3ch.github.io/ToolR/cli/)
 
-1. **Install ToolR** (see [Installation](#installation) above).
+## Project status
 
-2. **Create a tools package** in your project root:
-
-   ```bash
-   mkdir tools
-   touch tools/__init__.py
-   ```
-
-3. **Write your first command** in `tools/example.py`:
-
-   ```python
-   from toolr import Context, command_group
-
-   group = command_group("example", "Example Commands", "Example command group")
-
-   @group.command
-   def hello(ctx: Context, name: str = "World"):
-       """Say hello to someone.
-
-       Args:
-         name: The name to say hello to.
-       """
-       ctx.print(f"Hello, {name}!")
-   ```
-
-4. **Run your command**:
-
-   ```bash
-   toolr example hello --name Alice
-   ```
-
-## Advanced Usage
-
-### Third-Party Commands
-
-ToolR supports 3rd-party commands from installable Python packages. Create packages that extend ToolR's functionality by defining commands and registering them as entry points.
-
-See the [Advanced Topics section](https://s0undt3ch.github.io/ToolR/usage/#advanced-topics) in the documentation for detailed information about creating 3rd-party command packages.
-
-## Testing and Security
-
-ToolR includes comprehensive testing with a focus on security and robustness:
-
-### Property-Based Testing (Fuzzing)
-
-ToolR uses [Hypothesis](https://hypothesis.works/) for property-based testing to automatically discover edge cases and potential vulnerabilities.
-Fuzzing tests are integrated into the regular test suite:
-
-```bash
-# Run all tests (including fuzzing tests)
-uv run pytest
-
-# Run only fuzzing tests
-uv run pytest -k "test_fuzz"
-
-# Run with coverage
-uv run coverage run -m pytest -ra -s -v
-```
-
-### Security Testing Features
-
-- **Automated Fuzzing**: Property-based tests that generate thousands of test cases
-- **Unicode Edge Cases**: Comprehensive testing of text processing with various encodings
-- **Malformed Input Handling**: Tests ensure graceful handling of invalid input
-
-The integrated fuzzing tests help ensure ToolR can safely handle malformed input, unusual Unicode sequences, and other edge cases that might cause crashes or security vulnerabilities.
+ToolR is pre-1.0. The on-disk manifest is versioned (`schema_version` in `tools/.toolr-manifest.json`); the binary refuses to load a higher version than it understands. The public Python surface is `toolr.__all__`; anything not listed there is implementation detail. Backwards-incompatible changes will be explicit in the changelog (generated by `git-cliff` on release).
 
 ## Contributing
 
-We welcome contributions from the community! ToolR is an open-source project and we appreciate:
-
-- 🐛 Bug reports and fixes
-- ✨ Feature requests and implementations
-- 📖 Documentation improvements
-- 🧪 Test coverage enhancements
-- 💡 Ideas and suggestions
-
-Please read our [Contributing Guide](CONTRIBUTING.md) for:
-
-- Setting up your development environment
-- Coding standards and best practices
-- Pull request process
-- Commit message conventions
-- Testing guidelines
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-ToolR is licensed under the [Apache License 2.0](LICENSE).
+[Apache-2.0](LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
   <img width="240px" src="imgs/toolr.png" alt="ToolR - AI Generated Logo"/>
 </h1>
 
-{!README.md!lines=5-15}
+{!README.md!lines=5-18}
 
 ## Start here
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
   <img width="240px" src="imgs/toolr.png" alt="ToolR - AI Generated Logo"/>
 </h1>
 
-{!README.md!lines=5-18}
+{!README.md!lines=5-24}
 
 ## Start here
 

--- a/tools/bench.py
+++ b/tools/bench.py
@@ -1,0 +1,561 @@
+"""
+Benchmark task-runner CLI startup time.
+
+For each available task-runner (toolr, invoke, python-tools-scripts, duty,
+doit, nox), write a minimal task-file in its own temp subdirectory, then
+run ``<tool> -h`` repeatedly. We report three columns rather than just
+cold/hot so the first-run setup cost stays visible:
+
+- **First** — invocation #1. Truly cold; for toolr this includes the
+  static-manifest build that subsequent invocations skip, so pre-warming
+  would be unfair.
+- **Second** — invocation #2. OS file cache is warm but no in-process
+  warmup has happened; this is what a user sees on their second command
+  in a session.
+- **Remaining (mean / min / max)** — invocations #3 onward, averaged.
+  Steady state.
+
+Missing Python task-runners can be installed on demand with ``--install``
+(``uv tool install``). The ``toolr`` binary itself must already be on PATH
+(install via the standard ``install.sh``).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import statistics
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+
+from rich.table import Table
+
+from toolr import Context
+from toolr import command_group
+
+group = command_group("bench", "Benchmark task-runner CLIs", docstring=__doc__)
+
+
+# ---------------------------------------------------------------------------
+# Minimal task-files per tool. Each defines a single `hello` command so the
+# `--help` output has comparable shape across tools.
+# ---------------------------------------------------------------------------
+
+_TOOLR_PYPROJECT = """\
+[project]
+name = "tools"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = ["toolr-py"]
+"""
+
+_TOOLR_EXAMPLE = '''\
+"""Example commands."""
+
+from __future__ import annotations
+
+from toolr import Context
+from toolr import command_group
+
+example = command_group("example", "Example commands")
+
+
+@example.command
+def hello(ctx: Context, name: str = "world") -> None:
+    """Greet someone.
+
+    Args:
+        name: The name to greet.
+    """
+    ctx.print(f"hello, {name}")
+'''
+
+_INVOKE_TASKS = '''\
+"""Invoke tasks."""
+
+from invoke import task
+
+
+@task(help={"name": "Name to greet"})
+def hello(c, name="world"):
+    """Greet someone."""
+    print(f"hello, {name}")
+'''
+
+_PTSCRIPTS_INIT = '''\
+"""Tools package."""
+
+from tools.example import example  # noqa: F401
+'''
+
+_PTSCRIPTS_EXAMPLE = '''\
+"""Example commands."""
+
+from __future__ import annotations
+
+from ptscripts import Context
+from ptscripts import command_group
+
+example = command_group(name="example", help="Example commands")
+
+
+@example.command(
+    arguments={"name": {"help": "The name to greet"}},
+)
+def hello(ctx: Context, name: str = "world") -> None:
+    """Greet someone."""
+    ctx.print(f"hello, {name}")
+'''
+
+_DUTY_DUTIES = '''\
+"""Duties."""
+
+from duty import duty
+
+
+@duty
+def hello(ctx, name="world"):
+    """Greet someone.
+
+    Args:
+        name: The name to greet.
+    """
+    ctx.run(f"echo hello, {name}")
+'''
+
+_DOIT_DODO = '''\
+"""dodo file."""
+
+
+def task_hello():
+    """Greet someone."""
+    return {"actions": ["echo hello, world"]}
+'''
+
+_NOX_NOXFILE = '''\
+"""noxfile."""
+
+import nox
+
+
+@nox.session
+def hello(session):
+    """Greet someone."""
+    session.log("hello, world")
+'''
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """One benchmarkable task-runner."""
+
+    name: str
+    binary: str
+    pip_pkg: str | None  # `uv tool install <pkg>` for missing tools (None = skip)
+    files: tuple[tuple[str, str], ...]  # (relative path, contents)
+    args: tuple[str, ...] = ("-h",)
+
+
+_TOOLS: tuple[ToolSpec, ...] = (
+    ToolSpec(
+        name="toolr",
+        binary="toolr",
+        pip_pkg=None,  # ships as a binary; install via the install.sh path
+        files=(
+            ("tools/pyproject.toml", _TOOLR_PYPROJECT),
+            ("tools/example.py", _TOOLR_EXAMPLE),
+        ),
+    ),
+    ToolSpec(
+        name="invoke",
+        binary="invoke",
+        pip_pkg="invoke",
+        files=(("tasks.py", _INVOKE_TASKS),),
+    ),
+    ToolSpec(
+        name="python-tools-scripts",
+        binary="tools",
+        pip_pkg="python-tools-scripts",
+        files=(
+            ("tools/__init__.py", _PTSCRIPTS_INIT),
+            ("tools/example.py", _PTSCRIPTS_EXAMPLE),
+        ),
+    ),
+    ToolSpec(
+        name="duty",
+        binary="duty",
+        pip_pkg="duty",
+        files=(("duties.py", _DUTY_DUTIES),),
+    ),
+    ToolSpec(
+        name="doit",
+        binary="doit",
+        pip_pkg="doit",
+        files=(("dodo.py", _DOIT_DODO),),
+        # doit's top-level parser rejects `-h`; the equivalent subcommand
+        # is `doit help`. Same shape (prints help, then exits 0).
+        args=("help",),
+    ),
+    ToolSpec(
+        name="nox",
+        binary="nox",
+        pip_pkg="nox",
+        files=(("noxfile.py", _NOX_NOXFILE),),
+    ),
+)
+
+
+@dataclass
+class _Row:
+    """Captured timings for one tool. Mutable so the benchmark loop can fill it in.
+
+    ``samples`` collects every ``<tool> -h`` invocation in order. Position 0 is
+    "first" (cold + any first-run setup), position 1 is "second" (OS cache
+    warm), positions 2+ are the steady-state ``remaining`` runs.
+    """
+
+    spec: ToolSpec
+    binary: str | None = None
+    samples: list[float] = field(default_factory=list)
+    note: str = ""
+
+
+def _resolve_binary(ctx: Context, spec: ToolSpec, *, install: bool) -> str | None:
+    """Return the path to ``spec.binary``, optionally installing on demand.
+
+    For the Python task-runners (invoke, duty, doit, nox, ptscripts) we
+    install into a uv-managed tool venv; the resulting executable lands
+    in ``uv tool dir --bin`` which is *not* automatically on PATH. If
+    ``shutil.which`` still returns ``None`` after install, fall back to
+    that directory before giving up — keeps the benchmark usable on a
+    machine where the user hasn't run ``uv tool update-shell`` yet.
+    """
+    found = shutil.which(spec.binary)
+    if found:
+        return found
+    if not install or spec.pip_pkg is None:
+        return None
+    ctx.info(f"installing {spec.name} via `uv tool install {spec.pip_pkg}` …")
+    result = ctx.run(
+        "uv",
+        "tool",
+        "install",
+        "--quiet",
+        spec.pip_pkg,
+        capture_output=True,
+        stream_output=False,
+    )
+    if result.returncode != 0:
+        ctx.warn(f"`uv tool install {spec.pip_pkg}` failed; skipping {spec.name}")
+        return None
+    found = shutil.which(spec.binary)
+    if found:
+        return found
+    bin_dir = ctx.run("uv", "tool", "dir", "--bin", capture_output=True, stream_output=False)
+    if bin_dir.returncode == 0:
+        candidate = Path(bin_dir.stdout.read().strip()) / spec.binary
+        if candidate.exists():
+            return str(candidate)
+    ctx.warn(f"{spec.binary!r} installed but not on PATH; run `uv tool update-shell`")
+    return None
+
+
+def _write_files(root: Path, files: tuple[tuple[str, str], ...]) -> None:
+    for rel, contents in files:
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents)
+
+
+def _time_once(
+    binary: str,
+    args: tuple[str, ...],
+    cwd: Path,
+    env: dict[str, str] | None,
+) -> tuple[float, int]:
+    """Run ``binary args...`` in ``cwd``; return ``(elapsed_seconds, returncode)``.
+
+    Stdout/stderr are discarded so the terminal stays quiet during the
+    measurement loop. Subprocess spawn is what we're measuring, so we
+    wrap ``time.perf_counter()`` around the ``subprocess.run`` call.
+    """
+    start = time.perf_counter()
+    result = subprocess.run(  # noqa: S603 — `binary` is a path resolved by `_resolve_binary` and `args` is a static literal per tool spec.
+        [binary, *args],
+        cwd=cwd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        env=env,
+    )
+    return time.perf_counter() - start, result.returncode
+
+
+def _isolated_env(root: Path) -> dict[str, str]:
+    """Return a subprocess env that isolates per-tool persistent caches under ``root``.
+
+    Concretely: redirect ``XDG_CACHE_HOME`` into the workspace so toolr's
+    venv + static-manifest cache live next to the tool tree (and disappear
+    with it). ``UV_CACHE_DIR`` is preserved to the *user's* real uv cache
+    so each fresh run doesn't redownload ``toolr-py`` from PyPI — that's
+    network-bound and not what we want to measure.
+    """
+    env = dict(os.environ)
+    real_uv_cache = env.get("UV_CACHE_DIR")
+    if not real_uv_cache:
+        xdg = env.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+        real_uv_cache = str(Path(xdg) / "uv")
+    isolated_xdg = root / "_xdg_cache"
+    isolated_xdg.mkdir(parents=True, exist_ok=True)
+    env["XDG_CACHE_HOME"] = str(isolated_xdg)
+    env["UV_CACHE_DIR"] = real_uv_cache
+    return env
+
+
+@group.command
+def compare(
+    ctx: Context,
+    *only: str,
+    runs: int = 20,
+    install: bool = False,
+    keep_tmp: bool = False,
+    path: str | None = None,
+    reuse_caches: bool = False,
+    markdown: bool = False,
+) -> None:
+    """Compare ``<tool> -h`` startup time across task-runner CLIs.
+
+    For each task-runner whose binary is on PATH (or installable via
+    ``--install``), write a minimal task-file in ``<root>/<tool-name>/``
+    and run ``<tool> -h`` ``runs`` times. The result is a table sorted
+    by steady-state mean (fastest first).
+
+    Methodology
+    -----------
+
+    * **Workspace isolation.** Each ``compare`` invocation creates a
+      fresh ``<root>`` (a random tmp dir, or ``--path`` if supplied) and
+      places each tool's config in its own subdirectory. Per-tool state
+      a runner writes into ``cwd`` (e.g. doit's ``.doit.db``, nox's
+      ``.nox/``, toolr's ``.toolr-manifest.json``) lives inside the
+      per-tool subdir and therefore starts clean every invocation.
+
+    * **Cache isolation.** ``XDG_CACHE_HOME`` is redirected to
+      ``<root>/_xdg_cache`` for the measured subprocesses so toolr's
+      venv cache is rebuilt rather than reused from a prior bench run.
+      ``UV_CACHE_DIR`` is preserved to the user's real uv wheel cache so
+      ``toolr-py`` doesn't get re-downloaded from PyPI every run — that
+      would be network-bound, not what we want to measure. Pass
+      ``--reuse-caches`` to skip the XDG redirect entirely.
+
+    * **Three columns instead of cold/hot.** The first two runs each
+      get their own column so first-run setup cost stays separately
+      visible from steady state. Runs #3..N are averaged into the
+      "Remaining" column with min/max alongside. Pre-warming is
+      deliberately avoided — for toolr in particular, the first run
+      builds the static manifest cache, and hiding that would be
+      unfair.
+
+    * **Sleeps between #1↔#2 and #2↔#3.** A 500ms gap is inserted after
+      runs #1 and #2 so the "Second" and first "Remaining" samples
+      don't piggy-back on a still-warm CPU / OS page cache from the
+      previous invocation. Runs #3 onward fire back-to-back to capture
+      the steady-state cadence a user actually experiences.
+
+    * **What still leaks across runs.** ``uv tool install`` venvs (and
+      their pre-compiled ``.pyc`` files) under
+      ``$XDG_DATA_HOME/uv/tools/`` persist across bench invocations,
+      so the Python task-runners are measured "with an already-installed
+      tool". The OS page cache also can't be flushed without root, and
+      the ``toolr`` binary itself stays hot in kernel cache because the
+      parent process running this bench *is* toolr. Both biases favour
+      whichever tool was invoked most recently.
+
+    Args:
+        runs: Total invocations per tool. Must be >= 10 so the
+            "Remaining" mean averages over a reasonable number of
+            steady-state samples.
+        install: When set, ``uv tool install`` missing Python
+            task-runners. The ``toolr`` binary itself is never
+            auto-installed — provision it via the standard install.sh
+            path.
+        keep_tmp: Leave the per-tool directories in place after the run
+            so the user can poke around. Implied when ``--path`` is set.
+        path: Root directory to use instead of a random tmp dir. Created
+            if missing; existing per-tool subdirs are reused as-is.
+        reuse_caches: Inherit the parent ``XDG_CACHE_HOME`` instead of
+            isolating it under ``<root>``. Lets toolr reuse a previously
+            provisioned venv + manifest cache across bench runs.
+        markdown: Render the result as a column-padded markdown table
+            (copy/paste-able into a README or PR description) instead of
+            the default Rich-styled table.
+        only: Optional positional list of tool names to benchmark.
+            Defaults to all known tools when omitted.
+    """
+    min_runs = 10
+    if runs < min_runs:
+        ctx.error(f"--runs must be >= {min_runs} (got {runs}); steady-state mean needs enough samples")
+        ctx.exit(2)
+
+    known = {t.name for t in _TOOLS}
+    if only:
+        unknown = sorted(set(only) - known)
+        if unknown:
+            ctx.error(f"unknown tool(s): {', '.join(unknown)}")
+            ctx.error(f"known: {', '.join(sorted(known))}")
+            ctx.exit(2)
+        selected = [t for t in _TOOLS if t.name in only]
+    else:
+        selected = list(_TOOLS)
+
+    user_path = path is not None
+    if user_path:
+        root = Path(path).expanduser().resolve()
+        root.mkdir(parents=True, exist_ok=True)
+    else:
+        root = Path(tempfile.mkdtemp(prefix="toolr-bench-"))
+    ctx.info(f"workdir: {root}")
+
+    env = None if reuse_caches else _isolated_env(root)
+    if not reuse_caches:
+        ctx.info(f"isolated XDG_CACHE_HOME: {env['XDG_CACHE_HOME']}")  # type: ignore[index]
+
+    rows = [_Row(spec=s) for s in selected]
+
+    for row in rows:
+        spec = row.spec
+        ctx.info(f"benchmarking {spec.name} …")
+        binary = _resolve_binary(ctx, spec, install=install)
+        if binary is None:
+            row.note = "binary not on PATH (pass --install for Python runners)"
+            continue
+        row.binary = binary
+
+        workdir = root / spec.name
+        workdir.mkdir(exist_ok=True)
+        _write_files(workdir, spec.files)
+
+        for i in range(runs):
+            elapsed, rc = _time_once(binary, spec.args, workdir, env)
+            if rc != 0:
+                row.note = f"run #{i + 1} exited with code {rc}"
+                row.samples = []
+                break
+            row.samples.append(elapsed)
+            # Insert a brief gap between runs #1↔#2 and #2↔#3 so neither
+            # the "Second" nor the first "Remaining" sample piggy-backs on
+            # a still-warm CPU / OS page cache from the prior invocation.
+            # Subsequent runs are back-to-back to capture steady state.
+            if i <= 1:
+                time.sleep(0.5)
+
+    if markdown:
+        _render_markdown(ctx, rows, runs=runs)
+    else:
+        _render(ctx, rows, runs=runs)
+
+    if keep_tmp or user_path:
+        ctx.info(f"workdir kept at {root}")
+    else:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+_COLUMNS: tuple[tuple[str, bool], ...] = (
+    # (header, is_numeric)
+    ("Tool", False),
+    ("First (ms)", True),
+    ("Second (ms)", True),
+    ("Remaining mean (ms)", True),
+    ("Remaining min (ms)", True),
+    ("Remaining max (ms)", True),
+    ("Notes", False),
+)
+
+
+def _fmt_ms(seconds: float) -> str:
+    return f"{seconds * 1000:.1f}"
+
+
+def _remaining(r: _Row) -> list[float]:
+    return r.samples[2:]
+
+
+def _sorted_rows(rows: list[_Row]) -> list[_Row]:
+    """Completed rows first (by steady-state mean), failed rows last."""
+
+    def key(r: _Row) -> tuple[int, float]:
+        rest = _remaining(r)
+        if rest:
+            return (0, statistics.mean(rest))
+        return (1, 0.0)
+
+    return sorted(rows, key=key)
+
+
+def _row_cells(r: _Row) -> tuple[str, ...]:
+    """Format one ``_Row`` into the seven column strings (in column order)."""
+    rest = _remaining(r)
+    if not rest:
+        return (r.spec.name, "—", "—", "—", "—", "—", r.note or "—")
+    return (
+        r.spec.name,
+        _fmt_ms(r.samples[0]),
+        _fmt_ms(r.samples[1]),
+        _fmt_ms(statistics.mean(rest)),
+        _fmt_ms(min(rest)),
+        _fmt_ms(max(rest)),
+        r.note,
+    )
+
+
+def _render(ctx: Context, rows: list[_Row], *, runs: int) -> None:
+    """Render the timing rows as a Rich table sorted by remaining mean ascending."""
+    remaining_count = runs - 2
+    table = Table(title=f"`<tool> -h` startup — {runs} runs (remaining = mean of last {remaining_count})")
+    for header, is_numeric in _COLUMNS:
+        table.add_column(header, justify="right" if is_numeric else "left")
+    for r in _sorted_rows(rows):
+        table.add_row(*_row_cells(r))
+    ctx.print(table)
+
+
+def _render_markdown(ctx: Context, rows: list[_Row], *, runs: int) -> None:
+    """Render the timing rows as a column-padded markdown table.
+
+    Numeric columns are right-aligned (``|---:|``); text columns get the
+    default left alignment. Each cell is padded to the column's widest
+    value so the raw markdown source is readable on its own — and still
+    renders correctly when pasted into a README or PR description.
+    """
+    cells = [_row_cells(r) for r in _sorted_rows(rows)]
+    headers = [h for h, _ in _COLUMNS]
+    # Column width = max(header, max-cell-in-column).
+    widths = [max(len(h), *(len(row[i]) for row in cells)) if cells else len(h) for i, h in enumerate(headers)]
+
+    def pad(cell: str, width: int, *, numeric: bool) -> str:
+        return cell.rjust(width) if numeric else cell.ljust(width)
+
+    def line(values: tuple[str, ...] | list[str]) -> str:
+        padded = [pad(v, widths[i], numeric=_COLUMNS[i][1]) for i, v in enumerate(values)]
+        return f"| {' | '.join(padded)} |"
+
+    sep_cells = ["-" * widths[i] + (":" if is_numeric else "") for i, (_, is_numeric) in enumerate(_COLUMNS)]
+    # The leading position of the colon for right-align is on the right;
+    # left-align uses a plain dash run.
+
+    remaining_count = runs - 2
+    out_lines: list[str] = [
+        f"`<tool> -h` startup — {runs} runs (remaining = mean of last {remaining_count})",
+        "",
+        line(headers),
+        "| " + " | ".join(sep_cells) + " |",
+        *(line(row) for row in cells),
+    ]
+    # Use Rich with markup off + soft_wrap so brackets in headers aren't
+    # interpreted and long rows don't get terminal-width-wrapped. The
+    # source is then byte-identical to what gets pasted into markdown.
+    ctx.print("\n".join(out_lines), markup=False, soft_wrap=True, highlight=False)


### PR DESCRIPTION
## Summary

PR-2 of the [repo presentation pass](../blob/presentation-pass-2-readme-contributing/specs/2026-05-22-repo-presentation-pass-design.md). Rewrites the README and CONTRIBUTING end-to-end so the front door tells the story the project actually shipped (Rust front-end, sub-millisecond steady-state, per-repo uv-managed venv, static-manifest plugins, SLSA-attested releases), instead of the 2024-era "similar to invoke" framing.

Stacked on **#237** (PR-1: doc correctness fixes).

## The headline numbers

`toolr bench compare` against the Python task-runner field, on Apple M3 Pro / macOS 26.5 / arm64, 20 runs each (steady-state = mean of last 18):

| Tool runner          | `-h` steady-state |
| -------------------- | ----------------: |
| **toolr**            |       **10.4 ms** |
| doit                 |           83.4 ms |
| invoke               |           84.6 ms |
| nox                  |           91.8 ms |
| duty                 |          166.4 ms |
| python-tools-scripts |          252.2 ms |

The full first-run / second-run / steady-state breakdown ships in the README so readers can see the first-run setup cost (277 ms, building the static manifest) is honest.

## What's in this PR

- **`tools/bench.py` + `toolr bench compare`** (cherry-picked from earlier work). The benchmark tool itself. Users can reproduce the README numbers on their own hardware with `toolr bench compare --markdown`.
- **`README.md`** rewritten end-to-end:
    - Bench table near the top, with methodology + a "run it yourself" pointer to `toolr bench compare`.
    - "Why ToolR" replaces the abstract feature list with concrete value-props.
    - "Two wheels, two roles" pinned high so the `toolr` / `toolr-py` split is impossible to miss.
    - Five first-class install paths (mise, pip, curl|sh, PowerShell, GH-archive) with their actual use cases.
    - `toolr project init` + `toolr self completion install` as the "scaffold your repo" step.
    - The "What you write" example uses the canonical `command_group` + `@group.command` bound-decorator form (un-deprecated per the 2026-05-18 keep-bound-command-decorator design).
    - Drops the Hypothesis-as-headline section and the dead `/usage/#advanced-topics` link.
- **`docs/index.md`** widens its README include from `lines=5-15` to `lines=5-18` so the docs landing page surfaces the bench table and methodology line right under the logo.
- **`CONTRIBUTING.md`** rewritten end-to-end:
    - Repo-layout table covering the three-crate workspace.
    - Dev setup leads with `mise`.
    - Test table covering all four suites (Rust unit, Rust integration via `assert_cmd`, Python unit, opt-in distribution lock-tests).
    - Keeps the `RUNNER_SCHEMA_VERSION` ↔ `SCHEMA_VERSION` lock-step section as-is.
    - New "Benchmarking" section pointing at `toolr bench compare`.
    - Explicit repo policies: no `Co-Authored-By`, no `--no-verify` without justification, don't hand-edit `CHANGELOG.md`.

## Verification

- `prek run --all-files` clean — covers `rumdl`, `cargo check`, `clippy`, `codespell`, `typos`, `mypy`, `ruff`.
- `mkdocs build --strict` passes after every commit.
- Bench numbers measured on a fresh release build via the cherry-picked `toolr bench compare`.

## Test plan

- [ ] Render the new `docs/index.md` on a deployed preview and confirm the bench table renders correctly inside the README include.
- [ ] Spot-check the install paths — at minimum the `mise` and `pip` ones — against the docs in `docs/installation/`.
- [ ] Re-run `toolr bench compare --markdown --install` on a different machine; numbers will differ but the ordering should be stable.

## Stack

This is **PR-2 of 3**:

1. PR-1 (**#237**): doc correctness fixes.
2. **PR-2 (this PR):** README + CONTRIBUTING rewrite + `toolr bench`.
3. PR-3 (next): specs/ archival, dead-file cleanup, source-comment vestiges, auto-memory refresh.

_claude --resume d3b44758-ae3b-4a20-86c7-a264f4951f55_