### PR TITLE
fix(dispatch): emit clear error when tools venv python is missing

### DIFF
--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use anyhow::Context as _;
 use clap::ArgMatches;
 
 use toolr_core::complete::{
@@ -188,7 +189,21 @@ pub fn dispatch(
         }
     }
 
-    let (mut child, stderr_capture) = spawn_runner_capturing_stderr(&python, tempfile.path())?;
+    // Pre-check that the resolved Python interpreter actually exists.
+    // Without this, a missing tools venv surfaces as a bare
+    // `io::Error::NotFound` from `Command::spawn`, which `main` prints
+    // as `toolr: No such file or directory (os error 2)` — uninformative
+    // and gives no recovery hint. Mirror the same check `run_introspect`
+    // performs (`crates/toolr-core/src/dynamic/runner.rs`).
+    if !python.is_file() {
+        anyhow::bail!(
+            "Python interpreter not found at {}.\n\
+             Run `toolr project deps sync` to materialise the tools venv.",
+            python.display()
+        );
+    }
+    let (mut child, stderr_capture) = spawn_runner_capturing_stderr(&python, tempfile.path())
+        .with_context(|| format!("spawning Python runner at {}", python.display()))?;
     let status = wait_with_signals(&mut child)?;
     let stderr_bytes = stderr_capture.take();
     let stderr_str = String::from_utf8_lossy(&stderr_bytes);

--- a/crates/toolr/tests/cli_smoke.rs
+++ b/crates/toolr/tests/cli_smoke.rs
@@ -308,6 +308,52 @@ fn preflight_fails_when_an_import_is_missing_from_venv() {
     assert!(stderr.contains("toolr project deps sync"));
 }
 
+/// Regression: deleting the resolved tools venv's `bin/python` between
+/// invocations used to surface as the bare error
+/// `toolr: No such file or directory (os error 2)` — the user couldn't
+/// tell what was missing or how to recover. Dispatch now pre-checks
+/// `python.is_file()` and emits a message that names the path plus
+/// `toolr project deps sync` as the recovery action.
+#[test]
+#[cfg(unix)]
+fn dispatch_emits_clear_error_when_venv_python_is_missing() {
+    use std::fs;
+
+    let tmp = preflight_fixture(&[], &[]);
+    let py = tmp
+        .path()
+        .join("tools")
+        .join(".venv")
+        .join("bin")
+        .join("python");
+    assert!(py.exists(), "fixture should start with a stub python");
+    fs::remove_file(&py).unwrap();
+
+    let output = Command::cargo_bin("toolr")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["ci", "hello"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_ne!(output.status.code(), Some(0), "expected failure; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("Python interpreter not found at"),
+        "expected a 'Python interpreter not found at <path>' line; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("toolr project deps sync"),
+        "expected recovery hint; stderr:\n{stderr}"
+    );
+    // Anti-regression: the old bare `os error 2` line must not be the
+    // entire message.
+    assert!(
+        !stderr.trim().ends_with("No such file or directory (os error 2)")
+            || stderr.contains("Python interpreter not found at"),
+        "stderr should not be just the bare io::Error display; stderr:\n{stderr}"
+    );
+}
+
 /// A two-command fixture exercising pre-flight (top-level import that
 /// the static parser recorded) and post-mortem (inline import the
 /// parser missed) against the same project.


### PR DESCRIPTION
## Summary

When the tools-venv Python interpreter is absent — typical case: the user blew away `~/Library/Caches/toolr/<key>/venv/`, or checked out a branch with a different repo-key hash — the dispatch path's `spawn_runner_capturing_stderr(&python, …)?` returned a bare `std::io::Error::NotFound`. `main.rs::run`'s `eprintln!("toolr: {e:#}")` then printed exactly:

```text
toolr: No such file or directory (os error 2)
```

A single line that names nothing and gives no recovery hint. Hit during \`toolr bench compare\` debugging — same opaque error appeared three times across different sessions before I located the cause.

## Fix

Pre-check `python.is_file()` before spawning, mirroring `run_introspect` (`crates/toolr-core/src/dynamic/runner.rs`, which already does this correctly for the dynamic-layer path). Emit:

```text
toolr: Python interpreter not found at <path>.
Run \`toolr project deps sync\` to materialise the tools venv.
```

Also `.with_context(...)` the spawn call so unexpected `io::Errors` (permission denied, etc.) include the python path in the chain instead of just the bare display.

## Test

`crates/toolr/tests/cli_smoke.rs::dispatch_emits_clear_error_when_venv_python_is_missing` removes the stub `python` from the existing `preflight_fixture` and asserts:

- exit code is non-zero
- stderr contains `Python interpreter not found at`
- stderr contains the `toolr project deps sync` recovery hint
- stderr is *not* just the bare `os error 2` line

## Test plan

- [ ] Manually remove `~/Library/Caches/toolr/<key>/venv/bin/python` and run any user command; verify the new message renders cleanly.
- [ ] Verify `toolr project deps sync` (the recovery hint we point at) actually rebuilds the venv from there.

_claude --resume d3b44758-ae3b-4a20-86c7-a264f4951f55_