### PR TITLE
feat(argparse): `T | None` without default → zero-or-one positional

### DIFF
--- a/crates/toolr-core/src/parser/build.rs
+++ b/crates/toolr-core/src/parser/build.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 use walkdir::WalkDir;
 
 use crate::hash::hash_tools_dir;
-use crate::manifest::{Manifest, SCHEMA_VERSION};
-use crate::parser::types::{SourcesImports, TypeImports, TypeResolutionError};
+use crate::manifest::{ArgumentKind, Manifest, SCHEMA_VERSION};
+use crate::parser::types::{SourcesImports, SupportedType, TypeImports, TypeResolutionError};
 use crate::parser::{
     commands::extract_commands,
     groups::extract_groups,
@@ -99,6 +99,11 @@ fn build_static_manifest_inner(tools_dir: &Path) -> std::result::Result<Manifest
 
     if !type_errors.is_empty() {
         return Err(BuildError::UnsupportedTypes(type_errors));
+    }
+
+    let arity_errors = validate_positional_arity(&all_commands);
+    if !arity_errors.is_empty() {
+        return Err(BuildError::InvalidPositionalArity(arity_errors));
     }
 
     // Validate that every command points at a registered group. Catches
@@ -211,8 +216,133 @@ pub enum BuildError {
     UnsupportedTypes(Vec<TypeResolutionError>),
     #[error("unknown group references ({count}):\n{details}", count = .0.len(), details = format_unknown_groups(.0))]
     UnknownGroupRefs(Vec<UnknownGroupRef>),
+    #[error("invalid positional arity ({count}):\n{details}", count = .0.len(), details = format_positional_arity_errors(.0))]
+    InvalidPositionalArity(Vec<PositionalArityError>),
     #[error("argparse scanner error: {0}")]
     Argparse(#[from] crate::argparse::ArgparseError),
+}
+
+/// One command whose positional-argument layout violates the
+/// zero-or-one positional rules. Surfaced as a batch via
+/// [`BuildError::InvalidPositionalArity`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PositionalArityError {
+    pub module: String,
+    pub command: String,
+    pub kind: PositionalArityErrorKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PositionalArityErrorKind {
+    /// Two or more positionals declared `T | None` without a default.
+    /// clap can't disambiguate which trailing arg fills which slot.
+    MultipleZeroOrOne { first: String, second: String },
+    /// A `T | None` positional sits alongside `*args: T` — both compete
+    /// for the trailing slot.
+    OptionalWithVarPositional { optional: String, var_positional: String },
+    /// A required positional (no default, not `T | None`) follows the
+    /// zero-or-one slot. The parser can't backtrack to fill a required
+    /// slot that comes after one we've already accepted as absent.
+    RequiredAfterZeroOrOne { required: String, zero_or_one: String },
+}
+
+impl std::fmt::Display for PositionalArityErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MultipleZeroOrOne { first, second } => write!(
+                f,
+                "two zero-or-one positionals `{first}` and `{second}`. Only one `T | None` positional \
+                 is allowed per command; give one of them a default to make it a `--flag`."
+            ),
+            Self::OptionalWithVarPositional { optional, var_positional } => write!(
+                f,
+                "the zero-or-one positional `{optional}` cannot coexist with the variadic positional \
+                 `*{var_positional}` — both consume the trailing slot."
+            ),
+            Self::RequiredAfterZeroOrOne { required, zero_or_one } => write!(
+                f,
+                "the required positional `{required}` follows the zero-or-one positional `{zero_or_one}`. \
+                 Move required positionals before any `T | None` parameter."
+            ),
+        }
+    }
+}
+
+fn format_positional_arity_errors(errors: &[PositionalArityError]) -> String {
+    let mut s = String::new();
+    for (i, err) in errors.iter().enumerate() {
+        if i > 0 {
+            s.push('\n');
+        }
+        use std::fmt::Write as _;
+        let _ = write!(
+            &mut s,
+            "  - {}::{}: {}",
+            err.module, err.command, err.kind,
+        );
+    }
+    s
+}
+
+/// Walk every command and surface any positional-arity violation. Runs
+/// after type resolution because the "zero-or-one" tag lives on
+/// `Argument.resolved_type == Optional(_)`.
+fn validate_positional_arity(commands: &[crate::manifest::Command]) -> Vec<PositionalArityError> {
+    let mut errors = Vec::new();
+    for cmd in commands {
+        let mut zero_or_one: Option<&str> = None;
+        let mut var_positional: Option<&str> = None;
+        for arg in &cmd.arguments {
+            match arg.kind {
+                ArgumentKind::VarPositional => {
+                    var_positional = Some(arg.name.as_str());
+                }
+                ArgumentKind::Positional => {
+                    let is_optional = matches!(
+                        arg.resolved_type,
+                        Some(SupportedType::Optional(_))
+                    );
+                    if is_optional {
+                        if let Some(first) = zero_or_one {
+                            errors.push(PositionalArityError {
+                                module: cmd.module.clone(),
+                                command: cmd.name.clone(),
+                                kind: PositionalArityErrorKind::MultipleZeroOrOne {
+                                    first: first.to_string(),
+                                    second: arg.name.clone(),
+                                },
+                            });
+                        } else {
+                            zero_or_one = Some(arg.name.as_str());
+                        }
+                    } else if let Some(zo) = zero_or_one {
+                        // A non-optional positional after the zero-or-one slot.
+                        errors.push(PositionalArityError {
+                            module: cmd.module.clone(),
+                            command: cmd.name.clone(),
+                            kind: PositionalArityErrorKind::RequiredAfterZeroOrOne {
+                                required: arg.name.clone(),
+                                zero_or_one: zo.to_string(),
+                            },
+                        });
+                    }
+                }
+                // Keyword-like kinds don't compete for positional slots.
+                ArgumentKind::Optional | ArgumentKind::Flag | ArgumentKind::Repeated | ArgumentKind::Count => {}
+            }
+        }
+        if let (Some(zo), Some(vp)) = (zero_or_one, var_positional) {
+            errors.push(PositionalArityError {
+                module: cmd.module.clone(),
+                command: cmd.name.clone(),
+                kind: PositionalArityErrorKind::OptionalWithVarPositional {
+                    optional: zo.to_string(),
+                    var_positional: vp.to_string(),
+                },
+            });
+        }
+    }
+    errors
 }
 
 /// One command whose `group="…"` reference doesn't match any
@@ -683,5 +813,144 @@ def hello(ctx):
         let err = build_static_manifest(&tmp.path().join("tools")).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("missing a `group=...` kwarg"), "got: {msg}");
+    }
+
+    /// `T | None` (no default) is accepted as a single zero-or-one
+    /// positional. This is the user's primary use case (e.g.
+    /// `def bump(ctx, new_version: str | None)`).
+    #[test]
+    fn accepts_single_zero_or_one_positional() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "tools/v.py",
+            r#""""Version utils."""
+group = command_group("version", "Version", docstring=__doc__)
+
+@group.command
+def bump(ctx, new_version: str | None) -> None:
+    """Bump.
+
+    Args:
+        new_version: Explicit version.
+    """
+"#,
+        );
+        let m = build_static_manifest(&tmp.path().join("tools")).unwrap();
+        let bump = m.commands.iter().find(|c| c.name == "bump").unwrap();
+        assert_eq!(bump.arguments.len(), 1);
+        assert_eq!(bump.arguments[0].kind, ArgumentKind::Positional);
+        assert!(matches!(
+            bump.arguments[0].resolved_type,
+            Some(SupportedType::Optional(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_multiple_zero_or_one_positionals() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "tools/v.py",
+            r#""""Bad."""
+group = command_group("x", "X", docstring=__doc__)
+
+@group.command
+def f(ctx, a: str | None, b: str | None) -> None:
+    """Bad.
+
+    Args:
+        a: first.
+        b: second.
+    """
+"#,
+        );
+        let err = build_static_manifest(&tmp.path().join("tools")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("two zero-or-one positionals"), "got: {msg}");
+        assert!(msg.contains("`a`"), "got: {msg}");
+        assert!(msg.contains("`b`"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_required_positional_after_zero_or_one() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "tools/v.py",
+            r#""""Bad."""
+group = command_group("x", "X", docstring=__doc__)
+
+@group.command
+def f(ctx, maybe: str | None, name: str) -> None:
+    """Bad ordering.
+
+    Args:
+        maybe: optional.
+        name: required.
+    """
+"#,
+        );
+        let err = build_static_manifest(&tmp.path().join("tools")).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("required positional `name` follows"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_zero_or_one_combined_with_var_positional() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "tools/v.py",
+            r#""""Bad."""
+group = command_group("x", "X", docstring=__doc__)
+
+@group.command
+def f(ctx, maybe: str | None, *files: str) -> None:
+    """Bad combo.
+
+    Args:
+        maybe: optional.
+        files: trailing.
+    """
+"#,
+        );
+        let err = build_static_manifest(&tmp.path().join("tools")).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot coexist with the variadic positional"),
+            "got: {msg}"
+        );
+    }
+
+    /// `T | None = None` (with a default) stays a `--flag` and doesn't
+    /// trip the zero-or-one validator. Regression guard.
+    #[test]
+    fn allows_optional_keyword_alongside_required_positional() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "tools/v.py",
+            r#""""OK."""
+group = command_group("x", "X", docstring=__doc__)
+
+@group.command
+def f(ctx, name: str, alias: str | None = None) -> None:
+    """OK.
+
+    Args:
+        name: required.
+        alias: optional flag.
+    """
+"#,
+        );
+        let m = build_static_manifest(&tmp.path().join("tools")).unwrap();
+        let f = m.commands.iter().find(|c| c.name == "f").unwrap();
+        // `alias` should be Optional (flag), not a positional.
+        let kinds: Vec<ArgumentKind> = f.arguments.iter().map(|a| a.kind).collect();
+        assert_eq!(kinds, vec![ArgumentKind::Positional, ArgumentKind::Optional]);
     }
 }

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -19,9 +19,11 @@ import inspect
 import os
 import warnings
 from pathlib import Path
+from types import UnionType
 from typing import TYPE_CHECKING
 from typing import Annotated
 from typing import Any
+from typing import Union
 from typing import get_args
 from typing import get_origin
 from typing import get_type_hints
@@ -239,6 +241,17 @@ def _unwrap_annotated(hint: Any) -> Any:
     return hint
 
 
+def _is_optional(hint: Any) -> bool:
+    """True if `hint` is `T | None` (PEP 604) or `Optional[T]`/`Union[T, None]`.
+
+    Handles `Annotated[T | None, ...]` by peeling the wrapper first.
+    """
+    inner = _unwrap_annotated(hint)
+    if get_origin(inner) not in (UnionType, Union):
+        return False
+    return type(None) in get_args(inner)
+
+
 def _dec_hook(target_type: type, obj: Any) -> Any:  # noqa: PLR0911
     """Coerce values msgspec doesn't know about natively.
 
@@ -326,6 +339,26 @@ def _coerce_args(target: Callable[..., Any], raw: dict[str, Any]) -> tuple[list[
         except msgspec.ValidationError as exc:
             msg = f"toolr runner: invalid value for `--{name.replace('_', '-')}`: {exc}"
             raise SpecError(msg) from exc
+
+    # Zero-or-one positionals (`new_version: str | None`) are absent from
+    # `raw` when the user didn't pass them — clap accepts the omission
+    # (the type is Optional, so `is_optional_wrapper` flips `required` to
+    # false) but the python function has no default to fall back on. Fill
+    # `None` for each such missing parameter so the call doesn't blow up
+    # with "missing required positional argument".
+    for param_name, param in sig.parameters.items():
+        if param_name == "ctx":
+            continue
+        if param.kind == param.VAR_POSITIONAL:
+            continue
+        if param_name in keyword:
+            continue
+        if param.default is not param.empty:
+            # Function has its own default — let it apply.
+            continue
+        if _is_optional(hints.get(param_name)):
+            keyword[param_name] = None
+
     return positional, keyword
 
 

--- a/crates/toolr-py/python/toolr/utils/_signature.py
+++ b/crates/toolr-py/python/toolr/utils/_signature.py
@@ -425,6 +425,8 @@ def get_signature(func: F) -> Signature:
             raise SignatureError(exc.message, func) from None
         arguments.append(parameter)
 
+    _validate_positional_arity(func, arguments)
+
     return Signature(
         func=func,
         short_description=short_description,
@@ -432,6 +434,59 @@ def get_signature(func: F) -> Signature:
         arguments=arguments,
         signature=signature,
     )
+
+
+def _validate_positional_arity(func: F, arguments: list[Arg | KwArg]) -> None:
+    """Enforce the zero-or-one positional rules.
+
+    Three constraints, all checked together because they interact:
+
+    1. At most one zero-or-one positional (`T | None` w/o default,
+       i.e. ``nargs == "?"``). clap / argparse can't disambiguate two
+       trailing optionals.
+    2. Zero-or-one and zero-or-more (`*args: T`) are mutually exclusive
+       — both compete for the same trailing slot.
+    3. Required positionals must come **before** the zero-or-one slot.
+       Once we accept "no value here" the parser can't backtrack and
+       fill a required slot that comes later.
+
+    Fixed-arity tuples are deterministic, so they may freely precede a
+    zero-or-one positional.
+    """
+    optional_positional: Arg | None = None
+    var_positional: VarArg | None = None
+    for argument in arguments:
+        if isinstance(argument, KwArg):
+            continue
+        if isinstance(argument, VarArg):
+            var_positional = argument
+            continue
+        if argument.nargs == "?":
+            if optional_positional is not None:
+                err_msg = (
+                    f"Only one zero-or-one positional argument is allowed per command; "
+                    f"both {optional_positional.name!r} and {argument.name!r} are `T | None` "
+                    "without a default. Drop one or give it a default to make it a `--flag`."
+                )
+                raise SignatureError(err_msg, func)
+            optional_positional = argument
+            continue
+        # Required positional (no default, not `T | None`). Must appear
+        # before any zero-or-one slot.
+        if optional_positional is not None:
+            err_msg = (
+                f"Required positional {argument.name!r} follows the zero-or-one positional "
+                f"{optional_positional.name!r}. Move required positionals before any `T | None` "
+                "parameter."
+            )
+            raise SignatureError(err_msg, func)
+
+    if optional_positional is not None and var_positional is not None:
+        err_msg = (
+            f"Cannot combine the zero-or-one positional {optional_positional.name!r} with the "
+            f"variadic positional `*{var_positional.name}` — both consume the trailing slot."
+        )
+        raise SignatureError(err_msg, func)
 
 
 class EnumAction(Action):
@@ -531,6 +586,7 @@ def _parse_parameter(  # noqa: PLR0915
                 log.debug("Found ArgumentAnnotation config: %s", arg_config)
                 break
 
+    optional_type: bool = False
     if isinstance(actual_type, UnionType):
         if len(actual_type.__args__) > 2:
             err_msg = f"{klass.__name__} {param_name!r} has more than two types: , ".join(
@@ -545,6 +601,7 @@ def _parse_parameter(  # noqa: PLR0915
 
         # Now, the type that we're really interested in is the first one
         actual_type = actual_type.__args__[0]
+        optional_type = True
 
     description: str | None = docstring.params.get(param_name)
     if description is None:
@@ -575,6 +632,14 @@ def _parse_parameter(  # noqa: PLR0915
 
     if nargs is None and param.kind == Parameter.VAR_POSITIONAL:
         nargs = "*"
+
+    # `T | None` without a default is the type-driven replacement for
+    # `arg(nargs="?")` on a positional — argparse stores `None` when the
+    # user omits the value, matching the function's `Optional[T]` hint.
+    # `T | None = <something>` is intentionally NOT positional (line 493
+    # makes it a KwArg), so we only flip `nargs` here.
+    if nargs is None and positional and optional_type and param.kind != Parameter.VAR_POSITIONAL:
+        nargs = "?"
 
     if default is param.empty:
         # Reset default to None if it's empty

--- a/docs/writing-commands/arguments.md
+++ b/docs/writing-commands/arguments.md
@@ -83,6 +83,43 @@ toolr math add --help
 --8<-- "docs/writing-commands/files/calculator-add-help.txt"
 ```
 
+### Zero-or-one positionals (`T | None` without a default)
+
+A `T | None` annotation **without** a default declares a positional
+that takes zero or one value:
+
+```python
+def bump(ctx: Context, new_version: str | None) -> None:
+    """Bump the version.
+
+    Args:
+        new_version: Explicit version to bump to, or omit for auto.
+    """
+```
+
+```sh
+toolr version bump            # new_version is None
+toolr version bump 0.20.0     # new_version is "0.20.0"
+```
+
+This is the type-driven replacement for the deprecated
+`arg(nargs="?")` kwarg.
+
+A few rules apply, all enforced at manifest-build time so you get a
+clear error rather than confusing runtime behavior:
+
+| Rule | Why |
+|---|---|
+| At most **one** `T \| None` positional per command. | clap can't disambiguate two trailing optionals — which arg fills which slot? |
+| Required positionals must appear **before** the `T \| None` slot. | Once the parser accepts "no value here" it can't backtrack to fill a required slot that comes later. |
+| `T \| None` and `*args: T` cannot coexist. | Both compete for the trailing slot. |
+| Fixed-arity `tuple[T1, T2, …]` positionals **may** precede a `T \| None` slot. | Tuples have deterministic arity, so there's no ambiguity. |
+
+`T | None` **with** a default (e.g. `name: str | None = None`) is a
+keyword `--flag` instead — see [Optional arguments](#optional-arguments-with-a-default-value)
+below. The default's presence is what flips the parameter from
+positional to keyword; the annotation alone doesn't.
+
 ## Optional arguments (with a default value)
 
 Parameters with a default value become `--name VALUE` flags. The type

--- a/tests/runner/test_runner_coverage.py
+++ b/tests/runner/test_runner_coverage.py
@@ -407,6 +407,53 @@ def test_coerce_args_falls_back_when_get_type_hints_raises() -> None:
     assert keyword == {"x": "raw"}
 
 
+def test_coerce_args_fills_none_for_absent_optional_positional() -> None:
+    """`T | None` without a default → runner injects `None` when clap omits the slot.
+
+    The rust front-end accepts `T | None` positionals as zero-or-one, so when
+    the user doesn't pass the trailing arg, the value is absent from `raw`.
+    Without this fill-in, the python function call blows up with
+    "missing 1 required positional argument".
+    """
+
+    def _fn(ctx, new_version: str | None) -> None: ...
+
+    _, keyword = _coerce_args(_fn, {})
+    assert keyword == {"new_version": None}
+
+
+def test_coerce_args_does_not_overwrite_supplied_optional_positional() -> None:
+    """When the value IS in `raw`, the fill-in must not clobber it."""
+
+    def _fn(ctx, new_version: str | None) -> None: ...
+
+    _, keyword = _coerce_args(_fn, {"new_version": "0.20.0"})
+    assert keyword == {"new_version": "0.20.0"}
+
+
+def test_coerce_args_skips_fill_in_when_parameter_has_default() -> None:
+    """`T | None = None` is a flag; missing key means "use the function's own default", not "inject None"."""
+
+    def _fn(ctx, name: str | None = None) -> None: ...
+
+    _, keyword = _coerce_args(_fn, {})
+    # No injection — the function's own default takes over.
+    assert keyword == {}
+
+
+def test_coerce_args_skips_fill_in_for_non_optional_missing_params() -> None:
+    """Plain `str` (no default, not Optional) must NOT be auto-filled.
+
+    The call should still fail with the user's own clearer TypeError,
+    not silently receive `None`.
+    """
+
+    def _fn(ctx, name: str) -> None: ...
+
+    _, keyword = _coerce_args(_fn, {})
+    assert keyword == {}
+
+
 # --------------------------------------------------------------------------
 # run() — non-subprocess exit-code shapes
 # --------------------------------------------------------------------------

--- a/tests/utils/signature/test_get_signature.py
+++ b/tests/utils/signature/test_get_signature.py
@@ -287,3 +287,108 @@ def test_get_signature_var_positional_with_other_args():
     assert not isinstance(signature.arguments[0], VarArg)
     assert isinstance(signature.arguments[1], VarArg)
     assert signature.arguments[1].nargs == "*"
+
+
+def test_get_signature_optional_without_default_is_zero_or_one_positional():
+    """`T | None` without a default → positional with `nargs="?"`.
+
+    This is the type-driven replacement for `arg(nargs="?")`; argparse
+    stores `None` when the user omits the slot, matching the function's
+    `Optional[T]` hint.
+    """
+
+    def test_func(ctx: Context, new_version: str | None) -> None:
+        """Bump.
+
+        Args:
+            new_version: Explicit version to bump to.
+        """
+
+    signature = get_signature(test_func)
+    assert len(signature.arguments) == 1
+    arg_obj = signature.arguments[0]
+    assert isinstance(arg_obj, Arg)
+    assert not isinstance(arg_obj, KwArg)
+    assert arg_obj.nargs == "?"
+    assert arg_obj.type is str
+
+
+def test_get_signature_optional_with_none_default_stays_a_flag():
+    """`T | None = None` is a keyword flag (existing behavior); zero-or-one only triggers when there's no default."""
+
+    def test_func(ctx: Context, name: str | None = None) -> None:
+        """Greet.
+
+        Args:
+            name: Who to greet.
+        """
+
+    signature = get_signature(test_func)
+    arg_obj = signature.arguments[0]
+    assert isinstance(arg_obj, KwArg)
+    # KwArg means it's a flag, not a positional.
+    assert arg_obj.nargs is None
+
+
+def test_get_signature_rejects_multiple_zero_or_one_positionals():
+    """At most one zero-or-one positional per command — clap/argparse can't disambiguate."""
+
+    def test_func(ctx: Context, a: str | None, b: str | None) -> None:
+        """Bad.
+
+        Args:
+            a: first.
+            b: second.
+        """
+
+    with pytest.raises(SignatureError, match=r"Only one zero-or-one positional"):
+        get_signature(test_func)
+
+
+def test_get_signature_rejects_required_positional_after_zero_or_one():
+    """Required positionals must come before any `T | None` slot."""
+
+    def test_func(ctx: Context, maybe: str | None, name: str) -> None:
+        """Bad ordering.
+
+        Args:
+            maybe: optional.
+            name: required.
+        """
+
+    with pytest.raises(SignatureError, match=r"Required positional 'name' follows"):
+        get_signature(test_func)
+
+
+def test_get_signature_rejects_zero_or_one_with_var_positional():
+    """`T | None` and `*args: T` both compete for the trailing slot."""
+
+    def test_func(ctx: Context, maybe: str | None, *files: str) -> None:
+        """Bad combo.
+
+        Args:
+            maybe: optional.
+            files: trailing.
+        """
+
+    with pytest.raises(SignatureError, match=r"Cannot combine the zero-or-one positional"):
+        get_signature(test_func)
+
+
+def test_get_signature_allows_required_positional_before_zero_or_one():
+    """Required positionals (no default) may precede the zero-or-one slot."""
+
+    def test_func(ctx: Context, name: str, maybe: str | None) -> None:
+        """OK combo.
+
+        Args:
+            name: required.
+            maybe: optional trailing.
+        """
+
+    signature = get_signature(test_func)
+    assert len(signature.arguments) == 2
+    assert isinstance(signature.arguments[0], Arg)
+    assert isinstance(signature.arguments[1], Arg)
+    assert signature.arguments[0].nargs is None
+    assert signature.arguments[1].nargs == "?"

--- a/tools/version.py
+++ b/tools/version.py
@@ -7,11 +7,9 @@ import tomllib
 from datetime import UTC
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated
 from typing import Final
 
 from toolr import Context
-from toolr import arg
 from toolr import command_group
 
 # Built-in fallback for when there are no tags (e.g. brand-new repo).
@@ -102,7 +100,7 @@ def current(ctx: Context) -> None:
 @group.command
 def bump(
     ctx: Context,
-    new_version: Annotated[str | None, arg(nargs="?")] = None,
+    new_version: str | None = None,
     check_existing_tag: bool = False,
     write: bool = False,
 ) -> None:


### PR DESCRIPTION
## Summary

Make `T | None` (without a default) a proper zero-or-one positional argument — the type-driven replacement that the `arg(nargs="?")` deprecation message already pointed users at. Two runtime gaps closed:

- **Python runner** (`_coerce_args`): clap was already accepting the omission (the resolved `Optional(_)` type flips `required→false` on the positional), but the runner was leaving the parameter out of the call entirely, so the function blew up with `TypeError: missing 1 required positional argument`. The runner now injects `None` for any absent parameter whose annotation is `T | None` and which has no default.
- **Python signature parser** (legacy argparse path): didn't set `nargs="?"` on bare-positional `T | None`, so argparse-driven code paths still treated them as required.

## Semantics

| Annotation | Result |
|---|---|
| `name: str` | required positional |
| `name: str \| None` | **zero-or-one positional** (this PR) |
| `name: str \| None = None` | `--flag` (unchanged) |

```sh
toolr version bump              # new_version → None
toolr version bump 0.20.0       # new_version → "0.20.0"
```

## Structural rules (enforced at manifest-build time)

To prevent ambiguity at the parser layer, three rules are enforced — both in the rust static manifest builder (`BuildError::InvalidPositionalArity`) and the python legacy argparse path (`SignatureError`):

1. **At most one** zero-or-one positional per command. Two trailing optionals can't be disambiguated.
2. The zero-or-one slot must come **after all required positionals**. Fixed-arity `tuple[T1, T2, …]` positionals may freely precede it — they're deterministic.
3. `T | None` and `*args: T` **cannot coexist** — both consume the trailing slot.

Example error:
```
toolr: invalid positional arity (1):
  - tools.foo::two-optionals: two zero-or-one positionals `a` and `b`. Only one
    `T | None` positional is allowed per command; give one of them a default to
    make it a `--flag`.
```

## Also in this PR

Drops the deprecated `Annotated[str | None, arg(nargs="?")]` wrapper on `tools/version.py::bump` now that the type-driven form is sufficient.

## Test plan

- [x] `cargo test --workspace` — 426 + smaller test binaries, all green
- [x] `uv run pytest` — 389 passed, 8 skipped (distribution tests, no wheels in workspace)
- [x] `uv run prek run --files <changed>` — clean
- [x] Manual: `toolr version bump`, `toolr version bump 0.20.0`, `toolr version bump --check-existing-tag 0.20.0` all behave correctly
- [x] Manual: each of the three structural violations rejects with a clear, named error at `toolr project manifest rebuild` time

## Changes

- `crates/toolr-core/src/parser/build.rs` — new `BuildError::InvalidPositionalArity` variant + `PositionalArityError{,Kind}` types + `validate_positional_arity` walk after type resolution + 5 integration tests
- `crates/toolr-py/python/toolr/_runner.py` — `_coerce_args` injects `None` for absent `T | None` positionals without defaults; new `_is_optional` helper handles both PEP 604 and `Optional[T]`/`Union[T, None]`
- `crates/toolr-py/python/toolr/utils/_signature.py` — `_parse_parameter` sets `nargs="?"` for bare-positional `T | None`; new `_validate_positional_arity` enforces the three rules from `get_signature`
- `docs/writing-commands/arguments.md` — new "Zero-or-one positionals (`T | None` without a default)" subsection under Positional arguments, with the rules table
- `tests/runner/test_runner_coverage.py` — 4 tests covering the inject / no-inject paths
- `tests/utils/signature/test_get_signature.py` — 5 tests covering classification + each of the three structural rejections
- `tools/version.py` — drop the deprecated `arg(nargs="?")` wrapper on `bump`