### PR TITLE
docs(writing-commands): document toolr.testing.CommandsTester

### DIFF
--- a/docs/writing-commands/index.md
+++ b/docs/writing-commands/index.md
@@ -15,7 +15,9 @@ section you need:
 5. [Annotations](annotations.md) — `arg()` for aliases, choices,
    mutually exclusive groups.
 6. [Nested groups](nesting.md) — multi-level command hierarchies.
-7. [Known bugs](known-bugs.md) — GA-blocking gaps in the current
+7. [Testing your commands](testing.md) — drive Python-side
+   discovery from pytest via `toolr.testing.CommandsTester`.
+8. [Known bugs](known-bugs.md) — GA-blocking gaps in the current
    rust-front-end build.
 
 Every example on these pages is a real file under

--- a/docs/writing-commands/testing.md
+++ b/docs/writing-commands/testing.md
@@ -1,0 +1,107 @@
+# Testing your commands
+
+ToolR ships a small testing helper in the `toolr-py` wheel — `toolr.testing.CommandsTester` — that lets you write pytest assertions against your `tools/*.py` discovery without invoking the `toolr` binary as a subprocess.
+
+It's designed for the case where you want to test *your own* command modules: "does my decorator land in the registry?", "do my command groups collect the right commands?", "does my dispatcher pick up the right children?". For end-to-end behaviour (Tab completion, `--help` output, real subprocess execution) you'll still want to drive the binary directly.
+
+## What it does
+
+`CommandsTester(search_path=tmp_path)` is a context manager that:
+
+1. Saves and replaces `sys.path` so only `search_path` and the host's `site-packages` are visible — your fixture's `tools/` tree wins.
+2. Patches `toolr._decorators._get_command_group_storage` with a fresh `dict` so the test gets an isolated registry.
+3. Restores everything on exit (`sys.path`, `sys.modules`, `cwd`).
+
+Calling `.discover()` inside the context runs the same `tools/`-import pass that `python -m toolr._introspect` runs for the Rust binary's dynamic manifest layer. After it returns, `.collected_command_groups()` gives you a `{full_name: CommandGroup}` dict you can assert against.
+
+## Usage
+
+```python
+from pathlib import Path
+
+from toolr.testing import CommandsTester
+
+
+def test_my_tools_register_a_group(tmp_path: Path) -> None:
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    (tools / "ci.py").write_text(
+        '"""CI helpers."""\n'
+        "from toolr import Context, command_group\n"
+        "\n"
+        'ci = command_group("ci", "CI", "CI helpers")\n'
+        "\n"
+        "@ci.command\n"
+        "def hello(ctx: Context, name: str = 'world') -> None:\n"
+        "    ctx.print(f'hi {name}')\n",
+    )
+
+    with CommandsTester(search_path=tmp_path) as tester:
+        tester.discover()
+        groups = tester.collected_command_groups()
+
+    assert "tools.ci" in groups
+    assert "hello" in groups["tools.ci"].get_commands()
+```
+
+A typical pytest fixture wires the boilerplate once per test:
+
+```python
+import pytest
+from collections.abc import Iterator
+from pathlib import Path
+from toolr.testing import CommandsTester
+
+
+@pytest.fixture
+def commands_tester(tmp_path: Path) -> Iterator[CommandsTester]:
+    tester = CommandsTester(search_path=tmp_path)
+    with tester:
+        tester.discover()
+        yield tester
+```
+
+## What you can assert
+
+`collected_command_groups()` returns a dict keyed by the dotted full name (e.g. `tools.ci`, `tools.docker.image`). Each value is a `toolr._decorators.CommandGroup` instance, which exposes:
+
+- `name`, `title`, `description`, `parent` — what you passed to `command_group(...)`.
+- `full_name` — same key the dict uses.
+- `get_commands()` → `dict[name, Callable]` of registered commands.
+
+Common assertions:
+
+```python
+groups = tester.collected_command_groups()
+
+# A group exists at the expected dotted path.
+assert "tools.docker.image" in groups
+
+# A command is registered under it.
+assert "build" in groups["tools.docker.image"].get_commands()
+
+# A specific function got decorated.
+assert groups["tools.docker.image"].get_commands()["build"].__name__ == "build"
+
+# Cross-file attachment: a group declared in one file, commands added from another.
+assert {"helm-diff-pr-comment", "snippet-checker"} <= set(
+    groups["tools.ci"].get_commands().keys()
+)
+```
+
+## What it can't do
+
+`CommandsTester` only exercises the Python-side discovery path. It deliberately does not:
+
+- Boot the Rust binary or invoke clap.
+- Build a real `tools/.toolr-manifest.json`.
+- Spawn `toolr` as a subprocess.
+- Run the static AST parser (which is the *Rust* path; this helper drives only the *dynamic* / runtime-import path).
+
+If you need any of those, drive the `toolr` binary directly via `subprocess` (`shutil.which("toolr")` works under `mise` / `pip install toolr` / the install scripts), or use `assert_cmd` from a Rust integration test.
+
+## Stability
+
+`toolr.testing.CommandsTester` is part of toolr-py's public API and is tested in toolr's own suite. Its surface — the constructor, the context-manager protocol, `.discover()`, and `.collected_command_groups()` — is stable across the pre-1.0 series; any change is called out in the changelog.
+
+Internal attributes (`sys_path`, `sys_modules`, `command_group_patcher`, `cwd`) are implementation detail and may change without notice.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
     - Annotations: writing-commands/annotations.md
     - Scaling across files: writing-commands/across-files.md
     - Nested groups: writing-commands/nesting.md
+    - Testing your commands: writing-commands/testing.md
     - Known bugs: writing-commands/known-bugs.md
   - Migration (nested subgroup form): migration.md
   - Project configuration: project-config.md


### PR DESCRIPTION
## Summary

Audit Plan 4: decide on `toolr.testing`.

The module ships in the production `toolr-py` wheel but was undocumented outside its own docstring, and its only importer was `tests/conftest.py:10`. The audit flagged this as half-committed.

**Decision:** keep + document as stable public API. `CommandsTester` is genuinely useful for any project writing toolr commands that wants to assert command discovery from pytest without spawning the binary. Splitting it out (separate package, dev-deps changes, breaking any external user already importing it) costs more than documenting it.

## What's in the PR

- **`docs/writing-commands/testing.md`** (new): the user-facing page.
    - What `CommandsTester` does (sys.path / registry isolation, context-manager lifecycle).
    - A copy-pasteable usage example.
    - The pytest fixture pattern that toolr's own `conftest.py` uses.
    - What you can assert against `collected_command_groups()`.
    - What it can't do (Rust binary, manifest, subprocess) and where to go for those.
    - An explicit stability statement: the constructor + context protocol + `discover()` + `collected_command_groups()` are stable across pre-1.0; internal attributes are implementation detail.
- **`mkdocs.yml`**: nav entry slotted into the writing-commands chapter between "Nested groups" and "Known bugs".
- **`docs/writing-commands/index.md`**: chapter TOC bullet for the new page.

## Verification

- `mkdocs build --strict` clean.

## Test plan

- [ ] Render the new page on the deployed site and confirm code examples copy cleanly.
- [ ] Spot-check the fixture pattern against `tests/conftest.py:48-54` (it should look almost identical).

_claude --resume d3b44758-ae3b-4a20-86c7-a264f4951f55_