### PR TITLE
feat(argparse): accept underscored long-flag spelling as hidden alias

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -272,6 +272,15 @@ Migrating a plugin:
 If you don't ship the file, your plugin's commands will not appear in
 `toolr --help` or `toolr <group> --help`.
 
+### Improved — argparse options with underscores accept both spellings
+
+`toolr` normalises the canonical CLI form for argparse-scanned options
+to dashes, so `add_argument('--skip_warm_cache', ...)` shows up in
+`--help` and shell completion as `--skip-warm-cache`. The original
+underscored spelling is now also accepted at parse time, so muscle
+memory from the upstream tool (`--skip_warm_cache`) keeps working
+without the user having to know about the rewrite.
+
 ### Improved — dispatch detects stale manifests automatically
 
 Adding, removing, or editing `tools/*.py` is now reflected on the very

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -243,6 +243,16 @@ fn build_argument(positionals: &[String], call: &ExprCall, warnings: &mut Vec<St
         metadata.metavar = Some(mv);
     }
 
+    // When the source spells its long flag with underscores
+    // (`--skip_warm_cache`), cli.rs still normalises the canonical CLI
+    // form to dashes for help and shell completion
+    // (`--skip-warm-cache`). Register the underscored spelling as a
+    // hidden alias so users who type the upstream tool's exact flag
+    // still get a match.
+    if is_keyword_style && name.contains('_') {
+        metadata.aliases.push(format!("--{name}"));
+    }
+
     // Preserve the literal long-flag spelling from the source. The
     // scanner's canonical `name` strips the leading `--` and may pick
     // between aliases (`add_argument("--user_ids", "--user-ids", ...)`
@@ -524,6 +534,33 @@ def add_arguments(self, parser):
         assert_eq!(scanned.arguments[1].default.as_deref(), Some("default"));
         assert_eq!(scanned.arguments[2].kind, ArgumentKind::Flag);
         assert_eq!(scanned.arguments[3].kind, ArgumentKind::Repeated);
+    }
+
+    #[test]
+    fn underscored_long_flag_registers_alias_for_both_spellings() {
+        // argparse lets users write `--skip_warm_cache`; cli.rs
+        // normalises that to `--skip-warm-cache` for the canonical CLI
+        // form, but the user-typed underscored spelling must still
+        // resolve. The scanner records the underscored form as an
+        // alias so clap accepts both.
+        let source = r#"
+def add_arguments(self, parser):
+    parser.add_argument('--skip_warm_cache', action='store_true')
+    parser.add_argument('--already-dashed')
+"#;
+        let scanned = scan_source("x", source).unwrap();
+        assert_eq!(scanned.arguments.len(), 2);
+
+        let underscored = &scanned.arguments[0];
+        assert_eq!(underscored.name, "skip_warm_cache");
+        assert_eq!(underscored.metadata.aliases, vec!["--skip_warm_cache"]);
+        assert_eq!(underscored.long_flag.as_deref(), Some("--skip_warm_cache"));
+
+        // A flag that was already dashed in the source needs no alias —
+        // cli.rs emits the same spelling for `.long()`.
+        let dashed = &scanned.arguments[1];
+        assert_eq!(dashed.name, "already-dashed");
+        assert!(dashed.metadata.aliases.is_empty());
     }
 
     #[test]

--- a/crates/toolr/src/cli.rs
+++ b/crates/toolr/src/cli.rs
@@ -812,6 +812,37 @@ mod cli_tree_tests {
     }
 
     #[test]
+    fn underscored_alias_lets_clap_accept_both_spellings() {
+        // Mirrors the argparse scanner's output for
+        // `add_argument('--skip_warm_cache', action='store_true')`:
+        // the canonical CLI form is dashed (so help and shell
+        // completion offer the dashed spelling), but the upstream
+        // underscored form is registered as a hidden alias.
+        let mut arg = empty_arg("skip_warm_cache", ArgumentKind::Flag);
+        arg.metadata.aliases.push("--skip_warm_cache".into());
+        arg.long_flag = Some("--skip_warm_cache".into());
+
+        let mut cmd = normal_leaf("wrapup-company", "jenkins");
+        cmd.arguments = vec![arg];
+
+        let clap_cmd = build_user_command(&cmd);
+
+        // Dashed form parses.
+        let dashed = clap_cmd
+            .clone()
+            .try_get_matches_from(vec!["wrapup-company", "--skip-warm-cache"])
+            .expect("dashed form must parse");
+        assert!(dashed.get_flag("skip_warm_cache"));
+
+        // Underscored form (the upstream argparse spelling) parses too.
+        let underscored = clap_cmd
+            .clone()
+            .try_get_matches_from(vec!["wrapup-company", "--skip_warm_cache"])
+            .expect("underscored form must parse");
+        assert!(underscored.get_flag("skip_warm_cache"));
+    }
+
+    #[test]
     fn dispatcher_with_matching_leaf_name_hoists_children_onto_group() {
         // command_group("django") + def django(...) → dotted_name == "django"
         // (matches the leaf), so the dispatcher's children appear


### PR DESCRIPTION
## Summary

Argparse-scanned options whose long flag uses underscores
(`--skip_warm_cache`) were normalised to dashes by the Rust CLI
(`--skip-warm-cache`). The dashed form is still canonical — what `--help`
and shell completion offer — but the original underscored spelling is
now also accepted at parse time.

## Background

`crates/toolr-core/src/complete/engine.rs:385` and
`crates/toolr/src/cli.rs:525` both convert underscores to dashes when
building the user-facing CLI form. That keeps help and tab completion
readable, but it broke muscle memory: typing the upstream tool's exact
flag — for example

```
toolr jenkins job --follow --cpu 5000m --on-demand wrapup_company 73151 --skip_warm_cache
```

— failed with

```
error: unexpected argument '--skip_warm_cache' found
  tip: a similar argument exists: '--skip-warm-cache'
```

## Fix

`crates/toolr-core/src/argparse/scan.rs` (`build_argument`): when the
scanned canonical name contains `_`, append `--<name>` to
`metadata.aliases`. `apply_arg_metadata` in
`crates/toolr/src/cli.rs:600` already turns long-alias entries into
`Arg::alias(...)`, which clap treats as a hidden alias. Result:

- `--skip-warm-cache` (canonical) — shown in `--help`, offered by
  shell completion, parses.
- `--skip_warm_cache` (upstream spelling) — hidden from help and
  completion, parses.

The literal long-flag spelling for dispatch (`arg.long_flag`) is
untouched, so the downstream tool still receives the upstream
spelling verbatim.

## Tests

- `argparse::scan::tests::underscored_long_flag_registers_alias_for_both_spellings`
  asserts the scanner adds the underscored alias when the source spells
  the flag with `_`, and adds nothing when the source is already
  dashed. Also pins that `long_flag` is preserved verbatim for the
  dispatch path.
- `cli::cli_tree_tests::underscored_alias_lets_clap_accept_both_spellings`
  builds the user command via `build_user_command` and asserts clap
  accepts both `--skip-warm-cache` and `--skip_warm_cache` end-to-end.

## Verification

```text
cargo test -p toolr-core -p toolr   # all crates green
prek run --files \
  crates/toolr-core/src/argparse/scan.rs \
  crates/toolr/src/cli.rs \
  UNRELEASED.md
# all hooks pass (cargo check, clippy, typos, codespell, rumdl, …)
```

## Notes

- `UNRELEASED.md` gets a brief `### Improved` entry so this user-visible
  behavior surfaces in 0.20.0 release notes.
- **Out of scope:** native `def foo(skip_warm_cache: bool = ...)` Python
  commands. Underscored names are Python identifiers there, not
  user-chosen CLI spellings, so the dashed-only convention still
  holds. If we want to extend the alias to those too, the same trick
  fits cleanly in `crates/toolr-py/python/toolr/utils/_signature.py:666`
  (`_build_aliases`).