### PR TITLE
chore(mise): single `mise run test` entry point

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -12,3 +12,19 @@ _.python.venv = { path = ".venv", create = true, uv_create_args = ['--seed'] }
 
 [settings]
 python.uv_venv_auto = true
+
+# --------------------------------------------------------------------
+# `mise run test` is the single entry-point a contributor (or CI)
+# calls to run everything. The pre-existing `cargo-test` and
+# `pytest-test` tasks (in `.mise-tasks/`) remain available for
+# scoping to one language when iterating. The opt-in distribution
+# suite is slow (builds real wheels) and is NOT included here — run
+# `uv run pytest -m distribution` explicitly when changing packaging.
+# --------------------------------------------------------------------
+
+[tasks.test]
+description = "Run the full default test suite (cargo workspace + pytest)."
+run = [
+    "cargo test --workspace",
+    "mise run pytest-test",
+]


### PR DESCRIPTION
## Summary

Audit Plan 5: contributors had four ways to run tests (pytest, `cargo test`, the existing `.mise-tasks/cargo-test.sh`, the existing `.mise-tasks/pytest-test.sh`) and no single "everything I'd run before pushing" entry point.

This PR adds `[tasks.test]` to `mise.toml`:

```sh
mise run test
```

That runs `cargo test --workspace` then delegates to the existing `pytest-test` task (which itself runs `mise run develop-toolr-py` + `uv run pytest -s -ra -v`). The slow distribution suite is excluded — run it explicitly with `uv run pytest -m distribution`.

Pre-existing scoped tasks (`mise run cargo-test`, `mise run pytest-test`) are untouched and remain available for single-language iteration.

## Stack

Stacked on **#243** (Plan 1: fix the hung test). Without that, `cargo test --workspace` hangs on `test_no_output_timeout` and this aggregate never completes — so this PR is only meaningful once #243 lands.

## Test plan

- [ ] `mise run test` from a clean checkout runs both suites and exits 0.
- [ ] CONTRIBUTING.md mentions the new entry point (follow-up doc change; not in this PR).

_claude --resume d3b44758-ae3b-4a20-86c7-a264f4951f55_
