### PR TITLE
chore: dead-code cleanup + wire UvError::user_message into production

### DIFF
--- a/crates/toolr-core/src/build_fragment.rs
+++ b/crates/toolr-core/src/build_fragment.rs
@@ -290,7 +290,7 @@ def hello_command(ctx: Context, name: str = "World") -> None:
     /// assert the generated fragment equals the committed JSON byte-for-byte.
     ///
     /// We compare ManifestFragment values (not raw bytes) because byte
-    /// equality is asserted by the CLI golden test in Task 6
+    /// equality is asserted by the CLI golden test
     /// (`serialised_fragment_matches_committed_bytes`). Here we only
     /// need the *value* to match — serialisation ordering is a
     /// separate concern.

--- a/crates/toolr-core/src/cache/enumerate.rs
+++ b/crates/toolr-core/src/cache/enumerate.rs
@@ -45,8 +45,8 @@ pub fn dir_size_bytes(dir: &Path) -> Result<u64> {
 
 /// Enumerate every cache entry directly under `cache_root`. Missing
 /// `cache_root` returns an empty vector. Entries without a `meta.json`
-/// are silently skipped — they predate Plan 8 or were partially
-/// created.
+/// are silently skipped — they predate the sidecar format or were
+/// partially created.
 pub fn enumerate_caches(cache_root: &Path) -> Result<Vec<CachedVenv>> {
     let mut out = Vec::new();
     let read = match std::fs::read_dir(cache_root) {

--- a/crates/toolr-core/src/cache/init.rs
+++ b/crates/toolr-core/src/cache/init.rs
@@ -1,4 +1,4 @@
-//! Hook called by the venv-creation path (Plan 3) to drop a `meta.json`
+//! Hook called by the venv-creation path to drop a `meta.json`
 //! sidecar next to the freshly-built venv.
 
 use std::path::Path;

--- a/crates/toolr-core/src/cache/meta.rs
+++ b/crates/toolr-core/src/cache/meta.rs
@@ -1,10 +1,10 @@
 //! Per-cache-entry `meta.json` sidecar.
 //!
-//! Layout (alongside the venv that Plan 3 manages):
+//! Layout (alongside the venv that `toolr_core::venv` manages):
 //!
 //! ```text
 //! $XDG_CACHE_HOME/toolr/<repo-key>/
-//!     venv/         (managed by Plan 3)
+//!     venv/         (managed by `toolr_core::venv`)
 //!     meta.json     (this module)
 //! ```
 

--- a/crates/toolr-core/src/deps_check/mod.rs
+++ b/crates/toolr-core/src/deps_check/mod.rs
@@ -3,9 +3,9 @@
 //! Two halves:
 //!
 //! - [`probe`] — filesystem-only check that a top-level import exists in
-//!   a venv's `site-packages`. Used by pre-flight (Task 2).
-//! - [`post_mortem`] (Task 6) — parse Python `ImportError` tracebacks
-//!   off subprocess stderr and append the standard suggestion.
+//!   a venv's `site-packages`. Used by the pre-flight check.
+//! - [`post_mortem`] — parse Python `ImportError` tracebacks off
+//!   subprocess stderr and append the standard suggestion.
 
 pub mod post_mortem;
 pub mod preflight;

--- a/crates/toolr-core/src/dynamic/rebuild.rs
+++ b/crates/toolr-core/src/dynamic/rebuild.rs
@@ -24,7 +24,7 @@ pub struct RebuildOutcome {
 /// from the venv) + dynamic layer + write.
 ///
 /// `python` is the absolute path to the tools-venv Python interpreter
-/// (resolved by Plan 3's `toolr_core::venv::resolve_venv_path`).
+/// (resolved by `toolr_core::venv::resolve_venv_path`).
 /// `venv_root` is the venv directory: both globbed for
 /// `site-packages/*/toolr-manifest.json` (via
 /// `build_static_manifest_with_venv`) and hashed via

--- a/crates/toolr-core/src/dynamic/runner.rs
+++ b/crates/toolr-core/src/dynamic/runner.rs
@@ -25,9 +25,9 @@ pub enum IntrospectError {
 /// Run the dynamic introspection helper.
 ///
 /// `python` is the absolute path to the Python interpreter inside the
-/// tools venv (resolved by `toolr_core::venv` from Plan 3). `tools_dir`
-/// is the project's `tools/` directory; the helper inserts its parent on
-/// `sys.path` before importing.
+/// tools venv (resolved by `toolr_core::venv::resolve_venv_path`).
+/// `tools_dir` is the project's `tools/` directory; the helper
+/// inserts its parent on `sys.path` before importing.
 pub fn run_introspect(python: &Path, tools_dir: &Path) -> Result<DynamicPayload, IntrospectError> {
     if !python.is_file() {
         return Err(IntrospectError::PythonMissing(python.to_path_buf()));

--- a/crates/toolr-core/src/execute/python.rs
+++ b/crates/toolr-core/src/execute/python.rs
@@ -1,7 +1,10 @@
-//! Resolve a Python interpreter to use for `python -m toolr._runner`.
+//! Fallback Python interpreter resolution for projects without a
+//! `tools/pyproject.toml` (i.e. no tools venv). Resolves
+//! `$TOOLR_PYTHON` → `python3` on PATH → `python` on PATH.
 //!
-//! Plan 2 ships the minimal viable lookup. Plan 3 replaces this with a
-//! resolved tools-venv interpreter under `<venv>/bin/python`.
+//! The primary path resolves Python via the tools venv
+//! (`<venv>/bin/python`, see `toolr_core::venv::resolve_venv_path`);
+//! this module is the legacy-shape fallback.
 
 use std::env;
 use std::path::PathBuf;

--- a/crates/toolr-core/src/manifest/model.rs
+++ b/crates/toolr-core/src/manifest/model.rs
@@ -75,7 +75,8 @@ pub struct Command {
     pub description: String,
     /// Ordered list of arguments.
     pub arguments: Vec<Argument>,
-    /// Top-level imports recorded by the static parser (used by Plan 7).
+    /// Top-level imports recorded by the static parser. Consumed by
+    /// the pre-flight missing-dependency check in `deps_check`.
     #[serde(default)]
     pub imports: Vec<String>,
     /// Where this command entry came from.

--- a/crates/toolr-core/src/project.rs
+++ b/crates/toolr-core/src/project.rs
@@ -22,7 +22,7 @@ pub fn ensure_venv_ready(
         .context("locating project root for the tools venv")?;
     let resolved = resolve_venv_path(&repo_root)
         .context("resolving the tools venv path")?;
-    let uv = ensure_uv(consent).map_err(anyhow::Error::from)?;
+    let uv = ensure_uv(consent).map_err(|e| anyhow::anyhow!(e.user_message()))?;
     let tools = repo_root.join("tools");
     sync_if_needed(&uv, &tools, &resolved, force_sync)
         .with_context(|| format!("uv sync against {}", tools.display()))?;

--- a/crates/toolr-core/src/uv/mod.rs
+++ b/crates/toolr-core/src/uv/mod.rs
@@ -1,6 +1,6 @@
 //! `uv` integration: discovery, consent-based install, and sync invocation.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use thiserror::Error;
 
@@ -55,6 +55,33 @@ pub enum UvError {
     SyncFailed(Option<i32>),
 }
 
+impl UvError {
+    /// Render this error as a user-facing message with recovery hints.
+    ///
+    /// `Display` gives a technical one-liner suitable for log lines and
+    /// anyhow chains; `user_message` is the version meant for stderr at
+    /// the CLI surface, with concrete next steps the user can act on.
+    /// Callers should prefer this when they know they're producing the
+    /// final user-visible error (typically wrapped in `anyhow::anyhow!`
+    /// so `main`'s `"toolr: {e:#}"` prefix lands once and only once).
+    pub fn user_message(&self) -> String {
+        match self {
+            Self::UserRefusedInstall => {
+                "uv is required for this command. Install from \
+                 https://docs.astral.sh/uv/getting-started/installation/ \
+                 and rerun, or set TOOLR_AUTO_INSTALL_UV=1."
+                    .into()
+            }
+            Self::VersionTooOld { found, required } => format!(
+                "uv on PATH is {}.{}.{}, but toolr requires \
+                 >= {}.{}.{}. Upgrade uv and try again.",
+                found.0, found.1, found.2, required.0, required.1, required.2,
+            ),
+            other => other.to_string(),
+        }
+    }
+}
+
 /// Where toolr keeps its private state (binaries, etc).
 /// Defaults to `$XDG_DATA_HOME/toolr`, falling back to
 /// `~/.local/share/toolr` if `XDG_DATA_HOME` is unset.
@@ -80,11 +107,6 @@ pub fn managed_uv_path() -> Option<PathBuf> {
 
 fn uv_basename() -> &'static str {
     if cfg!(windows) { "uv.exe" } else { "uv" }
-}
-
-/// Optional binary-resolution helper to be exposed in later tasks.
-pub fn _placeholder(_path: &Path) -> Option<UvBinary> {
-    None
 }
 
 use install::perform_install;
@@ -184,14 +206,6 @@ mod tests {
     }
 
     #[test]
-    fn placeholder_helper_always_returns_none() {
-        // The `_placeholder` symbol is a stub that reserves the
-        // resolution surface for later work. Asserting `None` keeps it
-        // a no-op until someone wires it up.
-        assert!(_placeholder(Path::new("/anywhere")).is_none());
-    }
-
-    #[test]
     fn uv_error_display_strings_remain_descriptive() {
         // We don't want a future refactor to swap these for "error" or
         // an empty message — keep the user-facing text descriptive.
@@ -238,5 +252,38 @@ mod tests {
         let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
         let uv: UvError = io.into();
         assert!(matches!(uv, UvError::Io(_)));
+    }
+
+    #[test]
+    fn user_message_for_refused_install_names_the_install_url_and_env_var() {
+        let s = UvError::UserRefusedInstall.user_message();
+        assert!(s.contains("uv is required"));
+        assert!(s.contains("https://docs.astral.sh/uv/"));
+        assert!(s.contains("TOOLR_AUTO_INSTALL_UV"));
+        // Anti-regression: must not double-prefix `toolr: ` — main.rs
+        // adds that once at the CLI surface.
+        assert!(!s.starts_with("toolr:"), "actual: {s}");
+    }
+
+    #[test]
+    fn user_message_for_version_too_old_names_both_versions() {
+        let s = UvError::VersionTooOld {
+            found: (0, 1, 2),
+            required: (3, 4, 5),
+        }
+        .user_message();
+        assert!(s.contains("0.1.2"), "actual: {s}");
+        assert!(s.contains("3.4.5"), "actual: {s}");
+        assert!(s.contains("Upgrade uv"), "actual: {s}");
+        assert!(!s.starts_with("toolr:"), "actual: {s}");
+    }
+
+    #[test]
+    fn user_message_for_other_variants_falls_through_to_display() {
+        // Variants without bespoke recovery hints fall back to the
+        // technical `Display` string. Still no `toolr:` prefix.
+        let s = UvError::NotAvailable.user_message();
+        assert_eq!(s, UvError::NotAvailable.to_string());
+        assert!(!s.starts_with("toolr:"), "actual: {s}");
     }
 }

--- a/crates/toolr-py/python/toolr/_decorators.py
+++ b/crates/toolr-py/python/toolr/_decorators.py
@@ -1,13 +1,12 @@
 """User-facing decorator surface for declaring toolr command groups and commands.
 
-This module survives the retirement of the Python CLI frontend
-(``_parser.py`` / ``_registry.py``). User tool scripts continue to do::
+User tool scripts import from this module::
 
     from toolr import command, command_group
 
-and the decorators record metadata in a process-local registry. The
-Rust binary's static parser and the manifest builder consume that
-registry; there is no longer an in-process Python argparse driver.
+The decorators record metadata in a process-local registry. The Rust
+binary's static parser and the manifest builder consume that registry;
+the CLI surface itself is a Rust binary, not Python.
 """
 
 from __future__ import annotations
@@ -172,10 +171,10 @@ def command(
 ) -> Callable[..., Any]:
     """Register a function as a toolr CLI command.
 
-    String-path attachment to a group, used as an alternative to the
-    legacy ``@<binding>.command`` decorator. Lets you declare commands
-    in any file without importing a shared ``CommandGroup`` binding —
-    the ``group=`` string is the only contract.
+    String-path attachment to a group, an alternative to the bound
+    ``@<binding>.command`` form. Lets you declare commands in any
+    file without importing a shared ``CommandGroup`` binding — the
+    ``group=`` string is the only contract.
 
     Usage::
 

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -40,10 +40,10 @@ if TYPE_CHECKING:
 
 # Promote toolr's own deprecation warnings to visible-by-default. The
 # stdlib silences DeprecationWarning by default for non-__main__ code,
-# which means user `tools/*.py` files would never surface the legacy
-# decorator warnings. Filter is per-location ("default") so each call
-# site fires once per process — keeps output bounded across runs with
-# many legacy decorators.
+# which means user `tools/*.py` files would never surface the
+# `parent.command_group("child", ...)` deprecation. Filter is
+# per-location ("default") so each call site fires once per process —
+# keeps output bounded across runs with many deprecated call sites.
 warnings.simplefilter("default", ToolrDeprecationWarning)
 
 SCHEMA_VERSION: int = 1

--- a/crates/toolr-py/python/toolr/testing.py
+++ b/crates/toolr-py/python/toolr/testing.py
@@ -1,18 +1,13 @@
 """
-Utilities for testing ToolR and supported commands.
+Utilities for testing ToolR commands and command-group discovery.
 
-Survives the retirement of the Python CLI frontend
-(``_parser.py`` / ``_registry.py``). Instead of the legacy in-process
-``CommandRegistry``, this helper patches the registry storage in
+``CommandsTester`` patches the registry storage in
 :mod:`toolr._decorators` and drives the same Python-side discovery
 that the Rust binary's dynamic manifest layer uses
 (``toolr._introspect.build_payload``).
 
-The API surface remains the same: ``with CommandsTester(search_path=...) as t``
-yields an isolated collector available via ``t.collected_command_groups()``.
-
-Third-party entry-point loading has been removed; plugins must
-ship a static ``toolr-manifest.json`` instead.
+Usage: ``with CommandsTester(search_path=...) as t`` yields an
+isolated collector available via ``t.collected_command_groups()``.
 """
 
 from __future__ import annotations

--- a/crates/toolr-py/python/toolr/utils/_signature.py
+++ b/crates/toolr-py/python/toolr/utils/_signature.py
@@ -220,9 +220,9 @@ def arg_section(title: str, *, description: str | None = None) -> ArgSection:
 class ArgumentAnnotation(Struct, frozen=True):
     """Metadata harvested from ``Annotated[T, arg(...)]``.
 
-    The python runtime keeps the fields it actually uses (the legacy
-    argparse-era kwargs); the rust static parser independently reads
-    the same call expression and harvests the kwargs *it* uses, so the
+    The python runtime keeps only the fields it actually uses at
+    invocation time; the rust static parser independently reads the
+    same call expression and harvests the kwargs *it* uses, so the
     two sides don't need a serialised representation of this struct.
     """
 

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -139,9 +139,10 @@ pub fn dispatch(
     };
 
     let tempfile = write_spec_to_tempfile(&spec)?;
-    // Prefer the resolved tools-venv python (Plan 3). Fall back to the
-    // PATH/TOOLR_PYTHON lookup only when there is no `tools/pyproject.toml`
-    // — i.e. legacy projects that never opted into the venv layer.
+    // Prefer the resolved tools-venv python. Fall back to the
+    // PATH/TOOLR_PYTHON lookup only when there is no
+    // `tools/pyproject.toml` — i.e. projects that never opted into
+    // the per-repo venv layer.
     let (python, venv_dir, python_version) =
         if repo_root.join("tools").join("pyproject.toml").is_file() {
             let resolved = resolve_venv_path(&repo_root)?;
@@ -154,7 +155,7 @@ pub fn dispatch(
             (resolve_python()?, None, None)
         };
 
-    // Plan 8: touch last_used_at on every invocation against a cached venv.
+    // Touch last_used_at on every invocation against a cached venv.
     // Backfill a fresh `meta.json` for cache entries that predate the
     // sidecar — without this, `toolr self cache list` would silently
     // hide venvs created by older binaries.
@@ -172,8 +173,8 @@ pub fn dispatch(
         }
     }
 
-    // Pre-flight missing-dependency check (Plan 7). Skip when the user
-    // sets `TOOLR_NO_PREFLIGHT_DEPS` to a non-empty, non-`0` value —
+    // Pre-flight missing-dependency check. Skip when the user sets
+    // `TOOLR_NO_PREFLIGHT_DEPS` to a non-empty, non-`0` value —
     // post-mortem interception still catches inline imports.
     let skip_preflight = std::env::var_os("TOOLR_NO_PREFLIGHT_DEPS")
         .is_some_and(|v| !v.is_empty() && v != "0");
@@ -592,9 +593,9 @@ mod tests {
 #[cfg(test)]
 mod path_lookup_tests {
     //! Unit tests for `find_command_for_path`, the pure helper that
-    //! resolves a parsed subcommand path to its manifest entry. After
-    //! Task 6 grafts children under dispatchers, a 3-segment path like
-    //! `toolr jenkins job migrate` must still find `migrate` at
+    //! resolves a parsed subcommand path to its manifest entry.
+    //! Grafted children of a dispatcher live under a 3-segment path
+    //! like `toolr jenkins job migrate`, but `migrate` is stored at
     //! `group == "jenkins"` (the dispatcher hop is invisible to the
     //! manifest). These tests pin the most-specific-first preference
     //! and the one-level fallback.

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -439,7 +439,8 @@ fn run_install_uv_now() -> anyhow::Result<std::process::ExitCode> {
         yes_flag: true,
         auto_install_env: true,
     };
-    let uv = toolr_core::uv::ensure_uv(consent)?;
+    let uv = toolr_core::uv::ensure_uv(consent)
+        .map_err(|e| anyhow::anyhow!(e.user_message()))?;
     println!(
         "toolr: uv {}.{}.{} ready at {} (source: {:?})",
         uv.version.0,
@@ -480,25 +481,6 @@ fn output_options_from_matches(matches: &ArgMatches) -> OutputOptions {
     opts
 }
 
-#[allow(dead_code)]
-pub(crate) fn report_uv_error(err: &toolr_core::uv::UvError) -> String {
-    use toolr_core::uv::UvError;
-    match err {
-        UvError::UserRefusedInstall => {
-            "toolr: uv is required for this command. Install from \
-             https://docs.astral.sh/uv/getting-started/installation/ \
-             and rerun, or set TOOLR_AUTO_INSTALL_UV=1."
-                .into()
-        }
-        UvError::VersionTooOld { found, required } => format!(
-            "toolr: uv on PATH is {}.{}.{}, but toolr requires \
-             >= {}.{}.{}. Upgrade uv and try again.",
-            found.0, found.1, found.2, required.0, required.1, required.2,
-        ),
-        other => format!("toolr: {other}"),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     //! In-process unit tests for the pure helpers in this module.
@@ -510,37 +492,6 @@ mod tests {
     //! subprocess profraws by default). These unit tests run inside the
     //! test process so the coverage counter actually moves.
     use super::*;
-    use toolr_core::uv::UvError;
-
-    // ----------------------------------------------------------------
-    // report_uv_error: one assertion per variant.
-    // ----------------------------------------------------------------
-
-    #[test]
-    fn report_uv_error_renders_user_refused_install() {
-        let s = report_uv_error(&UvError::UserRefusedInstall);
-        assert!(s.contains("uv is required"));
-        assert!(s.contains("TOOLR_AUTO_INSTALL_UV"));
-    }
-
-    #[test]
-    fn report_uv_error_renders_version_too_old() {
-        let s = report_uv_error(&UvError::VersionTooOld {
-            found: (0, 1, 2),
-            required: (3, 4, 5),
-        });
-        assert!(s.contains("0.1.2"), "actual: {s}");
-        assert!(s.contains("3.4.5"), "actual: {s}");
-        assert!(s.contains("Upgrade uv"), "actual: {s}");
-    }
-
-    #[test]
-    fn report_uv_error_renders_other_variant() {
-        // Any non-(UserRefused|VersionTooOld) variant falls into the
-        // catch-all `format!("toolr: {other}")` arm.
-        let s = report_uv_error(&UvError::NotAvailable);
-        assert!(s.starts_with("toolr:"), "actual: {s}");
-    }
 
     // ----------------------------------------------------------------
     // dirs_home: $HOME present / absent.

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -733,7 +733,7 @@ mod dispatched_pack_tests {
         let packed = pack_child_args(&cmd, &matches);
         assert_eq!(packed.name, "migrate");
         assert_eq!(packed.args.get("check"), Some(&Value::Bool(true)));
-        // Schema round-trips intact (Task 17 reads it on the Python side).
+        // Schema round-trips intact for the Python runner to consume.
         assert_eq!(packed.schema.dispatched_from.as_deref(), Some("argparse:django"));
         assert_eq!(packed.schema.function, "django");
     }

--- a/crates/toolr/src/init_templates.rs
+++ b/crates/toolr/src/init_templates.rs
@@ -1,11 +1,4 @@
 //! Embedded scaffold templates for `toolr project init`.
-//!
-//! These items are wired into the dispatcher in a later task; until then
-//! the symbols are unused. Suppress `dead_code` here rather than
-//! sprinkling `#[allow]` attributes on every item.
-#![allow(dead_code)]
-
-use std::path::Path;
 
 /// Where the tools venv should live.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,10 +69,6 @@ pub fn parse_venv_location(value: &str) -> anyhow::Result<VenvLocation> {
         other => anyhow::bail!("invalid --venv-location value: {other} (use cache or in-tree)"),
     }
 }
-
-/// Suppress the unused `Path` import warning until Task 4 uses it.
-#[allow(dead_code)]
-fn _path_is_used(_p: &Path) {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/toolr/tests/cli_smoke.rs
+++ b/crates/toolr/tests/cli_smoke.rs
@@ -55,11 +55,12 @@ fn help_lists_groups_from_manifest() {
 /// `toolr` package installed is available, otherwise `None`. We accept
 /// the project's own dev venv (created by `uv sync`) as the runner.
 ///
-/// These smoke tests deliberately exercise the *legacy* fallback path in
-/// `dispatch.rs`: they write a `tools/.toolr-manifest.json` but no
-/// `tools/pyproject.toml`, so the dispatcher resolves Python via
-/// `TOOLR_PYTHON` rather than the tools venv. The full venv-driven path
-/// is covered by the network-dependent `end_to_end_sync` test (Task 17).
+/// These smoke tests deliberately exercise the no-pyproject fallback
+/// path in `dispatch.rs`: they write a `tools/.toolr-manifest.json`
+/// but no `tools/pyproject.toml`, so the dispatcher resolves Python
+/// via `TOOLR_PYTHON` rather than the tools venv. The full
+/// venv-driven path is covered by the network-dependent
+/// `end_to_end_sync` test.
 fn detect_test_python() -> Option<PathBuf> {
     let candidate = std::env::var_os("TOOLR_TEST_PYTHON").map(PathBuf::from);
     let candidate = candidate.or_else(|| {
@@ -227,7 +228,7 @@ fn preflight_fixture(
         fs::create_dir(&pkg).unwrap();
         fs::write(pkg.join("__init__.py"), "").unwrap();
     }
-    // `toolr` itself must appear installed so Plan 3's validate guard
+    // `toolr` itself must appear installed so the venv-validate guard
     // (if any) doesn't trip the dispatcher before pre-flight runs.
     let toolr_pkg = sp.join("toolr");
     fs::create_dir_all(&toolr_pkg).unwrap();
@@ -270,9 +271,9 @@ fn preflight_fixture(
     let mut f = fs::File::create(&py).unwrap();
     writeln!(f, "#!/bin/sh").unwrap();
     // The dispatcher invokes `python -m toolr._introspect ...` during
-    // auto-rebuild (Plan 6) and `python -m toolr._runner` during the
-    // actual command execution. Branch on the argv so both work without
-    // a real Python.
+    // auto-rebuild and `python -m toolr._runner` during the actual
+    // command execution. Branch on the argv so both work without a
+    // real Python.
     writeln!(f, r#"case " $* " in"#).unwrap();
     writeln!(
         f,

--- a/crates/toolr/tests/dispatch_coverage.rs
+++ b/crates/toolr/tests/dispatch_coverage.rs
@@ -19,9 +19,6 @@
 //! - `resolve_python_for_build()` explicit `--python` override + bail (188-211).
 //! - `output_options_from_matches()` flag propagation (366-390) — verified
 //!   indirectly by inspecting the spec the Python runner receives.
-//! - `report_uv_error()` per error variant (392-409).
-
-use std::path::Path;
 
 use assert_cmd::Command;
 use tempfile::TempDir;
@@ -247,27 +244,4 @@ fn root_help_advertises_every_output_option() {
             "expected `{needle}` in --help output, got:\n{stdout}"
         );
     }
-}
-
-// --------------------------------------------------------------------
-// report_uv_error(): pure helper, but only reachable indirectly.
-// We exercise the rendering by injecting a manifest that requires
-// __install-uv-now, which is the only callsite that surfaces a UvError.
-// In practice the function is reachable from the binary's own
-// `report_uv_error` use only when ensure_uv fails — that requires
-// network / filesystem mocking. We rely on the unit tests in toolr-core
-// (where `UvError` is defined) for the error-shape coverage and don't
-// add a parallel rust-binary integration test here.
-// --------------------------------------------------------------------
-
-// (intentionally no test for report_uv_error — see note above)
-
-// --------------------------------------------------------------------
-// Fixture: a Path that exists. Used by the explicit-python tests
-// alongside `nonexistent`.
-// --------------------------------------------------------------------
-
-#[allow(dead_code)]
-fn touch_file(at: &Path) {
-    std::fs::write(at, "").unwrap();
 }

--- a/crates/toolr/tests/end_to_end_sync.rs
+++ b/crates/toolr/tests/end_to_end_sync.rs
@@ -1,5 +1,5 @@
-//! End-to-end smoke. Requires network access (uv download) and that
-//! Plan 2's runner is already wired. Run explicitly with:
+//! End-to-end smoke. Requires network access (uv download). Run
+//! explicitly with:
 //!
 //!     cargo test --test end_to_end_sync -- --ignored --nocapture
 
@@ -24,7 +24,7 @@ fn deps_sync_then_run_user_command() {
     let tools = tmp.path().join("tools");
     std::fs::create_dir(&tools).unwrap();
     std::fs::write(tools.join("pyproject.toml"), PYPROJECT).unwrap();
-    // A minimal command file so Plan 1 picks up a group.
+    // A minimal command file so the static parser finds a group.
     std::fs::write(
         tools.join("ci.py"),
         r#"
@@ -60,8 +60,8 @@ def hello(ctx):
         .assert()
         .success();
 
-    // 3. Run the user command — Plan 2's runner now executes via the
-    //    venv python.
+    // 3. Run the user command — the runner now executes via the venv
+    //    python.
     let output = Command::cargo_bin("toolr")
         .unwrap()
         .current_dir(tmp.path())

--- a/crates/toolr/tests/uv_install_offline.rs
+++ b/crates/toolr/tests/uv_install_offline.rs
@@ -1,5 +1,6 @@
 //! Offline tests for the install path. The network-touching
-//! `perform_install` is exercised manually by the implementer in Task 4.3.
+//! `perform_install` is not covered here; verify it manually when
+//! changing the install flow.
 
 use toolr_core::uv::install::{asset_url, host_asset};
 

--- a/tests/distribution/test_toolr_py_wheel.py
+++ b/tests/distribution/test_toolr_py_wheel.py
@@ -24,23 +24,11 @@ EXPECTED_PRESENT = [
     "toolr/utils/command.py",
 ]
 
-EXPECTED_ABSENT = [
-    "toolr/__main__.py",
-    "toolr/_parser.py",
-    "toolr/_registry.py",
-]
-
 
 def test_toolr_py_wheel_contains_python_source(toolr_py_wheel: Path) -> None:
     names = set(wheel_namelist(toolr_py_wheel))
     missing = [p for p in EXPECTED_PRESENT if p not in names]
     assert not missing, f"toolr-py wheel missing expected files: {missing}"
-
-
-def test_toolr_py_wheel_does_not_re_ship_retired_modules(toolr_py_wheel: Path) -> None:
-    names = set(wheel_namelist(toolr_py_wheel))
-    re_shipped = [p for p in EXPECTED_ABSENT if p in names]
-    assert not re_shipped, f"toolr-py wheel re-shipped retired CLI modules: {re_shipped}"
 
 
 def test_toolr_py_wheel_ships_dynlib(toolr_py_wheel: Path) -> None:

--- a/tests/introspect/test_introspect_unit.py
+++ b/tests/introspect/test_introspect_unit.py
@@ -323,24 +323,6 @@ def test_build_payload_with_no_tools_root_returns_empty_state(
     assert payload["commands"] == []
 
 
-def test_build_payload_ignores_registered_entry_points(
-    tools_fixture: Path,
-    clean_registry: dict[str, Any],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Entry-point packages must not be loaded; toolr.commands support is removed."""
-    del clean_registry
-    called: list[str] = []
-
-    def fake_entry_points(*, group: str) -> list[object]:
-        called.append(group)
-        return []
-
-    monkeypatch.setattr("importlib.metadata.entry_points", fake_entry_points)
-    build_payload(str(tools_fixture))
-    assert called == [], "build_payload must not call importlib.metadata.entry_points"
-
-
 # --------------------------------------------------------------------
 # main() — argparse + JSON output
 # --------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three commits, all dead-code cleanup discovered during a post-presentation-pass audit. No behaviour change in steady state, but **one user-visible UX fix**: `UvError`'s recovery hints now actually reach the user.

## Commits

### 1. `fix(dispatch): wire UvError::user_message into production error paths`

`report_uv_error` in `crates/toolr/src/dispatch.rs` was `pub(crate)` + `#[allow(dead_code)]`, exercised only by its own three unit tests. The two real production sites (`run_install_uv_now`, `ensure_venv_ready`) propagated `UvError` raw via anyhow's `?` — so the helper's recovery hints ("Install uv from astral.sh", "Upgrade uv and try again", "set TOOLR_AUTO_INSTALL_UV=1") never reached the user.

Moved the rendering onto `UvError` itself as `user_message()` in `crates/toolr-core/src/uv/mod.rs`. Both call sites now do:

```rust
let uv = toolr_core::uv::ensure_uv(consent)
    .map_err(|e| anyhow::anyhow!(e.user_message()))?;
```

Dropped the leading "toolr: " prefix from the message strings — `main.rs`'s `eprintln!("toolr: {e:#}")` adds it once. Three new unit tests assert content + the anti-double-prefix invariant.

Also dropped the dead `_placeholder()` stub in `uv/mod.rs` (another archived-roadmap survivor).

### 2. `chore: drop dead test helpers and migration-era regression tests`

Five removals (-71 lines):

- `init_templates.rs` file-level `#![allow(dead_code)]` blanket (no longer accurate; everything's used) + `_path_is_used()` no-op ("until Task 4 uses it" — Task 4 shipped and was archived).
- `dispatch_coverage.rs::touch_file()` (defined, never called).
- `tests/distribution/test_toolr_py_wheel.py::EXPECTED_ABSENT` (guarded the deleted Python CLI frontend modules from re-appearing; that retirement was months ago).
- `tests/introspect/test_introspect_unit.py::test_build_payload_ignores_registered_entry_points` (guarded that entry-point discovery stays removed; same vintage).

### 3. `chore: rewrite Plan N / Task N comments + tighten migration prose`

22 source-comment / docstring references to archived rust-front-end plans across 11 source files + 4 test files. Each rewritten to describe what the code does *now*. Most notable:

- `crates/toolr-core/src/execute/python.rs` header rewrite (was "Plan 2 ships ... Plan 3 replaces this" — the latter never happened in this file).
- `_decorators.py` and `testing.py` module docstrings dropped the "Survives the retirement of the Python CLI frontend" framing.
- `_decorators.py:176` no longer calls `@<binding>.command` "legacy" (it's canonical per the 2026-05-18 keep-bound design).
- `_runner.py:46` singular-ed the "many legacy decorators" wording (only one form is still deprecated).

## Verification

- `cargo check --workspace` clean.
- `cargo clippy --workspace --all-targets` clean.
- `cargo test` on changed crates pass (`toolr-core` uv suite + `toolr` cli_smoke / dispatch_coverage).
- `uv run pytest tests/decorators tests/utils/signature` green (65 tests).
- `prek run --all-files` clean.

`cargo test --workspace` was *not* run in full — there's a pre-existing hang in `crates/toolr-core/src/command/command_test.rs::test_no_output_timeout` (uses `time.sleep(10)` + `no_output_timeout_secs: 0.1`; should take 300ms, runs forever). That's unrelated to this PR; filing separately.

## Test plan

- [ ] Trigger a uv error (e.g. `TOOLR_AUTO_INSTALL_UV=0 toolr __install-uv-now` on a machine without uv) and verify the new recovery hints appear instead of the raw error string.
- [ ] Verify pre-existing behavioural tests in cli_smoke / dispatch_coverage / introspect / distribution remain green.

_claude --resume d3b44758-ae3b-4a20-86c7-a264f4951f55_
