### PR TITLE
feat(arg): validate aliases / conflicts_with / requires kwargs

### DIFF
--- a/crates/toolr-core/src/parser/types/literals.rs
+++ b/crates/toolr-core/src/parser/types/literals.rs
@@ -11,14 +11,24 @@ pub(super) fn literal_str(expr: &Expr) -> Option<String> {
     }
 }
 
+/// Extract a string sequence from a list, tuple, or set literal of
+/// string literals. Mirrors the Python `arg()` helper, which accepts
+/// any non-string `Iterable[str]` — these three are the
+/// statically-recognisable literal forms.
+///
+/// Returns `None` for any other expression shape (name references,
+/// function calls, mixed-type literals). Callers should surface that
+/// as a manifest-build warning rather than silently dropping the
+/// kwarg.
 pub(super) fn literal_str_list(expr: &Expr) -> Option<Vec<String>> {
-    let Expr::List(list) = expr else { return None };
-    let out: Vec<String> = list.elts.iter().filter_map(literal_str).collect();
-    if out.len() == list.elts.len() {
-        Some(out)
-    } else {
-        None
-    }
+    let elts: &[Expr] = match expr {
+        Expr::List(list) => &list.elts,
+        Expr::Tuple(tup) => &tup.elts,
+        Expr::Set(set) => &set.elts,
+        _ => return None,
+    };
+    let out: Vec<String> = elts.iter().filter_map(literal_str).collect();
+    if out.len() == elts.len() { Some(out) } else { None }
 }
 
 pub(super) fn literal_u32(expr: &Expr) -> Option<u32> {

--- a/crates/toolr-core/src/parser/types/mod.rs
+++ b/crates/toolr-core/src/parser/types/mod.rs
@@ -341,6 +341,38 @@ def f(x: A): pass
     }
 
     #[test]
+    fn extract_arg_metadata_harvests_conflicts_from_tuple_literal() {
+        let (_, ann) = first_annotation(
+            "def f(x: Annotated[bool, arg(conflicts_with=(\"verbose\", \"silent\"))]): pass\n",
+        );
+        let md = extract_arg_metadata(&ann, &ArgSectionTable::default()).unwrap();
+        assert_eq!(md.conflicts_with, vec!["verbose", "silent"]);
+    }
+
+    #[test]
+    fn extract_arg_metadata_harvests_conflicts_from_set_literal() {
+        let (_, ann) = first_annotation(
+            "def f(x: Annotated[bool, arg(conflicts_with={\"verbose\"})]): pass\n",
+        );
+        let md = extract_arg_metadata(&ann, &ArgSectionTable::default()).unwrap();
+        assert_eq!(md.conflicts_with, vec!["verbose"]);
+    }
+
+    #[test]
+    fn extract_arg_metadata_drops_conflicts_when_bare_string() {
+        // Python-side `arg()` raises a TypeError on this shape; the
+        // AST parser is the second line of defence and should not
+        // misinterpret a bare string as a single-element list.
+        let (_, ann) = first_annotation(
+            "def f(x: Annotated[bool, arg(conflicts_with=\"verbose\")]): pass\n",
+        );
+        let md = extract_arg_metadata(&ann, &ArgSectionTable::default());
+        // Either the metadata is None (no recognised kwargs) or the
+        // `conflicts_with` field stays empty — both are safe.
+        assert!(md.is_none_or(|m| m.conflicts_with.is_empty()));
+    }
+
+    #[test]
     fn extract_arg_metadata_resolves_help_section_from_table() {
         let src = r#"
 LOGGING = arg_section("Logging Options", description="Control verbosity.")

--- a/crates/toolr-py/python/toolr/utils/_signature.py
+++ b/crates/toolr-py/python/toolr/utils/_signature.py
@@ -257,17 +257,95 @@ def _deprecated(name: str, *, replacement: str) -> None:
     )
 
 
+# Order-preserving string collection: ``list`` and ``tuple``. Used
+# for kwargs where declaration order is semantically meaningful (e.g.
+# ``aliases``, whose first short entry becomes clap's ``Arg::short``).
+_StrSequence: TypeAlias = list[str] | tuple[str, ...]
+
+# Order-insensitive string collection: ``list`` / ``tuple`` /
+# ``set`` / ``frozenset``. Used for kwargs whose values are
+# semantically set-like (``conflicts_with``, ``requires``).
+_StrCollection: TypeAlias = list[str] | tuple[str, ...] | set[str] | frozenset[str]
+
+
+def _validate_str_elements(name: str, items: list[str]) -> None:
+    for i, item in enumerate(items):
+        if not isinstance(item, str):
+            msg = f"arg(): `{name}=` element [{i}] must be a string, got {type(item).__name__} ({item!r})."
+            raise TypeError(msg)
+
+
+def _coerce_str_sequence_kwarg(name: str, value: _StrSequence | None) -> list[str] | None:
+    """Order-preserving validator for ``aliases``.
+
+    Accepts ``list`` or ``tuple`` — both preserve declaration order,
+    which matters because the first short entry becomes clap's
+    ``Arg::short``. Sets and frozensets are rejected: they have no
+    observable order and using them here is almost always a mistake.
+
+    Bare strings are rejected because ``str`` is itself iterable —
+    silently iterating yields one character per element, which is
+    never what the caller meant.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        msg = (
+            f"arg(): `{name}=` must be a list or tuple of strings, got a bare "
+            f"`str` ({value!r}). Wrap a single item as `{name}=[{value!r}]`."
+        )
+        raise TypeError(msg)
+    if not isinstance(value, (list, tuple)):
+        msg = f"arg(): `{name}=` must be a list or tuple of strings, got {type(value).__name__}."
+        raise TypeError(msg)
+    items = list(value)
+    _validate_str_elements(name, items)
+    return items
+
+
+def _coerce_str_collection_kwarg(name: str, value: _StrCollection | None) -> list[str] | None:
+    """Order-insensitive validator for ``conflicts_with`` / ``requires``.
+
+    These fields are semantically set-like: "this flag conflicts
+    with these other flags." Accept ``list`` / ``tuple`` / ``set`` /
+    ``frozenset`` and materialise to a ``list[str]`` so the rest of
+    the pipeline sees a uniform shape. The Rust AST parser mirrors
+    this and statically extracts ``[...]`` / ``(...)`` / ``{...}``
+    literals; anything more dynamic (name references, function
+    calls) is runtime-only and will not appear in the static
+    manifest.
+
+    Bare strings are rejected because ``str`` is itself iterable —
+    silently iterating yields one character per element, which is
+    never what the caller meant.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        msg = (
+            f"arg(): `{name}=` must be a list, tuple, or set of strings, got a "
+            f"bare `str` ({value!r}). Wrap a single item as `{name}=[{value!r}]`."
+        )
+        raise TypeError(msg)
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        msg = f"arg(): `{name}=` must be a list, tuple, or set of strings, got {type(value).__name__}."
+        raise TypeError(msg)
+    items = list(value)
+    _validate_str_elements(name, items)
+    return items
+
+
 def arg(  # noqa: PLR0913 — kwargs surface mirrors the clap features we expose; each is intentionally distinct.
     *,
     # Active kwargs (plumbed through to clap).
-    aliases: list[str] | None = None,
+    aliases: _StrSequence | None = None,
     metavar: str | None = None,
     env: str | None = None,
     hide: bool = False,
     help_section: ArgSection | None = None,
     display_order: int | None = None,
-    conflicts_with: list[str] | None = None,
-    requires: list[str] | None = None,
+    conflicts_with: _StrCollection | None = None,
+    requires: _StrCollection | None = None,
     must_exist: bool = False,
     must_be_file: bool = False,
     must_be_dir: bool = False,
@@ -320,6 +398,9 @@ def arg(  # noqa: PLR0913 — kwargs surface mirrors the clap features we expose
             ``conflicts_with=[...]`` for mutex relationships and
             ``help_section=`` for display grouping.
     """
+    aliases = _coerce_str_sequence_kwarg("aliases", aliases)
+    conflicts_with = _coerce_str_collection_kwarg("conflicts_with", conflicts_with)
+    requires = _coerce_str_collection_kwarg("requires", requires)
     if required is not None:
         _deprecated(
             "required",

--- a/crates/toolr/tests/conflicts_with_dispatch.rs
+++ b/crates/toolr/tests/conflicts_with_dispatch.rs
@@ -1,0 +1,141 @@
+//! End-to-end coverage for `arg(conflicts_with=[…])`: a manifest that
+//! cross-references two flags via `metadata.conflicts_with` must make
+//! clap reject the conflicting invocation at parse time (before any
+//! Python is spawned).
+//!
+//! The static AST parser and the `arg()` helper each have their own
+//! unit tests; this file fills the gap between them — that the
+//! metadata round-trips through the manifest and into clap's
+//! `conflicts_with_all`, the dispatch surface our users actually hit.
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+const MANIFEST: &str = r#"{
+    "schema_version": 1,
+    "static_hash": "h",
+    "third_party_hash": "",
+    "groups": [
+        {"name": "probe", "title": "Probe", "description": "", "origin": "static"}
+    ],
+    "commands": [
+        {
+            "name": "follow",
+            "group": "probe",
+            "module": "tools.probe",
+            "function": "follow",
+            "summary": "Mutex probe.",
+            "description": "",
+            "arguments": [
+                {
+                    "name": "follow",
+                    "kind": "flag",
+                    "help": "tail logs.",
+                    "default": "false",
+                    "type_annotation": "bool",
+                    "resolved_type": {"kind": "bool"},
+                    "allowed_values": [],
+                    "metadata": {"conflicts_with": ["no_follow"]}
+                },
+                {
+                    "name": "no_follow",
+                    "kind": "flag",
+                    "help": "do not tail logs.",
+                    "default": "false",
+                    "type_annotation": "bool",
+                    "resolved_type": {"kind": "bool"},
+                    "allowed_values": [],
+                    "metadata": {"conflicts_with": ["follow"]}
+                }
+            ],
+            "imports": [],
+            "origin": "static"
+        }
+    ]
+}"#;
+
+fn fixture() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let tools = tmp.path().join("tools");
+    std::fs::create_dir(&tools).unwrap();
+    std::fs::write(tools.join(".toolr-manifest.json"), MANIFEST).unwrap();
+    tmp
+}
+
+#[test]
+fn conflicting_flags_are_rejected_at_parse_time() {
+    let tmp = fixture();
+    let output = Command::cargo_bin("toolr")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["probe", "follow", "--follow", "--no-follow"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, got success. stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected clap usage-error exit code 2; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected clap conflict message in stderr; got:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("--follow") && stderr.contains("--no-follow"),
+        "expected both flag spellings in the conflict message; got:\n{stderr}",
+    );
+}
+
+#[test]
+fn either_flag_alone_passes_clap_parse() {
+    // Without Python, dispatch fails downstream — but it must get
+    // *past* clap's conflict gate, proving the mutex only fires for
+    // the conflicting combo. We assert clap's "cannot be used with"
+    // message is absent rather than asserting success, so the test
+    // doesn't depend on a working tools venv.
+    for flag in ["--follow", "--no-follow"] {
+        let tmp = fixture();
+        let output = Command::cargo_bin("toolr")
+            .unwrap()
+            .current_dir(tmp.path())
+            .args(["probe", "follow", flag])
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("cannot be used with"),
+            "{flag} alone should not trigger the mutex; stderr:\n{stderr}",
+        );
+    }
+}
+
+#[test]
+fn help_still_renders_with_conflicts_with_metadata() {
+    // Regression guard: clap historically panicked when an arg listed
+    // a `conflicts_with` target that no other arg matched. The
+    // manifest here cross-references the names correctly, but we
+    // verify `--help` builds the command tree cleanly all the same.
+    let tmp = fixture();
+    let output = Command::cargo_bin("toolr")
+        .unwrap()
+        .current_dir(tmp.path())
+        .args(["probe", "follow", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "--help failed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--follow"), "help missing --follow:\n{stdout}");
+    assert!(stdout.contains("--no-follow"), "help missing --no-follow:\n{stdout}");
+}

--- a/tests/utils/signature/test_argument_annotation.py
+++ b/tests/utils/signature/test_argument_annotation.py
@@ -158,3 +158,81 @@ def test_path_constraint_kwargs_land_on_annotation():
     assert annotation.must_exist is True
     assert annotation.must_be_dir is True
     assert annotation.must_be_file is False
+
+
+@pytest.mark.parametrize("kwarg", ["aliases", "conflicts_with", "requires"])
+def test_arg_rejects_bare_string_for_collection_kwarg(kwarg):
+    """Passing a bare string where a collection is expected raises a TypeError.
+
+    Without this guard, ``arg(conflicts_with="other")`` is silently
+    accepted in Python but then dropped by the AST parser, giving a
+    working-looking command whose mutex never fires.
+    """
+    with pytest.raises(TypeError, match=rf"`{kwarg}=`.*bare `str`.*Wrap"):
+        arg(**{kwarg: "value"})
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (["-n", "--name"], ["-n", "--name"]),
+        (("-n", "--name"), ["-n", "--name"]),
+    ],
+    ids=["list", "tuple"],
+)
+def test_arg_aliases_accepts_list_and_tuple(value, expected):
+    """``aliases`` accepts list and tuple — both preserve declaration order."""
+    annotation = arg(aliases=value)
+    assert annotation.aliases == expected
+
+
+@pytest.mark.parametrize("value", [{"-n", "--name"}, frozenset({"-n", "--name"})])
+def test_arg_aliases_rejects_unordered_collections(value):
+    """Sets are rejected because alias order drives clap short-flag assignment."""
+    with pytest.raises(TypeError, match=r"`aliases=` must be a list or tuple of strings"):
+        arg(aliases=value)
+
+
+def test_arg_aliases_rejects_non_string_elements():
+    with pytest.raises(TypeError, match=r"`aliases=` element \[0\].*got int"):
+        arg(aliases=[1, 2])
+
+
+@pytest.mark.parametrize("kwarg", ["conflicts_with", "requires"])
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (["a", "b"], ["a", "b"]),
+        (("a", "b"), ["a", "b"]),
+        (frozenset(["solo"]), ["solo"]),
+    ],
+    ids=["list", "tuple", "frozenset"],
+)
+def test_arg_setlike_kwargs_accept_list_tuple_set(kwarg, value, expected):
+    """``conflicts_with`` / ``requires`` accept list, tuple, set, or frozenset."""
+    annotation = arg(**{kwarg: value})
+    assert getattr(annotation, kwarg) == expected
+
+
+def test_arg_conflicts_with_accepts_set_literal():
+    annotation = arg(conflicts_with={"solo"})
+    assert annotation.conflicts_with == ["solo"]
+
+
+@pytest.mark.parametrize("kwarg", ["conflicts_with", "requires"])
+def test_arg_setlike_kwargs_reject_other_collections(kwarg):
+    """Generators / dicts / arbitrary iterables are rejected.
+
+    The AST parser only extracts literal ``[...]`` / ``(...)`` /
+    ``{...}`` forms; accepting fancier shapes at the Python layer
+    would create a silent-drop hazard between runtime and the static
+    manifest.
+    """
+    with pytest.raises(TypeError, match=rf"`{kwarg}=`.*got dict"):
+        arg(**{kwarg: {"a": 1}})
+
+
+@pytest.mark.parametrize("kwarg", ["conflicts_with", "requires"])
+def test_arg_setlike_kwargs_reject_non_string_elements(kwarg):
+    with pytest.raises(TypeError, match=rf"`{kwarg}=` element \[0\].*got int"):
+        arg(**{kwarg: [1, 2]})


### PR DESCRIPTION
## What this fixes

`arg(conflicts_with="other")` was silently accepted by the Python helper (msgspec doesn't validate plain construction) and then silently dropped by the Rust AST parser (which only matched list literals) — leaving the user with a working-looking command whose mutex never fired. Hit in a real downstream consumer earlier today.

## What changes

### `arg()` kwargs now validate at the boundary

| Kwarg            | Accepted shapes                                | Rejected                       | Why                                                  |
| ---------------- | ---------------------------------------------- | ------------------------------ | ---------------------------------------------------- |
| `aliases`        | `list` / `tuple`                               | set, frozenset, bare str       | Order drives clap's `Arg::short` assignment          |
| `conflicts_with` | `list` / `tuple` / `set` / `frozenset`         | bare str, dict, generators     | Semantically set-like                                |
| `requires`       | `list` / `tuple` / `set` / `frozenset`         | bare str, dict, generators     | Semantically set-like                                |

All accepted shapes coerce to `list[str]` internally. Rejection raises `TypeError` with the correct form to use, and pinpoints the bad element index when a member isn't a string.

Two type aliases capture the split:

```python
_StrSequence:   TypeAlias = list[str] | tuple[str, ...]
_StrCollection: TypeAlias = list[str] | tuple[str, ...] | set[str] | frozenset[str]
```

### Rust AST parser made symmetric

`literal_str_list` now matches `Expr::List`, `Expr::Tuple`, and `Expr::Set` — the same source-level literals the Python helper accepts at runtime. Anything more dynamic (name references, function calls) is still runtime-only and won't appear in the static manifest.

## Tests

| File                                                          | What's new                                                                                                                                                                                            |
| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `tests/utils/signature/test_argument_annotation.py`           | 10 cases: bare-string rejection on all three kwargs; `aliases` accepting list+tuple / rejecting sets; `conflicts_with` / `requires` accepting list/tuple/set/frozenset and rejecting dicts/non-strings |
| `crates/toolr-core/src/parser/types/mod.rs`                   | 3 parser cases: tuple literal, set literal, defensive bare-string case                                                                                                                                |
| `crates/toolr/tests/conflicts_with_dispatch.rs` *(new file)* | 3 end-to-end integration tests: clap rejects `--a --b` with exit 2, single-flag passes the gate, `--help` still renders. **This was the explicit coverage gap that let the downstream bug through.** |

## Verified

- [x] `uv run pytest tests/utils/signature/` — 73 pass
- [x] `cargo test -p toolr-core --lib parser::types::tests` — 27 pass
- [x] `cargo test -p toolr --test conflicts_with_dispatch` — 3 pass
- [x] `prek` on changed files — ruff / mypy / clippy / typos all clean
