### PR TITLE
fix(ci): pass GITHUB_TOKEN to git-cliff so [remote.github] auths

### DIFF
--- a/.github/workflows/_prepare-release.yml
+++ b/.github/workflows/_prepare-release.yml
@@ -180,6 +180,14 @@ jobs:
           # $GITHUB_ENV write; cliff.toml reads it via Tera get_env.
           OUTPUT: .release-changes.md
           GITHUB_REPO: ${{ github.repository }}
+          # cliff.toml's `[remote.github]` block makes git-cliff hit
+          # the GitHub API for commit/PR metadata used by the body
+          # template. Without an explicit token it falls through to
+          # unauthenticated requests and the API returns 401 on
+          # private endpoints / once rate-limited. The default
+          # workflow token is sufficient and has read-only repo
+          # scope.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare GH Release changelog
         id: prepare-release-notes
@@ -213,6 +221,9 @@ jobs:
           # TOOLR_RELEASE_NOTES is inherited from the loader step's
           # $GITHUB_ENV write; cliff.toml reads it via Tera get_env.
           GITHUB_REPO: ${{ github.repository }}
+          # See the matching step above for why GITHUB_TOKEN is needed
+          # alongside `[remote.github]` in cliff.toml.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Reset UNRELEASED.md
         shell: bash


### PR DESCRIPTION
## Summary

The release-prep workflow has been failing since the merge of `dad48f6c` (PR #237) with:

\`\`\`text
panicked at git-cliff-core/src/changelog.rs:493:18:
Could not get github metadata: HttpClientError(reqwest::Error { kind: Status(401, None),
url: "https://api.github.com/repos/s0undt3ch/ToolR/commits?per_page=100&page=0" })
\`\`\`

## Root cause

`cliff.toml` has:

\`\`\`toml
[remote.github]
owner = "s0undt3ch"
repo = "ToolR"
\`\`\`

git-cliff 2.13+ resolves that block eagerly on every run — it hits `api.github.com/repos/.../commits` to enrich the changelog body with commit metadata used by the Tera template (commit IDs, contributor PR numbers via the `remote_url` macro).

Both `git-cliff-action` invocations in `_prepare-release.yml` set `GITHUB_REPO` but **no `GITHUB_TOKEN`**, so git-cliff makes unauthenticated requests. Once it advances past the first page (or hits a rate-limited window), GitHub returns 401 and git-cliff panics — producing the trace in the issue.

The reason it surfaced after `dad48f6c`'s merge: that's when the release-prep workflow next fired against a repo state where the commit page count had grown enough to trip the unauthenticated rate ceiling.

## Fix

Add `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to both git-cliff-action `env:` blocks. The default workflow token has the read-only repo scope git-cliff needs; no new permissions, no new secrets, no behavioural change on success.

Inline comments in both steps explain *why* the token is needed (prevents the next editor stripping it back out as unused-looking env).

## Verification

- `prek run actionlint --files .github/workflows/_prepare-release.yml`: clean.
- Confirm fix by triggering the release workflow against an unreleased state once this merges.

## Test plan

- [ ] Dispatch `release.yml` against an unreleased state (or push a tag locally to simulate) and confirm the `Generate changelog for GH release` step succeeds.
- [ ] `Update CHANGELOG.md` step in the same workflow also succeeds (same fix applied).

_claude --resume d3b44758-ae3b-4a20-86c7-a264f4951f55_