### PR TITLE
ci(build): drop `cross`, build musl natively, run full matrix on main

### DIFF
--- a/.github/actions/throttle/action.yml
+++ b/.github/actions/throttle/action.yml
@@ -1,0 +1,17 @@
+name: Throttle Build
+description: Throttle the build to avoid thundering herd effects.
+
+inputs:
+  max-sleep-seconds:
+    description: The maximum number of seconds to sleep.
+    required: true
+    default: '5'
+
+runs:
+  using: composite
+
+  steps:
+    - name: Configure Git
+      shell: bash
+      run: |
+        t=$(python3 -c 'import random, sys; sys.stdout.write(str(random.randint(1, ${{ inputs.max-sleep-seconds }})))'); echo "Sleeping $t seconds"; sleep "$t"

--- a/.github/workflows/_build-binary-archive.yml
+++ b/.github/workflows/_build-binary-archive.yml
@@ -57,6 +57,8 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/throttle
+
       - name: Download Source Tarball Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/_build-binary-archive.yml
+++ b/.github/workflows/_build-binary-archive.yml
@@ -22,7 +22,7 @@ on:
       targets:
         required: true
         type: string
-        description: 'JSON-encoded array of {triple, runner, cross, archive} objects describing which standalone binaries to build. Produced by `toolr ci generate-build-matrix --workflow {ci,release}` so the matrix stays centralized in tools/ci.py.'
+        description: 'JSON-encoded array of {triple, runner, archive} objects describing which standalone binaries to build. Produced by `toolr ci generate-build-matrix --workflow {ci,release}` so the matrix stays centralized in tools/ci.py.'
 
 permissions:
   contents: read
@@ -38,10 +38,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Each entry: {triple, runner, cross, archive}. Native runners
-        # cover x86_64/arm64 on Linux + macOS + Windows; `cross` is reserved
-        # for the musl targets where GitHub does not provide a matching
-        # native runner. See tools/ci.py:_BINARY_ARCHIVE_TRIPLES for the
+        # Each entry: {triple, runner, archive}. Every triple builds
+        # natively — both gnu and musl Linux variants on architecture-
+        # matched ubuntu runners, plus macOS and Windows. No docker, no
+        # `cross`. See tools/ci.py:_BINARY_ARCHIVE_TRIPLES for the
         # canonical list.
         target: ${{ fromJson(inputs.targets) }}
 
@@ -76,15 +76,16 @@ jobs:
           cache: true
           cache_key_prefix: ${{ inputs.cache-seed }}|mise|${{ inputs.mise-version }}|build-binary|${{ runner.os }}|${{ runner.arch }}|${{ matrix.target.triple }}
 
-      # `cross` runs in a container with its own toolchain, so we only need
-      # to add the matrix target for native builds.
       - name: Add Rust target
-        if: ${{ !matrix.target.cross }}
         run: rustup target add ${{ matrix.target.triple }}
 
-      - name: Install cross
-        if: matrix.target.cross
-        run: cargo install cross --locked --version "^0.2"
+      # musl-tools provides musl-gcc, which rust needs as the linker
+      # when targeting *-linux-musl. Architecture-native: x86_64-musl
+      # runs on ubuntu-latest (x86_64); aarch64-musl on ubuntu-24.04-arm
+      # (aarch64). apt-get installs the matching musl-gcc on each.
+      - name: Install musl-tools
+        if: contains(matrix.target.triple, '-linux-musl')
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
 
       # `--locked` is intentionally absent: `uv build --sdist --package toolr`
       # rewrites the sdist's workspace `Cargo.toml` to drop `crates/toolr-py`,
@@ -93,15 +94,9 @@ jobs:
       # dep-version drift); `--locked` would refuse and fail the build. The
       # sdist itself is the reproducibility artifact — its Cargo.lock is the
       # canonical lock.
-      - name: Build binary (native)
-        if: ${{ !matrix.target.cross }}
+      - name: Build binary
         working-directory: workdir
         run: cargo build --release -p toolr --bin toolr --target ${{ matrix.target.triple }}
-
-      - name: Build binary (cross)
-        if: matrix.target.cross
-        working-directory: workdir
-        run: cross build --release -p toolr --bin toolr --target ${{ matrix.target.triple }}
 
       - name: Stage archive contents
         working-directory: workdir

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -57,6 +57,8 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/throttle
+
       - name: Download Source Tarball Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/_prepare-release.yml
+++ b/.github/workflows/_prepare-release.yml
@@ -140,14 +140,6 @@ jobs:
         id: bump-version
         shell: bash
         run: |
-          # Pass the version as `--new-version` (a keyword flag) rather
-          # than positionally so the invocation works against both the
-          # previously-released toolr (used to *prepare* the next
-          # release) and the post-release toolr — the `bump` parameter
-          # is `new_version: str | None = None`, which classifies as a
-          # `--new-version` flag under both old and new runtime parsers.
-          # When `release-version` is empty, omit the flag entirely so
-          # the dev-version path (`new_version=None`) kicks in.
           toolr version bump --write --check-existing-tag ${{ inputs.release-version != '' && format('--new-version={0}', inputs.release-version) || '' }}
 
       - name: Load UNRELEASED.md into TOOLR_RELEASE_NOTES env var

--- a/.github/workflows/_prepare-release.yml
+++ b/.github/workflows/_prepare-release.yml
@@ -140,7 +140,15 @@ jobs:
         id: bump-version
         shell: bash
         run: |
-          toolr version bump --write --check-existing-tag ${{ inputs.release-version }}
+          # Pass the version as `--new-version` (a keyword flag) rather
+          # than positionally so the invocation works against both the
+          # previously-released toolr (used to *prepare* the next
+          # release) and the post-release toolr — the `bump` parameter
+          # is `new_version: str | None = None`, which classifies as a
+          # `--new-version` flag under both old and new runtime parsers.
+          # When `release-version` is empty, omit the flag entirely so
+          # the dev-version path (`new_version=None`) kicks in.
+          toolr version bump --write --check-existing-tag ${{ inputs.release-version != '' && format('--new-version={0}', inputs.release-version) || '' }}
 
       - name: Load UNRELEASED.md into TOOLR_RELEASE_NOTES env var
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,15 @@ jobs:
       - name: Generate Build Matrix
         id: generate-build-matrix
         if: fromJSON(steps.check-build.outputs.should-run-build)
+        # Pushes to `main` run the full release-shaped matrix so main is
+        # always as close to a real release as possible — every triple
+        # release.yml would build, every CPython ABI for the toolr-py
+        # wheel. Pull requests keep the cheaper `ci` subset (native
+        # triples only) to stay snappy.
+        env:
+          MATRIX_WORKFLOW: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'release' || 'ci' }}
         run: |
-          toolr ci generate-build-matrix --workflow ci
+          toolr ci generate-build-matrix --workflow "$MATRIX_WORKFLOW"
 
   pre-commit:
     name: Pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ run-name: "CI (${{ github.event_name == 'pull_request' && format('pr: #{0}', git
 on:
   push:
   pull_request:
+    # Default PR triggers PLUS labeled/unlabeled: applying or removing
+    # the `full-build` label re-runs CI so the new matrix shape takes
+    # effect without needing a dummy commit. Other label changes also
+    # trigger a re-run (cheap and self-correcting); the matrix selector
+    # in `tools/ci.py` ignores labels other than `full-build`.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   # Concurrency is defined in a way that concurrent builds against the main branch do not not cancel previous builds.
@@ -101,15 +107,15 @@ jobs:
       - name: Generate Build Matrix
         id: generate-build-matrix
         if: fromJSON(steps.check-build.outputs.should-run-build)
-        # Pushes to `main` run the full release-shaped matrix so main is
-        # always as close to a real release as possible — every triple
-        # release.yml would build, every CPython ABI for the toolr-py
-        # wheel. Pull requests keep the cheaper `ci` subset (native
-        # triples only) to stay snappy.
-        env:
-          MATRIX_WORKFLOW: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'release' || 'ci' }}
+        # `--workflow` is intentionally omitted: `generate-build-matrix`
+        # auto-detects from the GitHub event context (push to main →
+        # release; PR with `full-build` label → release; otherwise ci)
+        # and writes a one-line _reason_ to the job step summary so
+        # reviewers can see at a glance why this run got the matrix it
+        # got. The decision logic lives in `tools/ci.py` next to the
+        # matrix data, not split across the workflow YAML.
         run: |
-          toolr ci generate-build-matrix --workflow "$MATRIX_WORKFLOW"
+          toolr ci generate-build-matrix
 
   pre-commit:
     name: Pre-commit

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -9,11 +9,17 @@ import os
 import re
 import sys
 from pathlib import Path
+from typing import Literal
 
 from packaging.version import Version
 
 from toolr import Context
 from toolr import command_group
+
+# Label name a PR can carry to opt into the full release-shaped build
+# matrix. Without it, PRs run the minimal `ci` subset (native triples
+# only) to keep iteration fast.
+FULL_BUILD_LABEL = "full-build"
 
 # tools/ci.py → repo root (two parents up resolves the `tools/` directory).
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -136,8 +142,65 @@ _WHEEL_PLATFORM_MATRIX: dict[str, list[dict[str, str]]] = {
 }
 
 
+def _pr_labels() -> set[str]:
+    """Return the label names attached to the PR in the current GitHub event payload.
+
+    Reads `$GITHUB_EVENT_PATH` (the action payload JSON). Returns an
+    empty set when the env var is unset, the file is missing, the JSON
+    is malformed, or the event isn't a `pull_request`-shaped payload.
+    """
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return set()
+    try:
+        with open(event_path) as f:
+            event = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return set()
+    labels = event.get("pull_request", {}).get("labels", []) or []
+    return {label.get("name", "") for label in labels if isinstance(label, dict)}
+
+
+def _select_workflow_mode() -> tuple[Literal["ci", "release"], str]:
+    """Pick `ci` vs `release` from the GitHub event context.
+
+    Returns ``(mode, reason)``. The reason is a human-readable string
+    rendered into the GitHub job step summary so reviewers can see at
+    a glance *why* this run got the matrix it got.
+
+    Rules (first match wins):
+
+    1. ``push`` to ``refs/heads/main`` → ``release``. Main is always
+       kept as close to a real release as possible so musl + cross-arch
+       regressions get caught before tag-time.
+    2. ``pull_request`` carrying the ``full-build`` label → ``release``.
+       Opt-in escape hatch for PRs that need to exercise the full
+       matrix (e.g. dependency bumps, build-system changes).
+    3. Everything else → ``ci`` (the minimal native-triple subset).
+    """
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    ref = os.environ.get("GITHUB_REF", "")
+
+    if event_name == "push" and ref == "refs/heads/main":
+        return "release", "push to `main` — full matrix mirrors the release surface."
+
+    if event_name == "pull_request":
+        labels = _pr_labels()
+        if FULL_BUILD_LABEL in labels:
+            return "release", f"PR carries the `{FULL_BUILD_LABEL}` label — running the full release matrix on opt-in."
+        return "ci", (
+            f"PR (no `{FULL_BUILD_LABEL}` label) — native-triple subset to keep PR builds snappy. "
+            f"Apply the `{FULL_BUILD_LABEL}` label and re-run to opt into the full release matrix."
+        )
+
+    return "ci", f"event=`{event_name or '(unset)'}`, ref=`{ref or '(unset)'}` — default to the minimal CI matrix."
+
+
 @group.command
-def generate_build_matrix(ctx: Context, workflow: str = "ci") -> None:
+def generate_build_matrix(
+    ctx: Context,
+    workflow: Literal["ci", "release"] | None = None,
+) -> None:
     """
     Emit the CI matrix configuration consumed by `prepare-ci` jobs.
 
@@ -156,13 +219,17 @@ def generate_build_matrix(ctx: Context, workflow: str = "ci") -> None:
     in sync and lets workflow files stay declarative.
 
     Args:
-        workflow: Which workflow is asking. `"ci"` emits the native-triple
-            subset (fast PR builds against linux-gnu + darwin-arm + win-msvc);
-            `"release"` emits the full 7-triple matrix that ships to users.
+        workflow: Which matrix shape to emit. When omitted, auto-detect
+            from the GitHub event context (push-to-main → release; PR
+            with `full-build` label → release; otherwise → ci). Pass
+            ``release`` explicitly to force the full matrix regardless
+            of context — release.yml does this so tag-time builds are
+            always the complete set.
     """
-    if workflow not in ("ci", "release"):
-        ctx.error(f"unknown workflow: {workflow!r} (expected 'ci' or 'release')")
-        ctx.exit(1)
+    if workflow is None:
+        workflow, reason = _select_workflow_mode()
+    else:
+        reason = f"caller forced `--workflow {workflow}`."
 
     if workflow == "release":
         binary_archive_triples: list[dict[str, object]] = list(_BINARY_ARCHIVE_TRIPLES)
@@ -188,6 +255,7 @@ def generate_build_matrix(ctx: Context, workflow: str = "ci") -> None:
 
     with open(github_step_summary, "a") as wfh:
         wfh.write(f"## Build matrix ({workflow})\n\n")
+        wfh.write(f"_{reason}_\n\n")
         wfh.write("### Wheels\n\n")
         wfh.write("| Platform | cibuildwheel platform | GH runner |\n")
         wfh.write("|----------|----------------------|-----------|\n")
@@ -203,7 +271,7 @@ def generate_build_matrix(ctx: Context, workflow: str = "ci") -> None:
         wfh.write(f"- Binary wheel: `{', '.join(BINARY_WHEEL_PYTHONS)}`\n")
         wfh.write(f"- toolr-py wheel: `{', '.join(ALL_CPYTHONS)}`\n\n")
 
-    ctx.info(f"Emitting build matrix outputs for workflow={workflow!r}")
+    ctx.info(f"Emitting build matrix outputs for workflow={workflow!r} (reason: {reason})")
     ctx.print(outputs)
     with open(github_output, "a") as f:
         f.writelines(f"{key}={json.dumps(value)}\n" for key, value in outputs.items())

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -52,64 +52,63 @@ TEST_PYTHONS = [_cp_tag_to_dotted(t) for t in ALL_CPYTHONS]
 BINARY_WHEEL_PYTHONS = ["cp311"]
 
 # Per-triple metadata for the standalone toolr binary archives that
-# `_build-binary-archive.yml` builds. release.yml ships all of them
-# (downstream consumers: install.sh, mise plugin); ci.yml only needs the
-# runner-native subset to back the test/docs jobs (see CI_BINARY_TRIPLES).
+# `_build-binary-archive.yml` builds. release.yml + pushes to main ship
+# all of them; PR builds use the runner-native subset (see
+# `_CI_BINARY_ARCHIVE_TRIPLE_NAMES`).
+#
+# Every triple builds natively now: the matrix uses
+# architecture-matching GitHub runners and `*-linux-musl` works as a
+# native `rustup target add` + `musl-tools` build on `ubuntu-*` runners.
+# No docker, no `cross`.
 _BINARY_ARCHIVE_TRIPLES: list[dict[str, object]] = [
     {
         "triple": "x86_64-unknown-linux-gnu",
         "runner": "ubuntu-latest",
-        "cross": False,
         "archive": "tar.gz",
         "display-name": "Linux",
     },
     {
         "triple": "aarch64-unknown-linux-gnu",
         "runner": "ubuntu-24.04-arm",
-        "cross": False,
         "archive": "tar.gz",
         "display-name": "Linux",
     },
     {
         "triple": "x86_64-unknown-linux-musl",
         "runner": "ubuntu-latest",
-        "cross": True,
         "archive": "tar.gz",
         "display-name": "Linux",
     },
     {
         "triple": "aarch64-unknown-linux-musl",
         "runner": "ubuntu-24.04-arm",
-        "cross": True,
         "archive": "tar.gz",
         "display-name": "Linux",
     },
     {
         "triple": "aarch64-apple-darwin",
         "runner": "macos-14",
-        "cross": False,
         "archive": "tar.gz",
         "display-name": "macOS",
     },
     {
         "triple": "x86_64-apple-darwin",
         "runner": "macos-15-intel",
-        "cross": False,
         "archive": "tar.gz",
         "display-name": "macOS",
     },
     {
         "triple": "x86_64-pc-windows-msvc",
         "runner": "windows-latest",
-        "cross": False,
         "archive": "zip",
         "display-name": "Windows",
     },
 ]
 
-# Triples that ci.yml builds on every PR — one native triple per OS
-# in the test matrix. musl + cross-compiled aarch64 only build in
-# release.yml.
+# Triples that ci.yml builds on every PR — one native triple per OS in
+# the test matrix. Pushes to main build the full set (every triple
+# release.yml would build) so main is always as close to release as
+# possible.
 _CI_BINARY_ARCHIVE_TRIPLE_NAMES = frozenset(
     {
         "x86_64-unknown-linux-gnu",
@@ -145,8 +144,8 @@ def generate_build_matrix(ctx: Context, workflow: str = "ci") -> None:
     Writes five GITHUB_OUTPUT keys:
 
       - `platform-matrix` — wheel platform map per OS (used by _build.yml).
-      - `binary-archive-triples` — list of triple+runner+cross+archive
-        objects (used by _build-binary-archive.yml's matrix).
+      - `binary-archive-triples` — list of triple+runner+archive objects
+        (used by _build-binary-archive.yml's matrix).
       - `pythons-binary` — CPython ABI tags for the toolr binary wheel.
       - `pythons-py` — CPython ABI tags for the toolr-py (pyo3) wheel.
       - `test-pythons` — dotted-form CPython versions for the test matrix
@@ -197,11 +196,9 @@ def generate_build_matrix(ctx: Context, workflow: str = "ci") -> None:
                 label = platform.title() if idx == 0 else ""
                 wfh.write(f"| {label} | {item['name']} | {item['os']} |\n")
         wfh.write("\n### Standalone binary archives\n\n")
-        wfh.write("| Triple | GH runner | Build mode | Archive |\n")
-        wfh.write("|--------|-----------|------------|---------|\n")
-        for t in binary_archive_triples:
-            mode = "cross" if t["cross"] else "native"
-            wfh.write(f"| `{t['triple']}` | {t['runner']} | {mode} | `{t['archive']}` |\n")
+        wfh.write("| Triple | GH runner | Archive |\n")
+        wfh.write("|--------|-----------|---------|\n")
+        wfh.writelines(f"| `{t['triple']}` | {t['runner']} | `{t['archive']}` |\n" for t in binary_archive_triples)
         wfh.write("\n### Python ABIs\n\n")
         wfh.write(f"- Binary wheel: `{', '.join(BINARY_WHEEL_PYTHONS)}`\n")
         wfh.write(f"- toolr-py wheel: `{', '.join(ALL_CPYTHONS)}`\n\n")

--- a/tools/version.py
+++ b/tools/version.py
@@ -100,7 +100,7 @@ def current(ctx: Context) -> None:
 @group.command
 def bump(
     ctx: Context,
-    new_version: str | None,
+    new_version: str | None = None,
     check_existing_tag: bool = False,
     write: bool = False,
 ) -> None:


### PR DESCRIPTION
## Summary

Three coupled CI changes that share the same answer — *"treat main pushes like releases, give PRs an opt-in escape hatch, and put the decision logic next to the matrix data."*

1. **Drop `cross` entirely.** Both `*-linux-musl` triples already run on architecture-matched runners, so cross was paying for itself with nothing. It also just broke outright — see [this run](https://github.com/s0undt3ch/ToolR/actions/runs/26437125416/job/77830040609#step:11:16): cross 0.2.5 unconditionally runs `rustup toolchain add stable-x86_64-unknown-linux-gnu`, which modern rustup refuses on the aarch64 runner.
2. **Push-to-main + opt-in label run the full release matrix.** PRs stay fast (3 native triples + 1 CPython ABI for the binary wheel); main pushes and any PR carrying the `full-build` label exercise every triple and every CPython ABI that `release.yml` would build — so musl + cross-arch regressions get caught before tag-time.
3. **The matrix-selection logic lives in `tools/ci.py`, not in inline YAML.** A new `_select_workflow_mode()` returns `(mode, reason)`, and `generate-build-matrix` writes the reason as a one-line `_italics_` blurb under the `## Build matrix` job-summary heading. No more hunting through workflow files to figure out *why* a run picked what it picked.

Supersedes #269 (the `--locked` workaround on `cargo install cross`) — there's no cross install anymore.

## Why was cross there at all?

The historical intent: \"cross handles the musl libc + linker setup so we don't have to.\" That was reasonable when the project was younger and the matrix didn't have arm-native GitHub runners.

It's no longer true:
- We already pick architecture-native runners (`ubuntu-latest` for x86_64-musl, `ubuntu-24.04-arm` for aarch64-musl), so there's nothing to *cross-compile* — only a libc to swap.
- `rustup target add <triple>-musl` + `apt-get install musl-tools` (provides `musl-gcc`) is a 2-line native build.
- `cross 0.2.5` has been the only published release since 2023-02-04 (project is alive on `main`, but unreleased), and its frozen `Cargo.lock` keeps pinning transitives that later get yanked (e.g. `dunce v1.0.2`). Every CI run was emitting `--locked` warnings.

## How the matrix is selected (first match wins)

| Event | Picked | Reason rendered to job summary |
|---|---|---|
| `push` to `refs/heads/main` | `release` | _push to `main` — full matrix mirrors the release surface._ |
| `pull_request` with `full-build` label | `release` | _PR carries the `full-build` label — running the full release matrix on opt-in._ |
| `pull_request` without that label | `ci` | _PR (no `full-build` label) — native-triple subset to keep PR builds snappy. Apply the `full-build` label and re-run to opt into the full release matrix._ |
| explicit `--workflow release` (release.yml) | `release` | _caller forced `--workflow release`._ |
| everything else (push to non-main, tag, manual dispatch) | `ci` | _event=`<name>`, ref=`<ref>` — default to the minimal CI matrix._ |

`ci.yml`'s `pull_request` trigger gained `labeled` + `unlabeled` so applying or removing the `full-build` label re-runs the workflow immediately — no dummy commit needed.

## Changes

**`tools/ci.py`**
- Drop the `cross: True/False` field from every `_BINARY_ARCHIVE_TRIPLES` entry.
- New `FULL_BUILD_LABEL = \"full-build\"` constant.
- New `_pr_labels()` reads `$GITHUB_EVENT_PATH` for the PR's labels.
- New `_select_workflow_mode()` returns `(mode, reason)` from the event context.
- `generate_build_matrix(workflow: Literal[\"ci\", \"release\"] | None = None)` — `None` triggers auto-detect, an explicit value bypasses it. Writes a `_reason_` italics line to the job-summary block.
- Step-summary table for binary archives loses its now-irrelevant \"Build mode\" column.

**`.github/workflows/_build-binary-archive.yml`**
- Delete \"Install cross\" + \"Build binary (cross)\" steps.
- Delete the `if: ${{ !matrix.target.cross }}` gating — there's only one path now.
- Add `Install musl-tools`, conditional on `contains(matrix.target.triple, '-linux-musl')`.
- Single `Build binary` step: `cargo build --release -p toolr --bin toolr --target <triple>`.

**`.github/workflows/ci.yml`**
- `pull_request` trigger now lists `types: [opened, synchronize, reopened, labeled, unlabeled]`.
- `generate-build-matrix` invocation drops the env var + inline conditional; just runs `toolr ci generate-build-matrix` and lets `tools/ci.py` decide.

## Test plan

- [x] `cargo build -p toolr` + `toolr project manifest rebuild` clean.
- [x] All five selector paths exercised locally:
  - default (no GH env) → `ci` with the unset-event reason
  - `push` to `refs/heads/main` → `release` with the main-push reason
  - PR with `full-build` label → `release` with the opt-in reason
  - PR without the label → `ci` with the apply-label-to-opt-in reason
  - explicit `--workflow release` → `release` with the forced-by-caller reason
- The real test is this PR itself: the CI matrix should pick `ci` (no `full-build` label). Apply the label to flip it to `release` on demand.