### PR TITLE
feat(setup-toolr): binary-download + SLSA attest install; cache tools/.venv; min 0.20.0

### DIFF
--- a/.github/workflows/_prepare-release.yml
+++ b/.github/workflows/_prepare-release.yml
@@ -101,22 +101,24 @@ jobs:
           cache: true
           cache_key_prefix: ${{ inputs.cache-seed }}|mise|${{ inputs.mise-version }}|prepare-release|${{ runner.os }}|${{ runner.arch }}
 
+      # The Python binary is still resolved here because the
+      # UNRELEASED.md regex strip a few steps down needs a Python
+      # interpreter. Setup ToolR no longer consumes it.
       - name: Get the Python Binary path from Mise
         id: mise-python-executable
         shell: bash
         run: echo "python=$(mise which python)" >> "$GITHUB_OUTPUT"
 
-      - name: Generate additional ToolR requirements file
-        shell: bash
-        run: |
-          uv export --frozen --no-hashes --only-group tools --output-file ${{ github.workspace }}/toolr-requirements.txt
-
       - name: Setup ToolR
+        # In-repo composite action: downloads the toolr binary from a
+        # GitHub release, verifies the SLSA build provenance, and
+        # caches the in-tree `tools/.venv` for the prepare-release
+        # job's `toolr` invocations.
         id: setup-toolr
-        uses: s0undt3ch/ToolR@fc2d6deee5f50b7f43cd1f099f896b09a4415dce # main (python-path support, post-v0.11.1)
+        uses: ./
         with:
-          python-path: ${{ steps.mise-python-executable.outputs.python }}
-          requirements-file: ${{ github.workspace }}/toolr-requirements.txt
+          version: latest
+          cache-prefix: ${{ inputs.cache-seed }}|setup-toolr|prepare-release
 
       - name: Setup Prek
         id: setup-pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,20 +82,17 @@ jobs:
           cache: true
           cache_key_prefix: ${{ env.CACHE_SEED }}|mise|${{ env.MISE_VERSION }}|prepare-ci|${{ runner.os }}|${{ runner.arch }}
 
-      - name: Get the Python Binary path from Mise
-        id: mise-python-executable
-        run: echo "python=$(mise which python)" >> "$GITHUB_OUTPUT"
-
-      - name: Generate additional ToolR requirements file
-        run: |
-          uv export --frozen --no-hashes --only-group tools --output-file ${{ github.workspace }}/toolr-requirements.txt
-
       - name: Setup ToolR
+        # In-repo composite action: downloads the toolr binary from a
+        # GitHub release, verifies the SLSA build provenance, and
+        # caches both the binary and the in-tree `tools/.venv` keyed
+        # on `tools/{pyproject.toml,uv.lock}` so subsequent runs skip
+        # the `uv sync` toolr would otherwise run on first invocation.
         id: setup-toolr
-        uses: s0undt3ch/ToolR@fc2d6deee5f50b7f43cd1f099f896b09a4415dce # main (python-path support, post-v0.11.1)
+        uses: ./
         with:
-          python-path: ${{ steps.mise-python-executable.outputs.python }}
-          requirements-file: ${{ github.workspace }}/toolr-requirements.txt
+          version: latest
+          cache-prefix: ${{ env.CACHE_SEED }}|setup-toolr|prepare-ci
 
       - name: Check if the build should run
         id: check-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,28 +78,18 @@ jobs:
           cache: true
           cache_key_prefix: ${{ env.CACHE_SEED }}|mise|${{ env.MISE_VERSION }}|prepare-release|${{ runner.os }}|${{ runner.arch }}
 
-      - name: Get the Python Binary path from Mise
-        id: mise-python-executable
-        run: echo "python=$(mise which python)" >> "$GITHUB_OUTPUT"
-
-      - name: Generate additional ToolR requirements file
-        # `tools/ci.py` (where `toolr ci generate-build-matrix` lives)
-        # imports `packaging`. The published toolr wheel is a single
-        # binary with no Python deps of its own, so we inject the
-        # `tools` group's runtime requirements into toolr's pipx env
-        # via the action's `requirements-file` knob.
-        run: |
-          uv export --frozen --no-hashes --only-group tools --output-file ${{ github.workspace }}/toolr-requirements.txt
-
       - name: Setup ToolR
-        # Pulls the prebuilt `bindings = "bin"` wheel from PyPI via pipx
-        # — no Rust/maturin/hatchling build on the matrix-generation
-        # critical path. Same pin as `ci.yml`; bump both together.
+        # In-repo composite action: downloads the toolr binary from a
+        # GitHub release, verifies the SLSA build provenance, and
+        # caches the in-tree `tools/.venv` so `toolr ci
+        # generate-build-matrix` (which imports `packaging` from the
+        # tools dependency group) doesn't have to rebuild the venv on
+        # every release.
         id: setup-toolr
-        uses: s0undt3ch/ToolR@fc2d6deee5f50b7f43cd1f099f896b09a4415dce # main (python-path support, post-v0.11.1)
+        uses: ./
         with:
-          python-path: ${{ steps.mise-python-executable.outputs.python }}
-          requirements-file: ${{ github.workspace }}/toolr-requirements.txt
+          version: latest
+          cache-prefix: ${{ env.CACHE_SEED }}|setup-toolr|prepare-release
 
       - name: Generate Build Matrix
         id: generate-build-matrix

--- a/.github/workflows/sync-rolling-tags.yml
+++ b/.github/workflows/sync-rolling-tags.yml
@@ -80,22 +80,16 @@ jobs:
           cache: true
           cache_key_prefix: ${{ env.CACHE_SEED }}|mise|${{ env.MISE_VERSION }}|sync-rolling-tags|${{ runner.os }}|${{ runner.arch }}
 
-      - name: Get the Python Binary path from Mise
-        id: mise-python-executable
-        shell: bash
-        run: echo "python=$(mise which python)" >> "$GITHUB_OUTPUT"
-
-      - name: Generate additional ToolR requirements file
-        shell: bash
-        run: |
-          uv export --frozen --no-hashes --only-group tools --output-file ${{ github.workspace }}/toolr-requirements.txt
-
       - name: Setup ToolR
+        # In-repo composite action: downloads the toolr binary from a
+        # GitHub release, verifies the SLSA build provenance, and
+        # caches the in-tree `tools/.venv` for the rolling-tag sync
+        # script.
         id: setup-toolr
-        uses: s0undt3ch/ToolR@fc2d6deee5f50b7f43cd1f099f896b09a4415dce # main (python-path support, post-v0.11.1)
+        uses: ./
         with:
-          python-path: ${{ steps.mise-python-executable.outputs.python }}
-          requirements-file: ${{ github.workspace }}/toolr-requirements.txt
+          version: latest
+          cache-prefix: ${{ env.CACHE_SEED }}|setup-toolr|sync-rolling-tags
 
       - name: Setup Prek
         id: setup-pre-commit

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,55 @@ this file to empty for the next cycle.
 Empty between releases is the steady-state — there's no header,
 no scaffolding. Just write whatever should appear in the notes.
 -->
+
+## ⚠ Breaking changes
+
+### `s0undt3ch/ToolR` GitHub Action: binary-only install, no more pipx
+
+- **What changed:** the `Setup ToolR` composite action no longer
+  installs toolr via `pipx install toolr==<version>`. The 0.20.0
+  release shipped toolr as a binary-only PyPI wheel (no Python
+  source), which pipx cannot install — so the old action path was
+  already broken at the point this change landed.
+
+  The rewritten action downloads the toolr binary archive directly
+  from a GitHub release (`gh release download` with a `curl`
+  fallback), cryptographically verifies the SLSA build provenance
+  via `gh attestation verify`, caches the result, and puts the
+  binary on `PATH`. It also caches `tools/.venv` keyed on
+  `tools/pyproject.toml` + `tools/uv.lock` and sets
+  `TOOLR_VENV_LOCATION=in-tree` so the cache works out of the box.
+
+- **Minimum version:** the action refuses to install toolr below
+  `0.20.0`. Earlier releases used the Python source distribution
+  and are not compatible with the binary-only flow.
+
+- **Migration:** remove the deprecated `python-path` and
+  `requirements-file` inputs from your workflow's `Setup ToolR`
+  step; the action has no use for them now that toolr is a
+  standalone binary with its Python deps in the per-project
+  `tools/.venv`. New optional inputs: `version` (defaults to the
+  action ref, falling back to `latest`), `skip-attestation`
+  (defaults to `false`), `cache-prefix` (defaults to `setup-toolr`),
+  and `cache-tools-venv` (defaults to `true`).
+
+### `installation/mise/` plugin: minimum toolr `0.20.0`, attests by default
+
+- **What changed:** the bundled mise plugin under
+  `installation/mise/` now rejects toolr versions below `0.20.0`
+  (matching the action's cutoff) and verifies the SLSA build
+  provenance via `gh attestation verify` on every install. Set
+  `TOOLR_SKIP_ATTESTATION=1` to bypass — the plugin tells you so
+  loudly if `gh` is missing from `PATH`.
+
+## New features
+
+### `TOOLR_VENV_LOCATION` environment variable
+
+The new `TOOLR_VENV_LOCATION` env var overrides the
+`[tool.toolr] venv-location` setting in `tools/pyproject.toml`.
+Accepts the same `in-tree` / `cache` spellings the TOML key does.
+Intended primarily for CI: the `Setup ToolR` action sets it to
+`in-tree` automatically so workflows can cache `tools/.venv`
+directly without forcing every consumer repo's
+`tools/pyproject.toml` to declare `venv-location = "in-tree"`.

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,15 @@ inputs:
       rebuild the venv on every run.
     default: "true"
 
+  sync-args:
+    description: |
+      Extra arguments appended to the `uv sync` invocation the
+      action runs to materialise the tools venv. Whitespace-split
+      shell-style; do not quote each flag. Useful for opting back
+      into a dependency group the default `--no-default-groups`
+      would skip (e.g. `--group lint`). Defaults to empty.
+    default: ""
+
 outputs:
   version:
     description: Resolved ToolR version installed (no leading `v`).
@@ -329,23 +338,67 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         # Independent cache from the toolr-binary cache: the venv
-        # is invalidated by dependency churn (`tools/uv.lock`) or
-        # project metadata changes (`tools/pyproject.toml`), not by
-        # a toolr release. The triple stays in the key so a runner
-        # OS / arch swap also misses.
-        key: ${{ inputs.cache-prefix }}-tools-venv|${{ steps.archive.outputs.triple }}|${{ hashFiles('tools/pyproject.toml', 'tools/uv.lock') }}
+        # is invalidated by dependency churn (`uv.lock` / its
+        # `tools/`-scoped sibling if it exists) or project metadata
+        # changes (`tools/pyproject.toml`), not by a toolr release.
+        # The triple stays in the key so a runner OS / arch swap
+        # also misses.
+        #
+        # The cache covers BOTH lock-file shapes that exist in the
+        # wild: a single-workspace `uv.lock` at the repo root (this
+        # is what the toolr repo itself uses — `tools/` is a uv
+        # workspace member of the root) and a standalone
+        # `tools/uv.lock` (which a consumer using toolr but no
+        # workspace would have). hashFiles' undefined-file behaviour
+        # is to skip the missing entry, so either layout produces a
+        # stable, deterministic key.
+        key: ${{ inputs.cache-prefix }}-tools-venv|${{ steps.archive.outputs.triple }}|${{ hashFiles('tools/pyproject.toml', 'tools/uv.lock', 'uv.lock') }}
         path: ${{ steps.venv-path.outputs.path }}
 
     - name: Sync tools venv
       if: inputs.cache-tools-venv == 'true'
       shell: bash
-      # Cache-miss path: materialise the venv from
-      # `tools/pyproject.toml` + `tools/uv.lock`. Cache-hit path:
-      # cheap no-op — `toolr project deps sync` skips the heavy
-      # work when the freshness marker matches. Either way the
-      # caller's first `toolr <group> <cmd>` invocation finds a
-      # working venv instead of the "Python interpreter not found"
-      # error the toolr dispatcher would otherwise emit.
+      env:
+        VENV_PATH: ${{ steps.venv-path.outputs.path }}
+        SYNC_ARGS: ${{ inputs.sync-args }}
+      # The action drives uv directly rather than going through
+      # `toolr project deps sync` so it can scope the install to
+      # what CI actually needs:
+      #
+      # - `--no-default-groups` skips the workspace's `dev` /
+      #   `docs` / etc. groups. Those carry test runners, doc
+      #   tooling, and (in the toolr repo itself) the example
+      #   plugin — none of which are needed for `toolr <group>
+      #   <cmd>` to dispatch a Python command. Users who DO need
+      #   the dev group at action time can pass extra flags via
+      #   the `sync-args` input.
+      # - `--frozen` refuses to re-resolve. CI always installs
+      #   what `uv.lock` says, never silently bumps versions.
+      # - `UV_PROJECT_ENVIRONMENT` pins the venv path that toolr
+      #   resolved above so the install lands where toolr expects.
+      # - `VIRTUAL_ENV` is unset so uv doesn't warn about a
+      #   mismatch with whatever venv mise / setup-virtualenv
+      #   already activated.
+      #
+      # After a successful sync we touch the freshness marker
+      # toolr uses to skip re-syncing. Without this, the next
+      # `toolr <group> <cmd>` invocation sees the lock-newer-than-
+      # marker timestamp and triggers another sync.
       run: |
         set -euo pipefail
-        toolr project deps sync
+        if ! command -v uv >/dev/null 2>&1; then
+          echo "setup-toolr: 'uv' is required on PATH to materialise the tools venv" >&2
+          echo "setup-toolr: install via mise or your platform's uv channel" >&2
+          exit 1
+        fi
+        unset VIRTUAL_ENV
+        # shellcheck disable=SC2086  # we deliberately split SYNC_ARGS on whitespace
+        UV_PROJECT_ENVIRONMENT="$VENV_PATH" uv sync \
+          --project tools \
+          --no-default-groups \
+          --frozen \
+          $SYNC_ARGS
+        # `.toolr-sync-stamp` is the freshness marker toolr writes
+        # when its own `project deps sync` succeeds. Mirror it here
+        # so a subsequent `toolr <cmd>` skips the redundant sync.
+        : > "$VENV_PATH/.toolr-sync-stamp"

--- a/action.yml
+++ b/action.yml
@@ -253,20 +253,14 @@ runs:
       # `[tool.toolr] venv-location` setting in the project's
       # `tools/pyproject.toml`, so caller repos don't need to
       # special-case CI in their config.
+      #
+      # The override is only honoured by toolr >= 0.20.1 (the
+      # release that ships `TOOLR_VENV_LOCATION` support). On
+      # 0.20.0 the env var is read but ignored and the venv falls
+      # back to `~/.cache/toolr/<repo-key>/venv` — which is why the
+      # cache step below grabs both candidate locations.
       run: |
         echo "TOOLR_VENV_LOCATION=in-tree" >> "$GITHUB_ENV"
-
-    - name: Cache tools venv
-      if: inputs.cache-tools-venv == 'true'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        # Independent cache from the toolr-binary cache: the venv
-        # is invalidated by dependency churn (`tools/uv.lock`) or
-        # project metadata changes (`tools/pyproject.toml`), not by
-        # a toolr release. The triple stays in the key so a runner
-        # OS / arch swap also misses.
-        key: ${{ inputs.cache-prefix }}-tools-venv|${{ steps.archive.outputs.triple }}|${{ hashFiles('tools/pyproject.toml', 'tools/uv.lock') }}
-        path: tools/.venv
 
     - name: Install toolr binary
       id: install
@@ -310,3 +304,48 @@ runs:
           echo "bin-path=${bin_dir}/${BIN}"
         } >> "$GITHUB_OUTPUT"
         echo "setup-toolr: installed toolr ${VERSION} at ${bin_dir}/${BIN}"
+
+    - name: Resolve tools venv path
+      id: venv-path
+      if: inputs.cache-tools-venv == 'true'
+      shell: bash
+      # Ask the freshly-installed toolr where it would put the
+      # venv. On 0.20.1+ with TOOLR_VENV_LOCATION=in-tree that's
+      # `tools/.venv`; on 0.20.0 it's the cache-dir path even with
+      # the env var set. Capturing the actual resolved path here
+      # means the cache step below targets the right directory
+      # regardless of the toolr version on the runner.
+      env:
+        BIN_PATH: ${{ steps.install.outputs.bin-path }}
+      run: |
+        set -euo pipefail
+        venv_path="$("$BIN_PATH" project venv path)"
+        echo "setup-toolr: resolved tools venv path: $venv_path"
+        echo "path=$venv_path" >> "$GITHUB_OUTPUT"
+
+    - name: Cache tools venv
+      id: venv-cache
+      if: inputs.cache-tools-venv == 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        # Independent cache from the toolr-binary cache: the venv
+        # is invalidated by dependency churn (`tools/uv.lock`) or
+        # project metadata changes (`tools/pyproject.toml`), not by
+        # a toolr release. The triple stays in the key so a runner
+        # OS / arch swap also misses.
+        key: ${{ inputs.cache-prefix }}-tools-venv|${{ steps.archive.outputs.triple }}|${{ hashFiles('tools/pyproject.toml', 'tools/uv.lock') }}
+        path: ${{ steps.venv-path.outputs.path }}
+
+    - name: Sync tools venv
+      if: inputs.cache-tools-venv == 'true'
+      shell: bash
+      # Cache-miss path: materialise the venv from
+      # `tools/pyproject.toml` + `tools/uv.lock`. Cache-hit path:
+      # cheap no-op — `toolr project deps sync` skips the heavy
+      # work when the freshness marker matches. Either way the
+      # caller's first `toolr <group> <cmd>` invocation finds a
+      # working venv instead of the "Python interpreter not found"
+      # error the toolr dispatcher would otherwise emit.
+      run: |
+        set -euo pipefail
+        toolr project deps sync

--- a/action.yml
+++ b/action.yml
@@ -1,163 +1,312 @@
 name: "Setup ToolR"
-description: "Install ToolR via uvx and cache it"
+description: "Install the ToolR Rust binary from a GitHub release and verify its SLSA build provenance"
 author: "Pedro Algarvio"
 
 inputs:
   version:
-    description: ToolR version to install (defaults to the action's git ref version, or 'latest' if not a tag)
+    description: |
+      ToolR version to install, with or without a leading `v`
+      (e.g. `0.20.0` or `v0.20.0`). The special value `latest`
+      resolves to the most recent release tag. When empty, the
+      action falls back to the git ref it was invoked with
+      (`github.action_ref`), and then to `latest`.
+
+      Versions below `0.20.0` are not accepted — the binary-only
+      release format started with that version.
     default: ""
 
-  python-path:
-    description: Path to the Python executable that shall be used
-    default: "python"
+  skip-attestation:
+    description: |
+      Set to `true` to skip `gh attestation verify` on the
+      downloaded archive. Defaults to `false`; the action
+      cryptographically verifies the SLSA build provenance the
+      release workflow attaches to every archive.
+    default: "false"
 
-  requirements-file:
-    description: Additional requirements file to install
-    default: ""
+  github-token:
+    description: |
+      Token used by `gh release download` and `gh attestation
+      verify`. Defaults to the workflow's GITHUB_TOKEN. The token
+      needs the `contents: read` permission scope.
+    default: ${{ github.token }}
+
+  cache-prefix:
+    description: |
+      Prefix prepended to the actions/cache keys this action
+      manages — both the toolr-binary cache and the in-tree
+      `tools/.venv` cache. Defaults to `setup-toolr`. Bump the
+      prefix in the caller workflow to force a cache miss without
+      changing the toolr version or the pinned dependencies —
+      useful when invalidating after a runner image upgrade or a
+      corrupted cache entry.
+    default: "setup-toolr"
+
+  cache-tools-venv:
+    description: |
+      When `true` (the default), cache the in-tree
+      `tools/.venv` keyed on `tools/pyproject.toml` and
+      `tools/uv.lock`. Set to `false` if you want toolr to
+      rebuild the venv on every run.
+    default: "true"
 
 outputs:
   version:
-    description: ToolR version installed
-    value: ${{ steps.toolr-version.outputs.version }}
-  pipx-home-dir:
-    description: Pipx home directory
-    value: ${{ steps.setup-pipx.outputs.cache-home-dir }}
-  pipx-bin-dir:
-    description: Pipx bin directory
-    value: ${{ steps.setup-pipx.outputs.cache-bin-dir }}
-  pipx-python-path:
-    description: Pipx python path
-    value: ${{ steps.python-version-checksum.outputs.python-path }}
-
-# pipx caching work was taken from https://generalreasoning.com/blog/cicd/python/software/2025/02/18/github-actions-caching-pipx.html
+    description: Resolved ToolR version installed (no leading `v`).
+    value: ${{ steps.resolve-version.outputs.version }}
+  bin-dir:
+    description: Directory containing the `toolr` binary (already on PATH).
+    value: ${{ steps.install.outputs.bin-dir }}
+  bin-path:
+    description: Absolute path to the installed `toolr` binary.
+    value: ${{ steps.install.outputs.bin-path }}
 
 runs:
   using: "composite"
   steps:
-    - name: Define ToolR version
+    - name: Resolve toolr version
+      id: resolve-version
       shell: bash
-      id: parse-version
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_VERSION: ${{ inputs.version }}
+        ACTION_REF: ${{ github.action_ref }}
       run: |
-        ACTION_VERSION_TAG="${{ inputs.version }}"
+        set -euo pipefail
 
-        # If no version specified, auto-detect from git ref
-        if [ -z "$ACTION_VERSION_TAG" ]; then
-          # GITHUB_ACTION_REF is the ref/tag that the action was referenced with
-          # e.g., "v0.11.0" if used as s0undt3ch/ToolR@v0.11.0
-          if [ -n "${{ github.action_ref }}" ]; then
-            ACTION_VERSION_TAG="${{ github.action_ref }}"
-            echo "Auto-detected version from action ref: $ACTION_VERSION_TAG"
-          else
-            # Fallback to latest if we can't detect
-            ACTION_VERSION_TAG="latest"
-            echo "No version specified and no action ref found, using latest"
+        raw="${INPUT_VERSION}"
+        if [ -z "$raw" ] && [ -n "${ACTION_REF}" ]; then
+          raw="${ACTION_REF}"
+          echo "setup-toolr: no version input; using action ref '$raw'"
+        fi
+        if [ -z "$raw" ]; then
+          raw="latest"
+          echo "setup-toolr: no version input or action ref; defaulting to 'latest'"
+        fi
+
+        # Strip the leading `v` so the rest of the action sees a bare
+        # semver string. Release artifacts are named without it; the
+        # release tag carries it. Normalising here means every
+        # downstream consumer (download URLs, output value) sees the
+        # same shape.
+        version="${raw#v}"
+
+        if [ "$version" = "latest" ]; then
+          # `gh release view --json tagName` returns `vX.Y.Z` for our
+          # release tags; strip the leading `v` for consistency.
+          version=$(gh release view --repo "${GITHUB_REPOSITORY:-s0undt3ch/ToolR}" --json tagName --jq '.tagName' 2>/dev/null | sed 's/^v//')
+          if [ -z "$version" ]; then
+            # Fallback for forks or downstream consumers: the action's
+            # canonical repo, not the calling workflow's.
+            version=$(gh release view --repo s0undt3ch/ToolR --json tagName --jq '.tagName' | sed 's/^v//')
           fi
-        fi
-
-        echo "THE ACTION_VERSION_TAG=$ACTION_VERSION_TAG"
-        VERSION_FROM_TAG=${ACTION_VERSION_TAG#v}
-        if [ "${VERSION_FROM_TAG}" = "latest" ]; then
-          VERSION_FROM_TAG=$(curl -s https://pypi.org/pypi/toolr/json | jq -r '.info.version' 2>/dev/null)
-        fi
-        if [ "${VERSION_FROM_TAG}" = "local" ]; then
-          if [ "${{ github.repository }}" != "s0undt3ch/ToolR" ]; then
-            echo "Local version is only supported for the ToolR repository"
+          if [ -z "$version" ]; then
+            echo "setup-toolr: could not resolve 'latest' to a release tag" >&2
             exit 1
           fi
-          VERSION_FROM_TAG=$(git describe --tags --match "v[0-9]*.[0-9]*.[0-9]*" --long || git rev-parse --short HEAD)
+          echo "setup-toolr: resolved 'latest' to $version"
         fi
-        # Generate a requirements file so that the setup-uv action can properly invalidate the cache when necessary
-        if [ -n "${{ inputs.requirements-file }}" ] && [ -f "${{ inputs.requirements-file }}" ]; then
-          REQUIREMENTS_FILE=${{ github.workspace }}/.toolr-action-requirements.txt
-          # Pipx only supports requirements files with one package per line, no even comments are allowed
-          grep -v '^#' "${{ inputs.requirements-file }}" > "$REQUIREMENTS_FILE"
+
+        # ToolR 0.20.0 is the first binary-only release shape. Earlier
+        # versions shipped via pipx + PyPI source; this action no
+        # longer supports them. Surface a loud error rather than
+        # silently downloading an asset that does not exist.
+        minimum="0.20.0"
+        if [ "$(printf '%s\n%s\n' "$minimum" "$version" | sort -V | head -n 1)" != "$minimum" ]; then
+          echo "setup-toolr: refusing to install toolr $version — minimum supported version is $minimum" >&2
+          echo "setup-toolr: earlier releases shipped as a Python package and are no longer compatible with this action." >&2
+          exit 1
         fi
-        echo "version=${VERSION_FROM_TAG}" >> "$GITHUB_OUTPUT"
-        echo "requirements-file=${REQUIREMENTS_FILE}" >> "$GITHUB_OUTPUT"
 
-    - name: Get Python version checksum
-      id: python-version-checksum
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Compute archive identifiers
+      id: archive
       shell: bash
+      env:
+        VERSION: ${{ steps.resolve-version.outputs.version }}
       run: |
-        PYTHON_PATH=${{ inputs.python-path || 'python' }}
-        echo "PYTHON_PATH=$PYTHON_PATH"
-        echo "python-path=$PYTHON_PATH" >> "$GITHUB_OUTPUT"
-        PYTHON_VERSION=$("$PYTHON_PATH" --version --version)
-        echo "PYTHON_VERSION=$PYTHON_VERSION"
-        VERSION_SHA256SUM=$(echo "$PYTHON_VERSION" | sha256sum | cut -d ' ' -f 1)
-        echo "VERSION_SHA256SUM=$VERSION_SHA256SUM"
-        echo "version-sha256sum=$VERSION_SHA256SUM" >> "$GITHUB_OUTPUT"
+        set -euo pipefail
+        case "$RUNNER_OS" in
+          Linux)
+            arch=$(uname -m)
+            libc=gnu
+            [ -f /etc/alpine-release ] && libc=musl
+            case "$arch" in
+              x86_64|amd64)  triple="x86_64-unknown-linux-${libc}" ;;
+              aarch64|arm64) triple="aarch64-unknown-linux-${libc}" ;;
+              *) echo "setup-toolr: unsupported Linux arch '$arch'" >&2; exit 1 ;;
+            esac
+            ext=tar.gz
+            bin=toolr
+            ;;
+          macOS)
+            arch=$(uname -m)
+            case "$arch" in
+              x86_64) triple="x86_64-apple-darwin" ;;
+              arm64|aarch64) triple="aarch64-apple-darwin" ;;
+              *) echo "setup-toolr: unsupported macOS arch '$arch'" >&2; exit 1 ;;
+            esac
+            ext=tar.gz
+            bin=toolr
+            ;;
+          Windows)
+            triple="x86_64-pc-windows-msvc"
+            ext=zip
+            bin=toolr.exe
+            ;;
+          *)
+            echo "setup-toolr: unsupported RUNNER_OS '$RUNNER_OS'" >&2
+            exit 1
+            ;;
+        esac
 
-    - name: Get pipx version checksum
-      id: pipx-version-checksum
-      shell: bash
-      run: |
-        PIPX_PATH=$(which pipx)
-        echo "PIPX_PATH=$PIPX_PATH"
-        echo "pipx-path=$PIPX_PATH" >> "$GITHUB_OUTPUT"
-        VERSION_SHA256SUM=$("$PIPX_PATH" --version | sha256sum | cut -d ' ' -f 1)
-        echo "VERSION_SHA256SUM=$VERSION_SHA256SUM"
-        echo "version-sha256sum=$VERSION_SHA256SUM" >> "$GITHUB_OUTPUT"
+        archive="toolr-${VERSION}-${triple}.${ext}"
+        {
+          echo "triple=$triple"
+          echo "ext=$ext"
+          echo "bin=$bin"
+          echo "archive=$archive"
+        } >> "$GITHUB_OUTPUT"
 
-    - name: Setup pipx
-      id: setup-pipx
-      shell: bash
-      run: |
-        # Custom cache dir for pipx
-        # custom cached dir
-        cache_home_dir="$HOME/.local/pipx"
-        cache_bin_dir="$HOME/.local/pipx_bin"
-
-        # add cached dir to PATH
-        echo "$cache_bin_dir" >> "$GITHUB_PATH"
-
-        echo "cache-home-dir=$cache_home_dir" >> "$GITHUB_OUTPUT"
-        echo "cache-bin-dir=$cache_bin_dir" >> "$GITHUB_OUTPUT"
-
-    - id: cache-pipx
-      uses: actions/cache@v5
-      if: ${{ inputs.version }} != 'local'
+    - name: Cache toolr install
+      id: cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        key: >-
-          pipx|toolr|${{ steps.parse-version.outputs.version}}|${{
-            steps.python-version-checksum.outputs.version-sha256sum }}|${{
-            steps.pipx-version-checksum.outputs.version-sha256sum }}|${{
-            hashFiles(inputs.requirements-file, steps.parse-version.outputs.requirements-file) }}
-        path: |
-          ${{ steps.setup-pipx.outputs.cache-home-dir }}
-          ${{ steps.setup-pipx.outputs.cache-bin-dir }}
+        # `cache-prefix` lets callers force-invalidate without
+        # bumping the toolr version (e.g. after a runner image swap
+        # that needs a fresh binary, or to recover from a corrupted
+        # cache entry).
+        key: ${{ inputs.cache-prefix }}|${{ steps.resolve-version.outputs.version }}|${{ steps.archive.outputs.triple }}
+        path: ${{ runner.tool_cache }}/toolr/${{ steps.resolve-version.outputs.version }}
 
-    - name: Install ToolR
-      if: ${{ inputs.version }} == 'local' || ${{ steps.cache-pipx.outputs.cache-hit != 'true' }}
+    - name: Download archive
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       env:
-        # Install in our custom cached dir
-        PIPX_HOME: ${{ steps.setup-pipx.outputs.cache-home-dir }}
-        PIPX_BIN_DIR: ${{ steps.setup-pipx.outputs.cache-bin-dir }}
-        # Use correct python
-        PIPX_DEFAULT_PYTHON: ${{ steps.python-version-checksum.outputs.python-path }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        VERSION: ${{ steps.resolve-version.outputs.version }}
+        ARCHIVE: ${{ steps.archive.outputs.archive }}
       run: |
-        if [ "${{ inputs.version }}" = "local" ]; then
-          pipx install .
+        set -euo pipefail
+        work="$RUNNER_TEMP/setup-toolr"
+        rm -rf "$work"
+        mkdir -p "$work"
+
+        # `gh release download` is the preferred path: authenticated,
+        # rate-limit-friendly, no need to construct release URLs by
+        # hand. Falls back to `curl` when `gh` is unavailable for any
+        # reason (custom runners, self-hosted images without gh).
+        if command -v gh >/dev/null 2>&1; then
+          gh release download "v${VERSION}" \
+            --repo s0undt3ch/ToolR \
+            --pattern "${ARCHIVE}" \
+            --pattern "${ARCHIVE}.sha256" \
+            --dir "$work"
+        elif command -v curl >/dev/null 2>&1; then
+          base="https://github.com/s0undt3ch/ToolR/releases/download/v${VERSION}"
+          curl --fail --location --silent --show-error --output "${work}/${ARCHIVE}" "${base}/${ARCHIVE}"
+          curl --fail --location --silent --show-error --output "${work}/${ARCHIVE}.sha256" "${base}/${ARCHIVE}.sha256"
         else
-          pipx install toolr==${{ steps.parse-version.outputs.version }}
+          echo "setup-toolr: neither 'gh' nor 'curl' is available on PATH" >&2
+          exit 1
         fi
 
-    - name: Install additional requirements
-      if: ${{ inputs.version }} == 'local' || ${{ steps.cache-pipx.outputs.cache-hit != 'true' }}
+        # Verify the checksum the release pipeline shipped alongside
+        # the archive. Mismatch means the file is corrupt or has been
+        # tampered with — abort before unpacking.
+        cd "$work"
+        if command -v sha256sum >/dev/null 2>&1; then
+          sha256sum --check "${ARCHIVE}.sha256"
+        else
+          # macOS lacks sha256sum; fall back to shasum.
+          expected=$(awk '{print $1}' "${ARCHIVE}.sha256")
+          actual=$(shasum -a 256 "${ARCHIVE}" | awk '{print $1}')
+          if [ "$expected" != "$actual" ]; then
+            echo "setup-toolr: sha256 mismatch for ${ARCHIVE} (expected $expected, got $actual)" >&2
+            exit 1
+          fi
+        fi
+
+        echo "ARCHIVE_PATH=${work}/${ARCHIVE}" >> "$GITHUB_ENV"
+
+    - name: Verify SLSA build provenance
+      if: steps.cache.outputs.cache-hit != 'true' && inputs.skip-attestation != 'true'
       shell: bash
       env:
-        # Install in our custom cached dir
-        PIPX_HOME: ${{ steps.setup-pipx.outputs.cache-home-dir }}
-        PIPX_BIN_DIR: ${{ steps.setup-pipx.outputs.cache-bin-dir }}
-        # Use correct python
-        PIPX_DEFAULT_PYTHON: ${{ steps.python-version-checksum.outputs.python-path }}
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        pipx inject toolr -r ${{ steps.parse-version.outputs.requirements-file }}
+        set -euo pipefail
+        if ! command -v gh >/dev/null 2>&1; then
+          echo "setup-toolr: attestation verification requires the 'gh' CLI" >&2
+          echo "setup-toolr: install gh or pass 'skip-attestation: true' to bypass" >&2
+          exit 1
+        fi
+        gh attestation verify "$ARCHIVE_PATH" --repo s0undt3ch/ToolR
 
-    - name: Get ToolR version
-      id: toolr-version
+    - name: Force in-tree tools venv
       shell: bash
+      # Toolr supports two venv layouts (`in-tree` / `cache`); CI
+      # works much better with in-tree because GitHub Actions can
+      # cache `tools/.venv` directly while the global cache dir
+      # lives under `$XDG_CACHE_HOME`, which differs per runner and
+      # is harder to scope. The env var overrides any
+      # `[tool.toolr] venv-location` setting in the project's
+      # `tools/pyproject.toml`, so caller repos don't need to
+      # special-case CI in their config.
       run: |
-        TOOLR_VERSION=$(toolr --version)
-        echo "version=$TOOLR_VERSION" >> "$GITHUB_OUTPUT"
+        echo "TOOLR_VENV_LOCATION=in-tree" >> "$GITHUB_ENV"
+
+    - name: Cache tools venv
+      if: inputs.cache-tools-venv == 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        # Independent cache from the toolr-binary cache: the venv
+        # is invalidated by dependency churn (`tools/uv.lock`) or
+        # project metadata changes (`tools/pyproject.toml`), not by
+        # a toolr release. The triple stays in the key so a runner
+        # OS / arch swap also misses.
+        key: ${{ inputs.cache-prefix }}-tools-venv|${{ steps.archive.outputs.triple }}|${{ hashFiles('tools/pyproject.toml', 'tools/uv.lock') }}
+        path: tools/.venv
+
+    - name: Install toolr binary
+      id: install
+      shell: bash
+      env:
+        VERSION: ${{ steps.resolve-version.outputs.version }}
+        EXT: ${{ steps.archive.outputs.ext }}
+        BIN: ${{ steps.archive.outputs.bin }}
+        TRIPLE: ${{ steps.archive.outputs.triple }}
+      run: |
+        set -euo pipefail
+        bin_dir="$RUNNER_TOOL_CACHE/toolr/${VERSION}"
+        mkdir -p "$bin_dir"
+
+        if [ ! -x "${bin_dir}/${BIN}" ]; then
+          tmp="$(mktemp -d)"
+          case "$EXT" in
+            tar.gz) tar -xzf "$ARCHIVE_PATH" -C "$tmp" ;;
+            zip)    unzip -q "$ARCHIVE_PATH" -d "$tmp" ;;
+          esac
+
+          # The release archives unpack into a single
+          # `toolr-<version>-<triple>/` directory containing the
+          # binary. Locate it explicitly rather than relying on
+          # `--strip-components` so the zip and tar paths share the
+          # same logic.
+          src_dir="${tmp}/toolr-${VERSION}-${TRIPLE}"
+          if [ ! -d "$src_dir" ]; then
+            echo "setup-toolr: archive layout changed — '$src_dir' missing" >&2
+            ls -la "$tmp" >&2
+            exit 1
+          fi
+          cp "${src_dir}/${BIN}" "${bin_dir}/${BIN}"
+          chmod +x "${bin_dir}/${BIN}"
+          rm -rf "$tmp"
+        fi
+
+        echo "$bin_dir" >> "$GITHUB_PATH"
+        {
+          echo "bin-dir=$bin_dir"
+          echo "bin-path=${bin_dir}/${BIN}"
+        } >> "$GITHUB_OUTPUT"
+        echo "setup-toolr: installed toolr ${VERSION} at ${bin_dir}/${BIN}"

--- a/crates/toolr-core/src/venv/config.rs
+++ b/crates/toolr-core/src/venv/config.rs
@@ -1,9 +1,16 @@
 //! Parse the `[tool.toolr]` table out of `tools/pyproject.toml`.
 
 use std::path::Path;
+use std::str::FromStr;
 
 use serde::Deserialize;
 use thiserror::Error;
+
+/// Environment variable that overrides `[tool.toolr] venv-location`
+/// in `tools/pyproject.toml`. Accepts the same kebab-case spellings
+/// the TOML key does (`in-tree` / `cache`). Primarily a CI escape
+/// hatch — the per-project default belongs in `pyproject.toml`.
+pub const VENV_LOCATION_ENV: &str = "TOOLR_VENV_LOCATION";
 
 /// Where the tools venv should be materialised.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
@@ -14,6 +21,20 @@ pub enum VenvLocation {
     Cache,
     /// Opt-in: `tools/.venv/`.
     InTree,
+}
+
+impl FromStr for VenvLocation {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "in-tree" | "intree" => Ok(VenvLocation::InTree),
+            "cache" => Ok(VenvLocation::Cache),
+            other => Err(format!(
+                "expected `in-tree` or `cache` for VenvLocation, got `{other}`",
+            )),
+        }
+    }
 }
 
 /// Strongly-typed view of the `[tool.toolr]` table.

--- a/crates/toolr-core/src/venv/resolve.rs
+++ b/crates/toolr-core/src/venv/resolve.rs
@@ -1,10 +1,13 @@
 //! Resolve the absolute path where the tools venv should live.
 
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use anyhow::{Context, Result};
 
-use super::config::{ToolrConfig, VenvLocation, load_toolr_config, read_requires_python};
+use super::config::{
+    ToolrConfig, VENV_LOCATION_ENV, VenvLocation, load_toolr_config, read_requires_python,
+};
 use super::repo_key::compute_repo_key;
 use crate::uv::toolr_cache_dir;
 
@@ -34,7 +37,19 @@ pub fn resolve_venv_path(repo_root: &Path) -> Result<ResolvedVenv> {
         .or(read_requires_python(&tools).ok().flatten())
         .unwrap_or_default();
 
-    let (venv_dir, repo_key) = match config.venv_location {
+    // Env-var override of the `[tool.toolr] venv-location` setting.
+    // Primary use case: CI workflows that want to opt every repo into
+    // in-tree venvs without rewriting each one's `tools/pyproject.toml`.
+    // An invalid spelling is a hard error so a typo doesn't silently
+    // fall back to the file-configured value.
+    let venv_location = match std::env::var(VENV_LOCATION_ENV) {
+        Ok(raw) if !raw.is_empty() => VenvLocation::from_str(&raw).map_err(|e| {
+            anyhow::anyhow!("{VENV_LOCATION_ENV}={raw:?} is invalid: {e}")
+        })?,
+        _ => config.venv_location,
+    };
+
+    let (venv_dir, repo_key) = match venv_location {
         VenvLocation::InTree => (tools.join(".venv"), String::new()),
         VenvLocation::Cache => {
             let key = compute_repo_key(repo_root, &python_version)?;
@@ -61,8 +76,17 @@ pub fn resolve_venv_path(repo_root: &Path) -> Result<ResolvedVenv> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
     use tempfile::TempDir;
+
+    /// Serialise every test in this module: they all share the
+    /// process-wide environment (via `std::env::var`), and the
+    /// `TOOLR_VENV_LOCATION` override is read on every invocation
+    /// of `resolve_venv_path`. Running tests in parallel would let
+    /// one test's `set_var` bleed into another's expectations.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn setup_repo(body: &str) -> TempDir {
         let tmp = TempDir::new().unwrap();
@@ -74,6 +98,9 @@ mod tests {
 
     #[test]
     fn cache_default_uses_repo_key_subdir() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::new(VENV_LOCATION_ENV);
+        unsafe { std::env::remove_var(VENV_LOCATION_ENV) };
         let tmp = setup_repo("[project]\nname=\"x\"\nversion=\"0\"\n");
         let resolved = resolve_venv_path(tmp.path()).unwrap();
         assert!(resolved.venv_dir.ends_with("venv"));
@@ -88,11 +115,80 @@ mod tests {
 
     #[test]
     fn in_tree_lands_inside_tools_dot_venv() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::new(VENV_LOCATION_ENV);
+        unsafe { std::env::remove_var(VENV_LOCATION_ENV) };
         let tmp = setup_repo(
             "[project]\nname=\"x\"\nversion=\"0\"\n\n[tool.toolr]\nvenv-location = \"in-tree\"\n",
         );
         let resolved = resolve_venv_path(tmp.path()).unwrap();
         assert_eq!(resolved.venv_dir, tmp.path().join("tools").join(".venv"));
         assert!(resolved.repo_key.is_empty());
+    }
+
+    /// Setting `TOOLR_VENV_LOCATION=in-tree` flips the resolution to
+    /// `tools/.venv` even when `pyproject.toml` requests `cache`. The
+    /// inverse direction (env says `cache`, file says `in-tree`) is
+    /// also covered to prove the override is bidirectional rather
+    /// than a one-way "force in-tree" flag.
+    #[test]
+    fn env_var_overrides_pyproject_venv_location() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::new(VENV_LOCATION_ENV);
+
+        let tmp = setup_repo("[project]\nname=\"x\"\nversion=\"0\"\n");
+        // SAFETY: the EnvVarGuard above ensures we restore the
+        // previous value on drop.
+        unsafe { std::env::set_var(VENV_LOCATION_ENV, "in-tree") };
+        let resolved = resolve_venv_path(tmp.path()).unwrap();
+        assert_eq!(resolved.venv_dir, tmp.path().join("tools").join(".venv"));
+
+        let tmp_in = setup_repo(
+            "[project]\nname=\"x\"\nversion=\"0\"\n\n[tool.toolr]\nvenv-location = \"in-tree\"\n",
+        );
+        unsafe { std::env::set_var(VENV_LOCATION_ENV, "cache") };
+        let resolved_cache = resolve_venv_path(tmp_in.path()).unwrap();
+        // Cache mode lands under the toolr cache dir, not in-tree.
+        assert!(!resolved_cache.venv_dir.starts_with(tmp_in.path()));
+        assert!(!resolved_cache.repo_key.is_empty());
+    }
+
+    #[test]
+    fn env_var_invalid_value_is_an_error() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let _guard = EnvVarGuard::new(VENV_LOCATION_ENV);
+        let tmp = setup_repo("[project]\nname=\"x\"\nversion=\"0\"\n");
+        unsafe { std::env::set_var(VENV_LOCATION_ENV, "bogus") };
+        let err = resolve_venv_path(tmp.path()).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("TOOLR_VENV_LOCATION"), "got: {msg}");
+        assert!(msg.contains("bogus"), "got: {msg}");
+    }
+
+    /// RAII helper that restores (or removes) the original env var
+    /// value on drop. Necessary because Rust tests run with a shared
+    /// process env and setting `TOOLR_VENV_LOCATION` from one test
+    /// would otherwise bleed into the next.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn new(key: &'static str) -> Self {
+            Self {
+                key,
+                previous: std::env::var(key).ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
     }
 }

--- a/docs/project-config.md
+++ b/docs/project-config.md
@@ -58,6 +58,13 @@ venv-location = "in-tree"
 The default `tools/.gitignore` written by `toolr project init` already
 excludes `.venv/`, so the in-tree venv won't leak into git.
 
+Setting the environment variable `TOOLR_VENV_LOCATION` overrides the
+value in `tools/pyproject.toml`. Accepts the same `in-tree` / `cache`
+spellings the TOML key does. Useful as a CI escape hatch — the
+`s0undt3ch/ToolR` setup-toolr action sets it to `in-tree`
+automatically so workflows can cache `tools/.venv` directly without
+the per-repo config caring.
+
 ### `editable-install` {#editable-install}
 
 A list of paths to `uv pip install -e` after the initial sync.

--- a/installation/mise/bin/download
+++ b/installation/mise/bin/download
@@ -6,6 +6,17 @@ REPO="${TOOLR_REPO:-s0undt3ch/ToolR}"
 VERSION="${ASDF_INSTALL_VERSION:?ASDF_INSTALL_VERSION required}"
 DOWNLOAD_PATH="${ASDF_DOWNLOAD_PATH:?ASDF_DOWNLOAD_PATH required}"
 
+# Minimum supported version, matched to `bin/install`. Catch the
+# unsupported case before we hit the network so users see a clear
+# message instead of a 404 on the release asset URL.
+minimum="0.20.0"
+if [ "$(printf '%s\n%s\n' "$minimum" "$VERSION" | sort -V | head -n 1)" != "$minimum" ]; then
+  echo "download: refusing to install toolr ${VERSION}; minimum supported is ${minimum}" >&2
+  echo "download: earlier toolr releases used a Python source distribution and" >&2
+  echo "download: cannot be installed via this mise plugin." >&2
+  exit 1
+fi
+
 detect_triple() {
   uname_s="$(uname -s)"
   uname_m="$(uname -m)"

--- a/installation/mise/bin/install
+++ b/installation/mise/bin/install
@@ -5,6 +5,19 @@ set -euo pipefail
 VERSION="${ASDF_INSTALL_VERSION:?ASDF_INSTALL_VERSION required}"
 INSTALL_PATH="${ASDF_INSTALL_PATH:?ASDF_INSTALL_PATH required}"
 DOWNLOAD_PATH="${ASDF_DOWNLOAD_PATH:?ASDF_DOWNLOAD_PATH required}"
+REPO="${TOOLR_REPO:-s0undt3ch/ToolR}"
+
+# Toolr 0.20.0 is the first release shape this installer supports —
+# earlier versions shipped as a Python package via PyPI and were
+# installed via pipx, not as a binary archive. Surface a loud error
+# rather than 404-ing on a missing release asset.
+minimum="0.20.0"
+if [ "$(printf '%s\n%s\n' "$minimum" "$VERSION" | sort -V | head -n 1)" != "$minimum" ]; then
+  echo "install: refusing to install toolr ${VERSION}; minimum supported is ${minimum}" >&2
+  echo "install: earlier toolr releases used a Python source distribution and" >&2
+  echo "install: cannot be installed via this mise plugin." >&2
+  exit 1
+fi
 
 detect_triple() {
   uname_s="$(uname -s)"
@@ -47,6 +60,24 @@ if [ -f "$sha_file" ]; then
     echo "install: checksum mismatch for $archive" >&2
     exit 1
   }
+fi
+
+# SLSA build-provenance check via `gh attestation verify`. Set
+# `TOOLR_SKIP_ATTESTATION=1` (or any non-empty value) to bypass —
+# useful in environments that don't carry the `gh` CLI or that need
+# to install offline. Defaults to verifying.
+if [ -z "${TOOLR_SKIP_ATTESTATION:-}" ]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "install: 'gh' CLI is required to verify the toolr archive's SLSA build provenance." >&2
+    echo "install: install gh (https://cli.github.com/) or set TOOLR_SKIP_ATTESTATION=1 to bypass." >&2
+    exit 1
+  fi
+  echo "install: verifying SLSA build provenance for ${filename}" >&2
+  if ! gh attestation verify "$archive" --repo "$REPO" >&2; then
+    echo "install: attestation verification failed for ${filename}" >&2
+    echo "install: set TOOLR_SKIP_ATTESTATION=1 to bypass (not recommended)." >&2
+    exit 1
+  fi
 fi
 
 bin_dir="${INSTALL_PATH}/bin"


### PR DESCRIPTION
## Summary

The `s0undt3ch/ToolR` composite action was already broken at 0.20.0+ because the old `pipx install toolr==<version>` path can't install the binary-only wheel ([example failure](https://github.com/s0undt3ch/ToolR/actions/runs/26458486146/job/77899259495)). This PR replaces that path entirely.

- **`action.yml`**: downloads the toolr binary archive via `gh release download` (curl fallback), SHA-256-verifies it, cryptographically verifies the SLSA build provenance via `gh attestation verify`, caches both the binary and the in-tree `tools/.venv`, and puts the binary on `PATH`. New inputs: `version`, `skip-attestation`, `github-token`, `cache-prefix`, `cache-tools-venv`. Removed inputs: `python-path`, `requirements-file`. Refuses versions below `0.20.0`.
- **`installation/mise/`**: the bundled mise plugin gets the same minimum-version gate and runs `gh attestation verify` on every install (`TOOLR_SKIP_ATTESTATION=1` bypasses).
- **`TOOLR_VENV_LOCATION` env var**: new env-var override of the `[tool.toolr] venv-location` setting in `tools/pyproject.toml`. The action sets it to `in-tree` so the venv cache works regardless of per-repo config.
- **Workflows**: `ci.yml`, `release.yml`, `_prepare-release.yml`, `sync-rolling-tags.yml` updated to the new input shape and switched to the in-repo `./` action reference.
- **Docs/UNRELEASED**: `docs/project-config.md` documents the env var; `UNRELEASED.md` queues the breaking-change notes.

## Commits

- `feat(venv)`: TOOLR_VENV_LOCATION env var
- `feat(action)`: binary-download + SLSA attest install
- `feat(mise)`: minimum toolr 0.20.0 + verify SLSA build provenance
- `chore`: update workflows + docs for new action shape

## Test plan

- [x] `cargo test -p toolr-core --lib venv` — 4/4 pass, including new env-var override tests
- [x] `cargo build --workspace` clean
- [x] `prek run` against every changed file passes (actionlint, shellcheck, rumdl, clippy, codespell)
- [ ] CI on this PR exercises the new action end-to-end (cache hit/miss, attestation verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)