### PR TITLE
ci(release): use setup-toolr action for matrix generation, drop the workspace build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,18 +71,40 @@ jobs:
         id: mise-version
         run: echo "mise-version=$MISE_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Virtual Environment
-        uses: ./.github/actions/setup-virtualenv
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          cache-prefix: prepare-release
-          cache-seed: ${{ env.CACHE_SEED }}
-          python-version: "3.11"
-          mise-version: ${{ env.MISE_VERSION }}
+          version: ${{ env.MISE_VERSION }}
+          cache: true
+          cache_key_prefix: ${{ env.CACHE_SEED }}|mise|${{ env.MISE_VERSION }}|prepare-release|${{ runner.os }}|${{ runner.arch }}
+
+      - name: Get the Python Binary path from Mise
+        id: mise-python-executable
+        run: echo "python=$(mise which python)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate additional ToolR requirements file
+        # `tools/ci.py` (where `toolr ci generate-build-matrix` lives)
+        # imports `packaging`. The published toolr wheel is a single
+        # binary with no Python deps of its own, so we inject the
+        # `tools` group's runtime requirements into toolr's pipx env
+        # via the action's `requirements-file` knob.
+        run: |
+          uv export --frozen --no-hashes --only-group tools --output-file ${{ github.workspace }}/toolr-requirements.txt
+
+      - name: Setup ToolR
+        # Pulls the prebuilt `bindings = "bin"` wheel from PyPI via pipx
+        # — no Rust/maturin/hatchling build on the matrix-generation
+        # critical path. Same pin as `ci.yml`; bump both together.
+        id: setup-toolr
+        uses: s0undt3ch/ToolR@9a9089ceb281520e57fc6453ef5ec8f44011d0ad # main (python-path support, post-v0.11.1)
+        with:
+          python-path: ${{ steps.mise-python-executable.outputs.python }}
+          requirements-file: ${{ github.workspace }}/toolr-requirements.txt
 
       - name: Generate Build Matrix
         id: generate-build-matrix
         run: |
-          uv run toolr ci generate-build-matrix --workflow release
+          toolr ci generate-build-matrix --workflow release
 
   prepare-release:
     name: Prepare Release


### PR DESCRIPTION
## Summary

`release.yml`'s `prepare-ci` job built the entire workspace (two
maturin Rust crates) every release just to emit a static JSON matrix.
`ci.yml`'s `prepare-ci` already solved this by pulling toolr from PyPI
via the `s0undt3ch/ToolR` action; this PR brings `release.yml` in line.

## The problem

```yaml
# .github/workflows/release.yml (before)
- uses: ./.github/actions/setup-virtualenv         # uv sync --no-install-workspace
- run: uv run toolr ci generate-build-matrix --workflow release
```

`uv sync --no-install-workspace` correctly skipped workspace members
during setup, but `uv run toolr …` re-syncs by default and the
`--no-install-workspace` flag does **not** carry over. uv then
resolves `toolr`, `toolr-py`, and `toolr-plugin-example` and invokes
maturin to compile the two Rust crates from source — visible in the
build log as:

```text
Run uv run toolr ci generate-build-matrix --workflow release
     Building toolr @ file:///home/runner/work/ToolR/ToolR/crates/toolr
     Building toolr-plugin-example @ file:///home/runner/work/ToolR/ToolR/examples/plugin-package
     Building toolr-py @ file:///home/runner/work/ToolR/ToolR/crates/toolr-py
```

Two pyo3/maturin Rust builds on the critical path of every release,
to produce a JSON matrix that doesn't depend on the binary at all.

## The fix — copy the pattern `ci.yml` is already using

```yaml
# .github/workflows/release.yml (after)
- uses: jdx/mise-action@…                          # provides mise, uv, python
- id: mise-python-executable
  run: echo "python=$(mise which python)" >> $GITHUB_OUTPUT
- run: uv export --frozen --no-hashes --only-group tools
       --output-file ${{ github.workspace }}/toolr-requirements.txt
- uses: s0undt3ch/ToolR@<sha>                      # pipx install toolr==X from PyPI
  with:
    python-path: ${{ steps.mise-python-executable.outputs.python }}
    requirements-file: ${{ github.workspace }}/toolr-requirements.txt
- run: toolr ci generate-build-matrix --workflow release
```

The `s0undt3ch/ToolR` action pipx-installs the prebuilt
`bindings = "bin"` PyPI wheel — **no compilation**. The
`--requirements-file` injects the `tools` group's runtime deps
(`packaging`, …) into toolr's pipx env so `tools/ci.py` can import
them. Same SHA pin as `ci.yml`; bump both together.

## Why this drift existed

The action's `python-path` input was added "post-v0.11.1" (see the pin
comment in `ci.yml:89`). `ci.yml` migrated to the new action when
that knob became available. `release.yml` never got the same update.
Classic drift between sibling workflows.

## What does **not** change

`tools/ci.py:141 generate_build_matrix()` is untouched. It still
emits the same five `GITHUB_OUTPUT` keys (`platform-matrix`,
`binary-archive-triples`, `pythons-binary`, `pythons-py`, plus
`test-pythons` on the ci.yml-only path). The downstream reusable
workflows (`_prepare-release.yml`, `_build-binary-archive.yml`,
`_build.yml`, `_test.yml`) read `needs.prepare-ci.outputs.*` exactly
as before.

`cache_key_prefix` uses `prepare-release` (where `ci.yml` uses
`prepare-ci`) so the two prepare jobs don't share a mise cache key —
they install the same mise version but live in different workflows
with different concurrency characteristics, matching how the dropped
`setup-virtualenv` call had `cache-prefix: prepare-release`.

## Diff size

`+29 / -7` in one file. The eleven inserted lines are an
almost-verbatim copy of `ci.yml:72-92` (mise + python-path +
uv-export + setup-toolr action steps); the seven removed lines are
the old `setup-virtualenv` + `uv run` pair.

## Verification

- `prek run --files .github/workflows/release.yml` — all hooks pass,
  including the GitHub Actions workflow linter and the
  SHA-pin-enforcer.
- No `cargo test` impact (workflow-only change).
- Real CI verification will happen on the first release after merge —
  the matrix step should drop from "build the workspace" to "pipx
  install + run". On a cache hit, the action reuses the cached pipx
  env entirely.