### PR TITLE
ci(release): drop --locked on `cargo install cross`

### DIFF
--- a/.github/workflows/_build-binary-archive.yml
+++ b/.github/workflows/_build-binary-archive.yml
@@ -84,7 +84,12 @@ jobs:
 
       - name: Install cross
         if: matrix.target.cross
-        run: cargo install cross --locked --version "^0.2"
+        # `--locked` intentionally absent: cross 0.2.5's bundled Cargo.lock
+        # pins a yanked `dunce v1.0.2`, which makes `--locked` warn (and
+        # in stricter cargo versions, refuse). We don't need lockstep
+        # transitive-dep determinism for a one-off CLI install — cargo
+        # picks the latest non-yanked semver-compatible version itself.
+        run: cargo install cross --version "^0.2"
 
       # `--locked` is intentionally absent: `uv build --sdist --package toolr`
       # rewrites the sdist's workspace `Cargo.toml` to drop `crates/toolr-py`,


### PR DESCRIPTION
## Summary

Drop `--locked` on `cargo install cross` in `_build-binary-archive.yml`. `cross 0.2.5`'s bundled `Cargo.lock` pins `dunce v1.0.2`, which has been yanked from crates.io, so every release/CI run is emitting:

```
warning: package `dunce v1.0.2` in Cargo.lock is yanked in registry
`crates-io`, consider running without --locked
```

A stricter cargo version would refuse outright.

## Trade-off

`--locked` would normally guarantee we install the *exact* transitive-dep set the `cross` maintainers tested with. For a one-off CLI install in CI, we don't actually care — `cross` has stable semver and its dependencies resolve cleanly without the lockfile. The cross maintainers would re-cut the lock the same way cargo's resolver does (latest non-yanked semver-compatible).

## Alternatives considered

- Use a pre-built `cross` binary (faster, but adds a download dependency we'd need to verify).
- Wait for `cross` to publish a new release with a refreshed lockfile (no ETA; this fixes us today).

Going with the in-place fix.

## Test plan

- [x] Diff is one workflow file, one line + a justification comment
- Validation happens on the next release run that exercises a `cross: true` triple (musl + cross-compiled aarch64 musl)