### PR TITLE
test(command): wall-clock-bound tokio command tests, fix #247 workspace hang

### DIFF
--- a/crates/toolr-core/src/command/command_test.rs
+++ b/crates/toolr-core/src/command/command_test.rs
@@ -433,6 +433,31 @@ mod test_suite {
         use super::*;
         use tokio::runtime::Runtime;
 
+        /// Run `run_command_internal` on a blocking worker thread, bounded by a
+        /// wall-clock timeout. Returns the inner result on completion, or an
+        /// `Err` describing the wall-clock breach.
+        ///
+        /// The bound exists so a future regression that wedges
+        /// `run_command_internal` (a stuck forwarder thread, a missed kill, etc.)
+        /// fails the test fast instead of hanging the entire workspace test run.
+        /// See issue #247 for the original `cargo test --workspace` hang this
+        /// guards against.
+        async fn bounded_run_command(
+            config: CommandConfig,
+            timeout: Duration,
+        ) -> Result<std::result::Result<i32, Box<dyn std::error::Error + Send + Sync>>> {
+            let join_handle =
+                tokio::task::spawn_blocking(move || run_command_internal(config));
+            match tokio::time::timeout(timeout, join_handle).await {
+                Err(_) => Err(anyhow!(
+                    "run_command_internal did not return within {:?}",
+                    timeout
+                )),
+                Ok(Err(e)) => Err(anyhow!("worker task failed: {e}")),
+                Ok(Ok(inner)) => Ok(inner),
+            }
+        }
+
         // Cross-platform pipe creation
         #[cfg(unix)]
         fn create_pipe() -> Result<(i32, i32)> {
@@ -637,12 +662,13 @@ mod test_suite {
                         "-c".to_string(),
                         "import time; time.sleep(10)".to_string(),
                     ],
-                    timeout_secs: Some(0.1), // Very short timeout
+                    timeout_secs: Some(0.5), // Short timeout; 0.5s tolerates workspace contention
                     ..Default::default()
                 };
 
-                // Run the command and expect failure
-                let result = run_command_internal(config);
+                // Wall-clock-bounded so the workspace test run can't hang if the
+                // internal kill+wait path ever wedges. See issue #247.
+                let result = bounded_run_command(config, Duration::from_secs(5)).await?;
 
                 // Should fail with timeout
                 assert!(result.is_err());
@@ -661,51 +687,30 @@ mod test_suite {
             let rt = Runtime::new()?;
 
             rt.block_on(async {
-                // Create pipes for output
-                let (stdout_read, stdout_write) = create_pipe()?;
-                let (_stderr_read, stderr_write) = create_pipe()?;
-
-                // Create a command that outputs once then waits, triggering no-output timeout
+                // Create a command that outputs once then waits, triggering no-output timeout.
+                //
+                // We intentionally do not wire up a `sys_stdout_fd` pipe here: the no-output
+                // watchdog updates `last_output` from the stdout-forwarder thread's read
+                // against `child.stdout` (the parent-owned pipe), which works whether or not
+                // a sys-fd consumer is present. Earlier revisions of this test passed a
+                // test-owned pipe and called `read_pipe` *before* `handle.join()`; under
+                // `cargo test --workspace` contention the watchdog could fire and kill
+                // python before any byte made it to that pipe, leaving the test stuck in a
+                // blocking read on a writer that nobody had closed. See issue #247.
                 let config = CommandConfig {
                     args: vec![
                         python,
                         "-c".to_string(),
                         "import sys, time; sys.stdout.write('initial output'); sys.stdout.flush(); time.sleep(10)".to_string(),
                     ],
-                    sys_stdout_fd: wrap_fd(stdout_write),
-                    sys_stderr_fd: wrap_fd(stderr_write),
-                    no_output_timeout_secs: Some(0.1), // Very short no-output timeout
+                    no_output_timeout_secs: Some(0.5),
                     ..Default::default()
                 };
 
-                // Run the command in a separate thread
-                let handle = std::thread::spawn(move || {
-                    run_command_internal(config)
-                });
-
-                // Read the initial output
-                let mut stdout_buffer = [0u8; 1024];
-                #[cfg(unix)]
-                unsafe { read_pipe(stdout_read, &mut stdout_buffer) };
-                #[cfg(windows)]
-                read_pipe(stdout_read, &mut stdout_buffer);
-
-                // Wait for command to fail
-                let result = handle.join().expect("Thread panicked");
-
-                // Clean up
-                #[cfg(unix)]
-                unsafe {
-                    libc::close(stdout_read);
-                    libc::close(_stderr_read);
-                    libc::close(stdout_write);
-                    libc::close(stderr_write);
-                }
-
-                #[cfg(windows)]
-                {
-                    // On Windows our test files will close automatically
-                }
+                // Bound the call with a wall-clock guard so any future regression that
+                // wedges `run_command_internal` fails fast instead of hanging the
+                // workspace. The watchdog should trip in ~0.5s; 5s is generous headroom.
+                let result = bounded_run_command(config, Duration::from_secs(5)).await?;
 
                 // Should fail with no-output timeout
                 assert!(result.is_err());


### PR DESCRIPTION
Closes #247.

## Summary

`test_no_output_timeout` deadlocked under `cargo test --workspace` even though it passed in
isolation. PR #243 covered the spawn-failure half (`python3` resolution); this PR closes the
other half (pipe-read deadlock under parallel-test contention) and adds a wall-clock guard so
no future regression in this code path can hang the workspace.

## Root cause

The test wired its own pipe through `sys_stdout_fd`, then read it *before* joining the worker:

```rust
let handle = thread::spawn(move || run_command_internal(config));

// Read first — BEFORE join. If nothing is ever written, this blocks forever.
read_pipe(stdout_read, &mut stdout_buffer);

let result = handle.join().expect("Thread panicked");
```

Under workspace contention the no-output watchdog could fire and kill python *before* the
in-process stdout forwarder had read anything to write to the test-owned pipe:

1. python is slow to start under load → no bytes on `child.stdout` yet.
2. Watchdog trips (`no_output_timeout_secs: 0.1` is very tight) and kills python.
3. Forwarder thread reads EOF and exits without ever writing to `sys_stdout_fd`.
4. Test is still parked in `read_pipe(stdout_read, …)`. The write end (`stdout_write`) is still
   open on the test process, so the kernel never delivers EOF. The read blocks indefinitely.
5. `handle.join()` is never reached.

## Fix

All changes are in `crates/toolr-core/src/command/command_test.rs`.

**1. New `bounded_run_command` helper in `tokio_tests`.**
Runs `run_command_internal` via `tokio::task::spawn_blocking` and wraps the join in
`tokio::time::timeout`. Any future regression that wedges the call fails the test fast with a
clear ``run_command_internal did not return within 5s`` message instead of hanging the workspace.

**2. `test_no_output_timeout` simplified.**
- Drop the test-owned `sys_stdout_fd` / `sys_stderr_fd` pipes entirely. The watchdog updates
  `last_output` from the parent-side read against `child.stdout`, so a sys-fd consumer is not
  needed to exercise the no-output path. This removes the deadlock surface completely.
- Bump `no_output_timeout_secs` from `0.1` to `0.5`. Under scheduler jitter the old value could
  trip *before* python had a chance to write anything; `0.5s` lets the test actually exercise
  the "wrote, then went silent" path.
- Call wrapped in `bounded_run_command(5s)` for belt-and-braces.

**3. `test_timeout_exception` hardened the same way.**
Same shape (direct `run_command_internal` call, very tight timeout), so the same guard applies.
`timeout_secs` `0.1` → `0.5`, call wrapped in `bounded_run_command(5s)`.

## Verification

```text
cargo test --workspace          # 3 back-to-back runs, all green
test result: ok. 419 passed; 0 failed; … finished in 3.04s
test result: ok. 419 passed; 0 failed; … finished in ~2.9s
test result: ok. 419 passed; 0 failed; … finished in ~2.9s

cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)

prek run --files crates/toolr-core/src/command/command_test.rs
# all hooks pass
```

Before this PR the workspace run hung indefinitely on `test_no_output_timeout` and had to be
killed manually (observed ≥3 minutes during the 2026-05-23 audit session).