### PR TITLE
fix(version): drop spurious `= None` default on bump's positional

### DIFF
--- a/tools/version.py
+++ b/tools/version.py
@@ -100,7 +100,7 @@ def current(ctx: Context) -> None:
 @group.command
 def bump(
     ctx: Context,
-    new_version: str | None = None,
+    new_version: str | None,
     check_existing_tag: bool = False,
     write: bool = False,
 ) -> None:


### PR DESCRIPTION
## Summary

Drop the spurious `= None` default on `tools/version.py::bump`'s `new_version` parameter — a carryover from #266 where the file was accidentally restored from a working-tree stash with `= None` still attached.

## Why this matters

With `new_version: str | None = None`, the parameter classifies as a **keyword flag** (`--new-version VALUE`) under the new 0.20.0+ semantics — and the release-prep workflow calls:

```yaml
- name: Bump Version
  run: toolr version bump --write --check-existing-tag ${{ inputs.release-version }}
```

passing the version *positionally*. That would error with `unexpected argument '0.20.0' found` and break the release.

## The right shape

`new_version: str | None` (no default) accepts the value positionally under both runtimes:
- **0.11.1** (used during release prep): treated as a required positional. The workflow always passes the value, so this works.
- **0.20.0+** (post-release, after #266 lands): zero-or-one positional. `toolr version bump` (no arg) takes the dev-version path; `toolr version bump 0.20.0` sets the explicit version.

Verified locally against the freshly-built toolr binary:

```
$ toolr version bump
0.11.2-dev538

$ toolr version bump 0.20.0
0.20.0

$ toolr version bump --check-existing-tag 0.20.0
0.20.0
```