### PR TITLE
style: soft-100 / hard-120 line-length policy across Rust, Python, Markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+# EditorConfig — https://editorconfig.org
+#
+# Policy across the workspace: target 100 columns, tolerate up to
+# 120 when the content really needs it. The 100-column ruler this
+# file sets in IDEs/editors is the soft ceiling; lint tools
+# (`ruff`, `rumdl`) enforce the 120 hard cap.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+max_line_length = 100
+
+# Rust + TOML + Python + YAML — 4-space indent.
+[*.{rs,toml,py,pyi}]
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown wraps prose; trailing whitespace is meaningful (hard
+# line break), so don't trim it.
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false
+
+# Shell + JSON — 2-space indent is the conventional default.
+[*.{sh,bash,zsh,fish,json}]
+indent_size = 2
+
+# Makefiles require literal tabs.
+[Makefile]
+indent_style = tab
+
+# Generated reference files: don't fight whatever the generator
+# emits.
+[skills/*/references/*.md]
+max_line_length = unset

--- a/.pre-commit-hooks/regen-doc-snippets.py
+++ b/.pre-commit-hooks/regen-doc-snippets.py
@@ -290,7 +290,9 @@ def capture(toolr: Path, fixture: Path, _python: Path, snippet: Snippet) -> str:
     # pre-commit hook can't fight us. clap occasionally emits a stray
     # trailing space on the line above a continuation; not interesting
     # to capture verbatim.
-    return "\n".join(line.rstrip() for line in body.splitlines()) + ("\n" if body.endswith("\n") else "")
+    return "\n".join(line.rstrip() for line in body.splitlines()) + (
+        "\n" if body.endswith("\n") else ""
+    )
 
 
 def regen_one(

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -3,7 +3,6 @@
 
 [global]
 disable = [
-    "MD013",  # line length — prose wraps freely
     "MD033",  # inline HTML — used in docs (<br>, <details>)
     "MD041",  # first-line H1 — not all docs lead with H1
     "MD052",  # mkdocstrings cross-refs look like reference links to rumdl
@@ -18,10 +17,26 @@ exclude = [
     "site",
     "CHANGELOG.md",
     "docs/reference",  # auto-generated reference stubs
+    # Archived design docs are immutable post-mortem records (see
+    # `specs/README.md`). New rules don't apply retroactively; new
+    # designs in `specs/` at the top level are still linted.
+    "specs/archive",
 ]
 
 respect-gitignore = true
 flavor = "gfm"
+
+[MD013]
+# Hard ceiling matches the language toolchain policy (soft 100 in
+# `.editorconfig` / `.rustfmt.toml` / `tool.ruff.line-length`, hard
+# 120 in `tool.ruff.lint.pycodestyle.max-line-length` and here).
+# Code blocks, tables, and headings are excluded because they
+# legitimately need more room — long shell one-liners, wide
+# tables, and self-explanatory heading titles.
+line_length = 120
+code_blocks = false
+tables = false
+headings = false
 
 [MD007]
 indent = 4

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,23 @@
+# rustfmt configuration for the toolr workspace.
+#
+# Policy: target 100 columns; tolerate up to 120 when the content
+# (a string literal, a doc comment, a tracing!/format! template,
+# etc.) doesn't fit any other way.
+#
+# rustfmt doesn't model "soft 100, hard 120" directly — it has one
+# `max_width` knob. We pin it to 100 so the formatter wraps code
+# at that width. Anything the formatter can't reach (long string
+# literals, doc-comment prose, embedded code examples) is left
+# alone; rustfmt won't break them. Hard-ceiling enforcement at 120
+# stays at the editor / review layer — there's no Clippy
+# line-length lint, so the 120-char cap is editor-side discipline
+# via `.editorconfig` plus reviewer judgement.
+#
+# The settings that would make this more explicit
+# (`error_on_line_overflow = false`, `wrap_comments = false`,
+# `format_code_in_doc_comments = false`, `error_on_unformatted =
+# false`) are nightly-only on the current toolchain and rustfmt
+# rejects them on stable. The pre-existing defaults already match
+# what we want for those knobs, so leaving them out is harmless.
+
+max_width = 100

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to ToolR
 
-Thanks for considering a contribution. ToolR is a small project with a focused surface; bug reports, doc fixes, and well-scoped feature PRs are all welcome.
+Thanks for considering a contribution. ToolR is a small project with a focused surface; bug
+reports, doc fixes, and well-scoped feature PRs are all welcome.
 
 ## Repo layout
 
@@ -53,7 +54,8 @@ cargo build -p toolr --release
 | Python unit tests                      | `uv run pytest`                   | `tests/**/*.py`                        |
 | Distribution lock-tests (opt-in, slow) | `uv run pytest -m distribution`   | `tests/distribution/`                  |
 
-The Rust integration tests spawn the built `toolr` binary via `assert_cmd`. Don't shadow them with Python-level subprocess tests unless the behaviour can't be exercised in Rust.
+The Rust integration tests spawn the built `toolr` binary via `assert_cmd`. Don't shadow them with
+Python-level subprocess tests unless the behaviour can't be exercised in Rust.
 
 ## RUNNER_SCHEMA_VERSION ↔ SCHEMA_VERSION lock-step
 
@@ -62,7 +64,9 @@ The Rust binary and the `toolr-py` Python runtime communicate over a versioned J
 - `RUNNER_SCHEMA_VERSION` in `crates/toolr-core/src/execute/spec.rs`
 - `SCHEMA_VERSION` in `crates/toolr-py/python/toolr/_runner.py`
 
-Both carry doc comments listing which changes require a bump and which don't. Read those before changing either the Rust serde structs or the Python `RunnerSpec` class. A CI gate fails the build when the two values disagree.
+Both carry doc comments listing which changes require a bump and which don't. Read those before
+changing either the Rust serde structs or the Python `RunnerSpec` class. A CI gate fails the build
+when the two values disagree.
 
 ## Commits
 
@@ -86,17 +90,22 @@ prek run --all-files
 prek run rumdl --files docs/internals/manifest.md
 ```
 
-Hooks include `ruff`, `mypy`, `clippy`, `cargo check`, `rumdl`, `codespell`, `typos`, `actionlint`, `shellcheck`, plus the project-local hooks (`pin-github-actions`, `regen-doc-snippets`).
+Hooks include `ruff`, `mypy`, `clippy`, `cargo check`, `rumdl`, `codespell`, `typos`, `actionlint`,
+`shellcheck`, plus the project-local hooks (`pin-github-actions`, `regen-doc-snippets`).
 
 ## Benchmarking
 
-`toolr bench compare` measures `<tool> -h` startup latency for every task-runner CLI it finds on `$PATH` (`toolr`, `invoke`, `python-tools-scripts`, `duty`, `doit`, `nox`). Add `--install` to let it `uv tool install` missing Python tools on demand, and `--markdown` to render the result as a table:
+`toolr bench compare` measures `<tool> -h` startup latency for every task-runner CLI it finds on
+`$PATH` (`toolr`, `invoke`, `python-tools-scripts`, `duty`, `doit`, `nox`). Add `--install` to let
+it `uv tool install` missing Python tools on demand, and `--markdown` to render the result as a
+table:
 
 ```sh
 toolr bench compare --install --markdown
 ```
 
-The README's headline benchmark table comes from this command. Re-run it on a fresh hardware target before changing the README's numbers.
+The README's headline benchmark table comes from this command. Re-run it on a fresh hardware target
+before changing the README's numbers.
 
 ## Filing bugs
 
@@ -107,7 +116,9 @@ Open a [GitHub issue](https://github.com/s0undt3ch/ToolR/issues/new) with:
 - Minimal `tools/*.py` (or repro repo URL) that triggers the bug
 - Expected vs actual output
 
-For suspected security issues, use [GitHub Security Advisories](https://github.com/s0undt3ch/ToolR/security/advisories/new) instead of a public issue.
+For suspected security issues, use
+[GitHub Security Advisories](https://github.com/s0undt3ch/ToolR/security/advisories/new) instead of
+a public issue.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
   <em>Pronounced <tt>/ˈtuːlər/</tt> (tool-er)</em>
 </p>
 
-ToolR is a Python task runner that boots in milliseconds because the front-end is a Rust binary. Python only runs when you invoke a command, inside a per-repo `uv`-managed venv.
+ToolR is a Python task runner that boots in milliseconds because the front-end is a Rust binary.
+Python only runs when you invoke a command, inside a per-repo `uv`-managed venv.
 
 | Tool runner          | `-h` steady-state | First run | Second run |
 | -------------------- | ----------------: | --------: | ---------: |
@@ -21,15 +22,21 @@ ToolR is a Python task runner that boots in milliseconds because the front-end i
 | duty                 |          166.4 ms |  188.5 ms |   252.4 ms |
 | python-tools-scripts |          252.2 ms |  340.3 ms |   189.0 ms |
 
-`<tool> -h`, 20 runs, steady-state = mean of last 18. Measured on Apple M3 Pro / macOS 26.5 / arm64. Reproduce locally with `toolr bench compare` (add `--markdown` for the table above).
+`<tool> -h`, 20 runs, steady-state = mean of last 18. Measured on Apple M3 Pro / macOS 26.5 / arm64.
+Reproduce locally with `toolr bench compare` (add `--markdown` for the table above).
 
 ## Why ToolR
 
-- **Sub-millisecond discovery.** The CLI is a Rust binary. `--help` and Tab completion read a cached static manifest; Python never boots for non-execute paths.
-- **No system-Python dependency.** Toolr resolves a per-repo Python venv via `uv` on first invocation. The host OS doesn't need Python at all to install toolr — it's a single static binary.
-- **Write Python, not framework boilerplate.** Drop a `tools/*.py` file with a `command_group` and a `@command` decorator. Type hints become CLI arguments; Google-style docstrings become `--help` text.
-- **First-class third-party command packages.** Plugins ship a static `toolr-manifest.json` inside the wheel. Discovery is a glob + JSON parse; no Python import to find them.
-- **Signed releases.** Every release archive ships with a SLSA build-provenance attestation. The install scripts verify it automatically when `gh` is on PATH.
+- **Sub-millisecond discovery.** The CLI is a Rust binary. `--help` and Tab completion read a cached
+  static manifest; Python never boots for non-execute paths.
+- **No system-Python dependency.** Toolr resolves a per-repo Python venv via `uv` on first
+  invocation. The host OS doesn't need Python at all to install toolr — it's a single static binary.
+- **Write Python, not framework boilerplate.** Drop a `tools/*.py` file with a `command_group` and a
+  `@command` decorator. Type hints become CLI arguments; Google-style docstrings become `--help` text.
+- **First-class third-party command packages.** Plugins ship a static `toolr-manifest.json` inside
+  the wheel. Discovery is a glob + JSON parse; no Python import to find them.
+- **Signed releases.** Every release archive ships with a SLSA build-provenance attestation. The
+  install scripts verify it automatically when `gh` is on PATH.
 
 ## Two wheels, two roles
 
@@ -38,7 +45,8 @@ ToolR is a Python task runner that boots in milliseconds because the front-end i
 | `toolr`    | The Rust CLI binary you run from the shell.  | On `$PATH`, installed once.     |
 | `toolr-py` | The Python runtime your `tools/*.py` import. | In your `tools/pyproject.toml`. |
 
-Most projects want both: the CLI installed globally, `toolr-py` declared in the per-repo `tools/pyproject.toml` so `from toolr import Context, command_group` works when your commands run.
+Most projects want both: the CLI installed globally, `toolr-py` declared in the per-repo
+`tools/pyproject.toml` so `from toolr import Context, command_group` works when your commands run.
 
 ## Install
 
@@ -51,7 +59,9 @@ mise plugin add toolr https://github.com/s0undt3ch/ToolR.git#installation/mise
 mise use --global toolr@latest
 ```
 
-For projects that already pin tool versions via `.mise.toml`, this is the most-natural fit — toolr's version becomes part of your project's reproducible tool set. See [docs/installation/mise/](https://toolr.readthedocs.io/latest/installation/mise/).
+For projects that already pin tool versions via `.mise.toml`, this is the most-natural fit —
+toolr's version becomes part of your project's reproducible tool set.
+See [docs/installation/mise/](https://toolr.readthedocs.io/latest/installation/mise/).
 
 ### pip
 
@@ -59,7 +69,11 @@ For projects that already pin tool versions via `.mise.toml`, this is the most-n
 pip install toolr   # Rust CLI binary
 ```
 
-This installs the `toolr` binary into whatever venv `pip` is pointing at. **Do not `pip install toolr-py`** into that same venv — `toolr-py` is the Python runtime your `tools/*.py` files import, and it belongs in the per-repo tools venv that `toolr project init` scaffolds for you (where it's declared in `tools/pyproject.toml` and materialised via `uv sync`). See "Two wheels, two roles" above for the split.
+This installs the `toolr` binary into whatever venv `pip` is pointing at.
+**Do not `pip install toolr-py`** into that same venv — `toolr-py` is the Python runtime your
+`tools/*.py` files import, and it belongs in the per-repo tools venv that `toolr project init`
+scaffolds for you (where it's declared in `tools/pyproject.toml` and materialised via `uv sync`).
+See "Two wheels, two roles" above for the split.
 
 ### curl | sh (Linux + macOS)
 
@@ -67,7 +81,8 @@ This installs the `toolr` binary into whatever venv `pip` is pointing at. **Do n
 curl -fsSL https://raw.githubusercontent.com/s0undt3ch/ToolR/main/installation/install.sh | sh
 ```
 
-Verifies the SLSA attestation when `gh` is on PATH. Pin a version with `sh -s -- --version X.Y.Z`. Custom prefix: `sh -s -- --prefix /opt/toolr/bin`.
+Verifies the SLSA attestation when `gh` is on PATH. Pin a version with `sh -s -- --version X.Y.Z`.
+Custom prefix: `sh -s -- --prefix /opt/toolr/bin`.
 
 ### PowerShell (Windows)
 
@@ -77,7 +92,10 @@ irm https://raw.githubusercontent.com/s0undt3ch/ToolR/main/installation/install.
 
 ### GitHub release archives
 
-Download `toolr-<version>-<target-triple>.tar.gz` (or `.zip` for Windows) from <https://github.com/s0undt3ch/ToolR/releases>, verify the `.sha256` sibling and the SLSA attestation, drop the binary on `$PATH`. Useful in locked-down environments that audit binaries before allowing them on a machine.
+Download `toolr-<version>-<target-triple>.tar.gz` (or `.zip` for Windows) from
+<https://github.com/s0undt3ch/ToolR/releases>, verify the `.sha256` sibling and the SLSA
+attestation, drop the binary on `$PATH`. Useful in locked-down environments that audit binaries
+before allowing them on a machine.
 
 ### Scaffold your repo
 
@@ -89,7 +107,8 @@ toolr example hello                 # run the generated example
 toolr self completion install bash  # or zsh / fish
 ```
 
-The full install matrix (per-OS notes, attestation flags, prefix overrides) lives in [docs/installation/](https://toolr.readthedocs.io/latest/installation/).
+The full install matrix (per-OS notes, attestation flags, prefix overrides) lives in
+[docs/installation/](https://toolr.readthedocs.io/latest/installation/).
 
 ## What you write
 
@@ -116,7 +135,8 @@ $ toolr example hello --name Pedro
 Hello, Pedro!
 ```
 
-`toolr project init` writes a richer four-command starter than this two-liner — open it and edit, or delete it and start from scratch.
+`toolr project init` writes a richer four-command starter than this two-liner — open it and edit,
+or delete it and start from scratch.
 
 ## Where to go next
 
@@ -128,7 +148,11 @@ Hello, Pedro!
 
 ## Project status
 
-ToolR is pre-1.0. The on-disk manifest is versioned (`schema_version` in `tools/.toolr-manifest.json`); the binary refuses to load a higher version than it understands. The public Python surface is `toolr.__all__`; anything not listed there is implementation detail. Backwards-incompatible changes will be explicit in the changelog (generated by `git-cliff` on release).
+ToolR is pre-1.0. The on-disk manifest is versioned (`schema_version` in
+`tools/.toolr-manifest.json`); the binary refuses to load a higher version than it understands. The
+public Python surface is `toolr.__all__`; anything not listed there is implementation detail.
+Backwards-incompatible changes will be explicit in the changelog (generated by `git-cliff` on
+release).
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,7 +59,8 @@ When using ToolR:
 
 ### Bug Bounty
 
-While we don't currently offer a formal bug bounty program, we deeply appreciate security researchers who help keep ToolR secure and will acknowledge your contributions.
+While we don't currently offer a formal bug bounty program, we deeply appreciate security
+researchers who help keep ToolR secure and will acknowledge your contributions.
 
 ## Contact
 

--- a/crates/toolr-py/python/toolr/_context.py
+++ b/crates/toolr-py/python/toolr/_context.py
@@ -264,7 +264,9 @@ class Context(Struct, frozen=True):
             else:
                 os.chdir(cwd)
 
-    def which(self, name: str, mode: int = os.F_OK | os.X_OK, path: str | None = None) -> str | None:
+    def which(
+        self, name: str, mode: int = os.F_OK | os.X_OK, path: str | None = None
+    ) -> str | None:
         """
         Find the path to an executable in the system PATH.
 

--- a/crates/toolr-py/python/toolr/_decorators.py
+++ b/crates/toolr-py/python/toolr/_decorators.py
@@ -108,7 +108,9 @@ class CommandGroup(Struct, frozen=True):
 
         def register(func: F) -> F:
             if name in self.__commands:
-                log.debug("Command '%s' already exists in group '%s', overriding", name, self.full_name)
+                log.debug(
+                    "Command '%s' already exists in group '%s', overriding", name, self.full_name
+                )
             self.__commands[name] = func
             return func
 

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -289,7 +289,9 @@ def _dec_hook(target_type: type, obj: Any) -> Any:  # noqa: PLR0911
     raise TypeError(msg)
 
 
-def _coerce_args(target: Callable[..., Any], raw: dict[str, Any]) -> tuple[list[Any], dict[str, Any]]:
+def _coerce_args(
+    target: Callable[..., Any], raw: dict[str, Any]
+) -> tuple[list[Any], dict[str, Any]]:
     """Coerce `raw` against `target`'s actual type hints.
 
     Returns a ``(positional_args, keyword_args)`` pair. Positional args come
@@ -324,7 +326,10 @@ def _coerce_args(target: Callable[..., Any], raw: dict[str, Any]) -> tuple[list[
                 raise SpecError(msg)
             if hint is not None:
                 try:
-                    positional = [msgspec.convert(elem, type=hint, strict=False, dec_hook=_dec_hook) for elem in value]
+                    positional = [
+                        msgspec.convert(elem, type=hint, strict=False, dec_hook=_dec_hook)
+                        for elem in value
+                    ]
                 except msgspec.ValidationError as exc:
                     msg = f"toolr runner: invalid value for `{name}`: {exc}"
                     raise SpecError(msg) from exc

--- a/crates/toolr-py/python/toolr/testing.py
+++ b/crates/toolr-py/python/toolr/testing.py
@@ -60,7 +60,10 @@ class CommandsTester:
 
     @command_group_patcher.default
     def _default_command_group_patcher(self) -> _patch:
-        return patch("toolr._decorators._get_command_group_storage", return_value=self.command_group_collector)
+        return patch(
+            "toolr._decorators._get_command_group_storage",
+            return_value=self.command_group_collector,
+        )
 
     def collected_command_groups(self) -> dict[str, object]:
         """
@@ -94,7 +97,9 @@ class CommandsTester:
         # entries from the saved sys_path; drop anything that points
         # back at the host repo (which would shadow the fixture's
         # ``tools/`` tree with the repo's own).
-        site_pkg_entries = [p for p in self.sys_path if "site-packages" in p or "dist-packages" in p]
+        site_pkg_entries = [
+            p for p in self.sys_path if "site-packages" in p or "dist-packages" in p
+        ]
         sys.path[:] = [str(self.search_path), *site_pkg_entries]
         return self
 

--- a/crates/toolr-py/python/toolr/utils/_signature.py
+++ b/crates/toolr-py/python/toolr/utils/_signature.py
@@ -582,9 +582,8 @@ class EnumAction(Action):
         values: Any,
         option_string: str | None = None,  # noqa: ARG002
     ) -> None:
-        err_msg = (
-            f"Invalid choice: '{values}'. Available choices are {', '.join(repr(c) for c in self.choices_mapping)}."
-        )
+        choices_repr = ", ".join(repr(c) for c in self.choices_mapping)
+        err_msg = f"Invalid choice: '{values}'. Available choices are {choices_repr}."
         if isinstance(values, Enum):
             if values in self.choices_mapping.values():
                 setattr(namespace, self.dest, values)
@@ -642,7 +641,11 @@ def _parse_parameter(  # noqa: PLR0915
         klass = KwArg
 
     log.debug(
-        "Parsing parameter %r, positional=%s, annotation=%s, default=%s", param_name, positional, annotation, default
+        "Parsing parameter %r, positional=%s, annotation=%s, default=%s",
+        param_name,
+        positional,
+        annotation,
+        default,
     )
 
     # Extract Argument config from Annotated if present
@@ -661,7 +664,10 @@ def _parse_parameter(  # noqa: PLR0915
         # Look for ArgumentSpec in metadata
         for metadata in args[1:]:
             log.debug("Checking metadata: %s, type=%s", metadata, type(metadata))
-            log.debug("isinstance(metadata, ArgumentAnnotation): %s", isinstance(metadata, ArgumentAnnotation))
+            log.debug(
+                "isinstance(metadata, ArgumentAnnotation): %s",
+                isinstance(metadata, ArgumentAnnotation),
+            )
             if isinstance(metadata, ArgumentAnnotation):
                 arg_config = metadata
                 log.debug("Found ArgumentAnnotation config: %s", arg_config)
@@ -707,7 +713,9 @@ def _parse_parameter(  # noqa: PLR0915
             nargs = arg_config.nargs
         if arg_config.group is not None:
             if positional:
-                err_msg = f"Positional parameter {param_name!r} cannot be in a mutually exclusive group."
+                err_msg = (
+                    f"Positional parameter {param_name!r} cannot be in a mutually exclusive group."
+                )
                 raise SignatureParameterError(err_msg)
             group = arg_config.group
 
@@ -737,7 +745,8 @@ def _parse_parameter(  # noqa: PLR0915
 
                 if not isinstance(choice, actual_type):
                     err_msg = (
-                        f"{klass.__name__} {param_name!r} has choices and they are not of the same type as the enum."
+                        f"{klass.__name__} {param_name!r} has choices and "
+                        "they are not of the same type as the enum."
                     )
                     raise SignatureParameterError(err_msg)
         choices_mapping = {choice.name.lower(): choice for choice in choices}
@@ -859,7 +868,9 @@ def detect_dispatch_parameter(func: Callable[..., Any]) -> str | None:
         if annotation is not DispatchCommand:
             continue
         if param.kind != inspect.Parameter.KEYWORD_ONLY:
-            msg = f"DispatchCommand parameter {name!r} on {func.__qualname__!r} must be keyword-only"
+            msg = (
+                f"DispatchCommand parameter {name!r} on {func.__qualname__!r} must be keyword-only"
+            )
             raise DispatcherDetectionError(msg)
         found_kw.append(name)
 

--- a/crates/toolr-py/python/toolr/utils/command.py
+++ b/crates/toolr-py/python/toolr/utils/command.py
@@ -166,11 +166,15 @@ def run(  # noqa: PLR0915
         if text is True:
             return cast(
                 "CommandResult[str]",
-                CommandResult(args=command_args, stdout=stdout_file, stderr=stderr_file, returncode=returncode),
+                CommandResult(
+                    args=command_args, stdout=stdout_file, stderr=stderr_file, returncode=returncode
+                ),
             )
         return cast(
             "CommandResult[bytes]",
-            CommandResult(args=command_args, stdout=stdout_file, stderr=stderr_file, returncode=returncode),
+            CommandResult(
+                args=command_args, stdout=stdout_file, stderr=stderr_file, returncode=returncode
+            ),
         )
 
     except Exception as exc:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,7 +59,12 @@ Operations on the current repo's `tools/` directory.
 
 Scaffold `tools/` in the current directory.
 
-**Usage:** `toolr project init [--force] [--no-sync] [--venv-location {cache,in-tree}] [--no-example] [--python <version>] [--quiet]`
+**Usage:**
+
+```text
+toolr project init [--force] [--no-sync] [--venv-location {cache,in-tree}]
+                   [--no-example] [--python <version>] [--quiet]
+```
 
 **Flags:**
 

--- a/docs/writing-commands/testing.md
+++ b/docs/writing-commands/testing.md
@@ -1,18 +1,26 @@
 # Testing your commands
 
-ToolR ships a small testing helper in the `toolr-py` wheel — `toolr.testing.CommandsTester` — that lets you write pytest assertions against your `tools/*.py` discovery without invoking the `toolr` binary as a subprocess.
+ToolR ships a small testing helper in the `toolr-py` wheel — `toolr.testing.CommandsTester` —
+that lets you write pytest assertions against your `tools/*.py` discovery without invoking the
+`toolr` binary as a subprocess.
 
-It's designed for the case where you want to test *your own* command modules: "does my decorator land in the registry?", "do my command groups collect the right commands?", "does my dispatcher pick up the right children?". For end-to-end behaviour (Tab completion, `--help` output, real subprocess execution) you'll still want to drive the binary directly.
+It's designed for the case where you want to test *your own* command modules: "does my decorator
+land in the registry?", "do my command groups collect the right commands?", "does my dispatcher
+pick up the right children?". For end-to-end behaviour (Tab completion, `--help` output, real
+subprocess execution) you'll still want to drive the binary directly.
 
 ## What it does
 
 `CommandsTester(search_path=tmp_path)` is a context manager that:
 
-1. Saves and replaces `sys.path` so only `search_path` and the host's `site-packages` are visible — your fixture's `tools/` tree wins.
+1. Saves and replaces `sys.path` so only `search_path` and the host's `site-packages` are visible
+   — your fixture's `tools/` tree wins.
 2. Patches `toolr._decorators._get_command_group_storage` with a fresh `dict` so the test gets an isolated registry.
 3. Restores everything on exit (`sys.path`, `sys.modules`, `cwd`).
 
-Calling `.discover()` inside the context runs the same `tools/`-import pass that `python -m toolr._introspect` runs for the Rust binary's dynamic manifest layer. After it returns, `.collected_command_groups()` gives you a `{full_name: CommandGroup}` dict you can assert against.
+Calling `.discover()` inside the context runs the same `tools/`-import pass that
+`python -m toolr._introspect` runs for the Rust binary's dynamic manifest layer. After it returns,
+`.collected_command_groups()` gives you a `{full_name: CommandGroup}` dict you can assert against.
 
 ## Usage
 
@@ -63,7 +71,8 @@ def commands_tester(tmp_path: Path) -> Iterator[CommandsTester]:
 
 ## What you can assert
 
-`collected_command_groups()` returns a dict keyed by the dotted full name (e.g. `tools.ci`, `tools.docker.image`). Each value is a `toolr._decorators.CommandGroup` instance, which exposes:
+`collected_command_groups()` returns a dict keyed by the dotted full name (e.g. `tools.ci`,
+`tools.docker.image`). Each value is a `toolr._decorators.CommandGroup` instance, which exposes:
 
 - `name`, `title`, `description`, `parent` — what you passed to `command_group(...)`.
 - `full_name` — same key the dict uses.
@@ -98,10 +107,16 @@ assert {"helm-diff-pr-comment", "snippet-checker"} <= set(
 - Spawn `toolr` as a subprocess.
 - Run the static AST parser (which is the *Rust* path; this helper drives only the *dynamic* / runtime-import path).
 
-If you need any of those, drive the `toolr` binary directly via `subprocess` (`shutil.which("toolr")` works under `mise` / `pip install toolr` / the install scripts), or use `assert_cmd` from a Rust integration test.
+If you need any of those, drive the `toolr` binary directly via `subprocess`
+(`shutil.which("toolr")` works under `mise` / `pip install toolr` / the install scripts), or use
+`assert_cmd` from a Rust integration test.
 
 ## Stability
 
-`toolr.testing.CommandsTester` is part of toolr-py's public API and is tested in toolr's own suite. Its surface — the constructor, the context-manager protocol, `.discover()`, and `.collected_command_groups()` — is stable across the pre-1.0 series; any change is called out in the changelog.
+`toolr.testing.CommandsTester` is part of toolr-py's public API and is tested in toolr's own suite.
+Its surface — the constructor, the context-manager protocol, `.discover()`, and
+`.collected_command_groups()` — is stable across the pre-1.0 series; any change is called out in
+the changelog.
 
-Internal attributes (`sys_path`, `sys_modules`, `command_group_patcher`, `cwd`) are implementation detail and may change without notice.
+Internal attributes (`sys_path`, `sys_modules`, `command_group_patcher`, `cwd`) are implementation
+detail and may change without notice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,13 @@ tools = [
 ]
 
 [tool.ruff]
-line-length = 120
+# Formatter target. `ruff format` wraps to 100 columns; the
+# pycodestyle override below raises the E501 lint threshold to
+# 120 so the formatter can land at 100 without lint failures and
+# longer-but-still-readable lines aren't rejected outright. See
+# `.editorconfig` for the matching editor ruler and CONTRIBUTING
+# for the policy summary.
+line-length = 100
 show-fixes = true
 target-version = "py311"
 respect-gitignore = true
@@ -149,6 +155,13 @@ ignore = [
   "INP001",   # File `xyz` is part of an implicit namespace package. Add an `__init__.py`.
   "TRY003",   # Avoid specifying long messages outside the exception class
 ]
+
+[tool.ruff.lint.pycodestyle]
+# Hard ceiling for E501. `tool.ruff.line-length` (the formatter
+# target) stays at 100; this raises the lint threshold to 120 so
+# lines the formatter can't reduce (long string literals, error
+# messages, etc.) still pass lint up to 120 columns.
+max-line-length = 120
 
 [tool.ruff.lint.pydocstyle]
 # Use Google-style docstrings.

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,8 +4,12 @@ Design records for toolr — both live work and historical post-mortems.
 
 ## Where work lives
 
-- **Top level (`specs/<date>-<topic>-design.md`)** — active design work and proposed-but-not-shipped features. Each design pairs with a `<date>-<topic>-plan.md` implementation plan once it leaves brainstorming.
-- **`specs/archive/<year>/`** — shipped or abandoned designs. Archived files are immutable post-mortem records; do not edit them in place. If a shipped design needs revising, write a new design that supersedes it.
+- **Top level (`specs/<date>-<topic>-design.md`)** — active design work and proposed-but-not-shipped
+  features. Each design pairs with a `<date>-<topic>-plan.md` implementation plan once it leaves
+  brainstorming.
+- **`specs/archive/<year>/`** — shipped or abandoned designs. Archived files are immutable
+  post-mortem records; do not edit them in place. If a shipped design needs revising, write a new
+  design that supersedes it.
 
 ## How to start a new design
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,9 @@ def pytest_configure(config: pytest.Config) -> None:
         entries = existing.split(os.pathsep) if existing else []
         if str(_COVERAGE_SUPPORT_DIR) not in entries:
             os.environ["PYTHONPATH"] = (
-                str(_COVERAGE_SUPPORT_DIR) + os.pathsep + existing if existing else str(_COVERAGE_SUPPORT_DIR)
+                str(_COVERAGE_SUPPORT_DIR) + os.pathsep + existing
+                if existing
+                else str(_COVERAGE_SUPPORT_DIR)
             )
     if _COVERAGERC.is_file():
         os.environ.setdefault("COVERAGE_PROCESS_START", str(_COVERAGERC))

--- a/tests/context/test_prompt.py
+++ b/tests/context/test_prompt.py
@@ -30,7 +30,11 @@ def test_prompt_string_default(ctx: Context, capfd: pytest.CaptureFixture[str]):
     ],
 )
 def test_prompt_string_with_choices(
-    ctx: Context, capfd: pytest.CaptureFixture[str], stream_input: str, expected_value: str, case_sensitive: bool
+    ctx: Context,
+    capfd: pytest.CaptureFixture[str],
+    stream_input: str,
+    expected_value: str,
+    case_sensitive: bool,
 ):
     """Test prompt with string type and choices."""
     result = ctx._prompt(

--- a/tests/decorators/test_decorators_unit.py
+++ b/tests/decorators/test_decorators_unit.py
@@ -179,7 +179,9 @@ def test_command_group_dotted_name_overrides_explicit_parent_with_warning(
 ):
     del clean_registry
     with caplog.at_level(logging.WARNING, logger="toolr._decorators"):
-        g = command_group("docker.diff", "Docker Diff", description="Docker diff group", parent="wrong")
+        g = command_group(
+            "docker.diff", "Docker Diff", description="Docker diff group", parent="wrong"
+        )
     assert g.parent == "tools.docker"
     assert any("dotted path" in r.message for r in caplog.records)
 

--- a/tests/distribution/test_cross_wheel.py
+++ b/tests/distribution/test_cross_wheel.py
@@ -77,12 +77,16 @@ def test_install_both_wheels_and_run_subcommand(
     # filename uses the PEP 440 dot-form, the binary may emit either,
     # so compare on the normalized PEP 440 form.
     binary_version = _version_from_wheel(toolr_wheel)
-    assert binary_version.replace(".dev", "-dev") in result.stdout or binary_version in result.stdout, (
-        f"unexpected --version output: {result.stdout!r} (expected to contain {binary_version!r})"
-    )
+    assert (
+        binary_version.replace(".dev", "-dev") in result.stdout or binary_version in result.stdout
+    ), f"unexpected --version output: {result.stdout!r} (expected to contain {binary_version!r})"
 
     result = subprocess.run(  # noqa: S603
-        [str(python), "-c", "import toolr; import toolr.utils._rust_utils; print(toolr.__version__)"],
+        [
+            str(python),
+            "-c",
+            "import toolr; import toolr.utils._rust_utils; print(toolr.__version__)",
+        ],
         capture_output=True,
         text=True,
         check=True,

--- a/tests/distribution/test_example_plugin_contract.py
+++ b/tests/distribution/test_example_plugin_contract.py
@@ -104,7 +104,9 @@ def test_example_plugin_wheel_ships_manifest_and_commands(
     assert result.returncode == 0, (
         f"toolr --help failed: returncode={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
-    assert "third-party" in result.stdout, f"expected `third-party` group in --help; got:\n{result.stdout}"
+    assert "third-party" in result.stdout, (
+        f"expected `third-party` group in --help; got:\n{result.stdout}"
+    )
     assert "utils" in result.stdout, f"expected `utils` group in --help; got:\n{result.stdout}"
 
     # ---- Run one of the example commands end-to-end. This proves the

--- a/tests/distribution/test_toolr_py_wheel.py
+++ b/tests/distribution/test_toolr_py_wheel.py
@@ -33,5 +33,9 @@ def test_toolr_py_wheel_contains_python_source(toolr_py_wheel: Path) -> None:
 
 def test_toolr_py_wheel_ships_dynlib(toolr_py_wheel: Path) -> None:
     names = wheel_namelist(toolr_py_wheel)
-    dynlibs = [n for n in names if n.startswith("toolr/utils/_rust_utils.") and n.endswith((".so", ".pyd", ".dylib"))]
+    dynlibs = [
+        n
+        for n in names
+        if n.startswith("toolr/utils/_rust_utils.") and n.endswith((".so", ".pyd", ".dylib"))
+    ]
     assert dynlibs, f"toolr-py wheel missing _rust_utils dynlib, got: {names}"

--- a/tests/distribution/test_toolr_wheel.py
+++ b/tests/distribution/test_toolr_wheel.py
@@ -10,7 +10,9 @@ from tests.distribution.conftest import wheel_namelist
 def test_toolr_wheel_ships_binary(toolr_wheel: Path) -> None:
     names = wheel_namelist(toolr_wheel)
     binary_entries = [n for n in names if "/scripts/toolr" in n]
-    assert binary_entries, f"binary wheel must ship `toolr` under <wheel>.data/scripts/, got: {names}"
+    assert binary_entries, (
+        f"binary wheel must ship `toolr` under <wheel>.data/scripts/, got: {names}"
+    )
 
 
 def test_toolr_wheel_has_no_python_source(toolr_wheel: Path) -> None:
@@ -27,4 +29,6 @@ def test_toolr_wheel_has_no_dynlib(toolr_wheel: Path) -> None:
 
 def test_toolr_wheel_filename_is_universal_python(toolr_wheel: Path) -> None:
     """Binary wheels don't link Python; tag should be py3-none-*."""
-    assert "py3-none-" in toolr_wheel.name, f"binary wheel filename should carry py3-none- tag, got: {toolr_wheel.name}"
+    assert "py3-none-" in toolr_wheel.name, (
+        f"binary wheel filename should carry py3-none- tag, got: {toolr_wheel.name}"
+    )

--- a/tests/introspect/test_introspect_unit.py
+++ b/tests/introspect/test_introspect_unit.py
@@ -70,7 +70,9 @@ def isolated_sys_path() -> Iterator[None]:
     """
     saved_path = list(sys.path)
     saved_modules = {
-        name: sys.modules[name] for name in list(sys.modules) if name == "tools" or name.startswith("tools.")
+        name: sys.modules[name]
+        for name in list(sys.modules)
+        if name == "tools" or name.startswith("tools.")
     }
     for name in saved_modules:
         del sys.modules[name]
@@ -127,7 +129,9 @@ def test_ensure_tools_on_syspath_noop_when_path_is_empty(isolated_sys_path: None
     assert sys.path == before
 
 
-def test_ensure_tools_on_syspath_inserts_parent_of_tools_root(tmp_path: Path, isolated_sys_path: None) -> None:
+def test_ensure_tools_on_syspath_inserts_parent_of_tools_root(
+    tmp_path: Path, isolated_sys_path: None
+) -> None:
     del isolated_sys_path
     tools_root = tmp_path / "tools"
     tools_root.mkdir()

--- a/tests/registry/test_command_group_errors.py
+++ b/tests/registry/test_command_group_errors.py
@@ -9,20 +9,26 @@ from toolr import command_group
 
 def test_command_group_without_description_or_docstring():
     """Test command_group error when neither description nor docstring provided."""
-    with pytest.raises(ValueError, match="You must at least pass either the 'docstring' or 'description' argument"):
+    with pytest.raises(
+        ValueError, match="You must at least pass either the 'docstring' or 'description' argument"
+    ):
         command_group("test", "Test Group")
 
 
 def test_command_group_with_both_docstring_and_description():
     """Test command_group error when both docstring and description provided."""
-    with pytest.raises(ValueError, match="You can't pass both docstring and description or long_description"):
+    with pytest.raises(
+        ValueError, match="You can't pass both docstring and description or long_description"
+    ):
         command_group("test", "Test Group", description="Description", docstring="Docstring")
 
 
 def test_command_group_with_docstring_parsing():
     """Test command_group with docstring parsing."""
     group = command_group(
-        "docstring_test", "Docstring Test", docstring="Short description.\n\nLong description with more details."
+        "docstring_test",
+        "Docstring Test",
+        docstring="Short description.\n\nLong description with more details.",
     )
 
     assert group.description == "Short description."

--- a/tests/registry/test_integration.py
+++ b/tests/registry/test_integration.py
@@ -24,7 +24,9 @@ def test_complete_workflow_example(commands_tester):
 
     # Create nested command groups
     build_group = docker_group.command_group("build", "Build Tools", "Docker image building")
-    compose_group = docker_group.command_group("compose", "Compose Tools", "Docker Compose operations")
+    compose_group = docker_group.command_group(
+        "compose", "Compose Tools", "Docker Compose operations"
+    )
 
     # Add commands to build group
     @build_group.command("image")
@@ -49,7 +51,9 @@ def test_complete_workflow_example(commands_tester):
         return "Stopping services"
 
     # Create deeply nested group
-    advanced_group = build_group.command_group("advanced", "Advanced Build", "Advanced build features")
+    advanced_group = build_group.command_group(
+        "advanced", "Advanced Build", "Advanced build features"
+    )
 
     @advanced_group.command("multi-stage")
     def multi_stage_build(ctx: Context):
@@ -140,7 +144,13 @@ def test_real_world_tool_structure(commands_tester):
 
     # Verify the complex structure
     command_groups = commands_tester.collected_command_groups()
-    expected_groups = ["tools.dev", "tools.dev.test", "tools.dev.test.coverage", "tools.ci", "tools.ci.deploy"]
+    expected_groups = [
+        "tools.dev",
+        "tools.dev.test",
+        "tools.dev.test.coverage",
+        "tools.ci",
+        "tools.ci.deploy",
+    ]
 
     for group_name in expected_groups:
         assert group_name in command_groups

--- a/tests/runner/test_runner_coverage.py
+++ b/tests/runner/test_runner_coverage.py
@@ -130,7 +130,9 @@ def test_load_spec_invalid_json_raises_spec_error(make_spec_file: Callable[..., 
         load_spec(spec_path)
 
 
-def test_load_spec_type_mismatch_raises_schema_validation(tmp_path: Path, make_spec_file: Callable[..., Path]) -> None:
+def test_load_spec_type_mismatch_raises_schema_validation(
+    tmp_path: Path, make_spec_file: Callable[..., Path]
+) -> None:
     # `context.verbosity` is required and typed `str`; an int trips msgspec's
     # struct decoder, which surfaces as `msgspec.ValidationError` (the
     # subclass of `DecodeError`). The runner reports it under the more
@@ -276,7 +278,11 @@ def test_unwrap_annotated_returns_bare_type_untouched() -> None:
         (dt.datetime, "2026-01-02T03:04:05", dt.datetime(2026, 1, 2, 3, 4, 5)),  # noqa: DTZ001
         (dt.date, "2026-01-02", dt.date(2026, 1, 2)),
         (dt.time, "03:04:05", dt.time(3, 4, 5)),
-        (uuid.UUID, "12345678-1234-5678-1234-567812345678", uuid.UUID("12345678-1234-5678-1234-567812345678")),
+        (
+            uuid.UUID,
+            "12345678-1234-5678-1234-567812345678",
+            uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        ),
         (ipaddress.IPv4Address, "10.0.0.1", ipaddress.IPv4Address("10.0.0.1")),
         (ipaddress.IPv6Address, "2001:db8::1", ipaddress.IPv6Address("2001:db8::1")),
         (Version, "1.2.3", Version("1.2.3")),
@@ -459,7 +465,9 @@ def test_coerce_args_skips_fill_in_for_non_optional_missing_params() -> None:
 # --------------------------------------------------------------------------
 
 
-def test_run_returns_zero_on_systemexit_none(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_run_returns_zero_on_systemexit_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     captured: dict[str, object] = {}
 
     def fake_target(ctx, **_kw):  # pragma: no cover - executed via run()
@@ -494,7 +502,9 @@ def test_run_returns_2_for_spec_error_from_coercion(
 ) -> None:
     # Force `_coerce_args` to raise `SpecError` via a target that takes a
     # Literal-typed kwarg the spec value can't satisfy.
-    def fake_target(ctx, level: Literal["debug", "info"]) -> None:  # pragma: no cover - run via runner
+    def fake_target(
+        ctx, level: Literal["debug", "info"]
+    ) -> None:  # pragma: no cover - run via runner
         pass
 
     monkeypatch.setattr("toolr._runner._import_target", lambda _spec: fake_target)
@@ -511,7 +521,9 @@ def test_run_returns_0_on_clean_completion(monkeypatch: pytest.MonkeyPatch, tmp_
     assert run(_runner_spec(repo_root=tmp_path)) == 0
 
 
-def test_run_returns_integer_exit_code_from_systemexit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_run_returns_integer_exit_code_from_systemexit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     def fake_target(ctx, **_kw) -> None:
         raise SystemExit(7)
 

--- a/tests/sources/test_e2e.py
+++ b/tests/sources/test_e2e.py
@@ -138,7 +138,9 @@ def test_e2e_dispatch_through_argparse_scanner(
     assert "primary" in captured["argv"]
 
 
-def _make_project(tmp_path: Path, name: str, tools_py: str, pyproject_toml: str, command_files: dict[str, str]) -> Path:
+def _make_project(
+    tmp_path: Path, name: str, tools_py: str, pyproject_toml: str, command_files: dict[str, str]
+) -> Path:
     project = tmp_path / name
     project.mkdir()
     tools = project / "tools"
@@ -282,7 +284,9 @@ def test_e2e_collision_across_sources_fails_build(tmp_path: Path, toolr_bin: Pat
         ).strip()
         + "\n"
     )
-    cmd_body = 'def add_arguments(self, parser):\n    parser.add_argument("--flag", action="store_true")\n'
+    cmd_body = (
+        'def add_arguments(self, parser):\n    parser.add_argument("--flag", action="store_true")\n'
+    )
     project = _make_project(
         tmp_path,
         "collision",

--- a/tests/utils/command/conftest.py
+++ b/tests/utils/command/conftest.py
@@ -47,7 +47,11 @@ def cat_command():
 
     def _cat_cmd(file_path):
         # Use Python's open() to reliably read files on all platforms
-        return [sys.executable, "-c", f"with open(r'{file_path}', 'r') as f: print(f.read(), end='')"]
+        return [
+            sys.executable,
+            "-c",
+            f"with open(r'{file_path}', 'r') as f: print(f.read(), end='')",
+        ]
 
     return _cat_cmd
 

--- a/tests/utils/command/test_command.py
+++ b/tests/utils/command/test_command.py
@@ -189,7 +189,9 @@ def test_stream_output_both_fd_required(echo_command):
     """Test that sys_stdout_fd and sys_stderr_fd must both be provided"""
     # Directly access the low-level implementation to test the requirement
 
-    with pytest.raises(CommandError, match="Both sys_stdout_fd and sys_stderr_fd must be provided together"):
+    with pytest.raises(
+        CommandError, match="Both sys_stdout_fd and sys_stderr_fd must be provided together"
+    ):
         # Mock case where only stdout fd is provided
         run_command_impl(
             echo_command("test"),
@@ -197,7 +199,9 @@ def test_stream_output_both_fd_required(echo_command):
             sys_stderr_fd=None,
         )
 
-    with pytest.raises(CommandError, match="Both sys_stdout_fd and sys_stderr_fd must be provided together"):
+    with pytest.raises(
+        CommandError, match="Both sys_stdout_fd and sys_stderr_fd must be provided together"
+    ):
         # Mock case where only stderr fd is provided
         run_command_impl(
             echo_command("test"),

--- a/tests/utils/docstrings/test_advanced_features.py
+++ b/tests/utils/docstrings/test_advanced_features.py
@@ -258,7 +258,9 @@ def test_large_docstring_complete():  # noqa: PLR0915
     result = Docstring.parse(LONG_DOCSTRING)
 
     # Check short description
-    assert result.short_description == "Generate comprehensive test data for Stripe sandbox accounts."
+    assert (
+        result.short_description == "Generate comprehensive test data for Stripe sandbox accounts."
+    )
 
     # Check long description
     long_desc = result.long_description
@@ -293,7 +295,10 @@ def test_large_docstring_complete():  # noqa: PLR0915
     # Check examples - Rust parser doesn't parse examples the same way
     examples = result.examples
     assert len(examples) == 3
-    assert examples[0].description == "Basic usage - creates 5 products, 20 customers, 1 subscription each:"
+    assert (
+        examples[0].description
+        == "Basic usage - creates 5 products, 20 customers, 1 subscription each:"
+    )
     assert examples[0].snippet is not None
     assert examples[1].description == "Custom quantities:"
     assert examples[1].snippet is not None

--- a/tests/utils/docstrings/test_fuzzing.py
+++ b/tests/utils/docstrings/test_fuzzing.py
@@ -21,7 +21,9 @@ def docstring_content(draw):
     # Start with basic text that could be a docstring
     content = draw(
         text(
-            alphabet=st.characters(whitelist_categories=("Lu", "Ll", "N", "Pc", "Pd", "Ps", "Pe", "Po", "Sm", "Zs")),
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "N", "Pc", "Pd", "Ps", "Pe", "Po", "Sm", "Zs")
+            ),
             min_size=0,
             max_size=1000,
         )
@@ -127,7 +129,9 @@ def test_fuzz_malformed_docstrings(content: str):
         # Some malformed input might legitimately cause parsing errors
         # but it should be well-defined exceptions, not crashes
         if not isinstance(e, EXPECTED_EXCEPTIONS):
-            pytest.fail(f"Unexpected exception type on malformed input: {content!r}\nError: {type(e).__name__}: {e}")
+            pytest.fail(
+                f"Unexpected exception type on malformed input: {content!r}\nError: {type(e).__name__}: {e}"
+            )
 
 
 @given(content=text(min_size=0, max_size=10000), repeat=integers(min_value=1, max_value=10))

--- a/tests/utils/logs/test_duplicate_times_formatter.py
+++ b/tests/utils/logs/test_duplicate_times_formatter.py
@@ -13,7 +13,13 @@ def test_format_time_duplicate():
 
     # First call should set the timestamp
     record = logging.LogRecord(
-        name="test", level=logging.INFO, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
     formatted_time = formatter.formatTime(record)
     assert formatted_time != " " * len(formatted_time)
@@ -28,7 +34,13 @@ def test_format_single_line():
     formatter = DuplicateTimesFormatter(fmt="%(asctime)s%(message)s", datefmt="[%H:%M:%S] ")
 
     record = logging.LogRecord(
-        name="test", level=logging.INFO, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
 
     result = formatter.format(record)
@@ -40,7 +52,13 @@ def test_format_multiline_with_lf():
     formatter = DuplicateTimesFormatter(fmt="%(asctime)s%(message)s", datefmt="[%H:%M:%S] ")
 
     record = logging.LogRecord(
-        name="test", level=logging.INFO, pathname="", lineno=0, msg="line1\nline2\nline3", args=(), exc_info=None
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="line1\nline2\nline3",
+        args=(),
+        exc_info=None,
     )
 
     result = formatter.format(record)
@@ -58,7 +76,13 @@ def test_format_multiline_with_crlf():
     formatter = DuplicateTimesFormatter(fmt="%(asctime)s%(message)s", datefmt="[%H:%M:%S] ")
 
     record = logging.LogRecord(
-        name="test", level=logging.INFO, pathname="", lineno=0, msg="line1\r\nline2\r\nline3", args=(), exc_info=None
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="line1\r\nline2\r\nline3",
+        args=(),
+        exc_info=None,
     )
 
     result = formatter.format(record)

--- a/tests/utils/logs/test_level_filter.py
+++ b/tests/utils/logs/test_level_filter.py
@@ -13,13 +13,25 @@ def test_level_filter_with_level():
 
     # Create a record with INFO level
     record = logging.LogRecord(
-        name="test", level=logging.INFO, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
     assert filter_obj.filter(record) is True
 
     # Create a record with DEBUG level
     record = logging.LogRecord(
-        name="test", level=logging.DEBUG, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.DEBUG,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
     assert filter_obj.filter(record) is False
 
@@ -30,13 +42,25 @@ def test_level_filter_with_not_levels():
 
     # Create a record with ERROR level
     record = logging.LogRecord(
-        name="test", level=logging.ERROR, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.ERROR,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
     assert filter_obj.filter(record) is False
 
     # Create a record with INFO level
     record = logging.LogRecord(
-        name="test", level=logging.INFO, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
     assert filter_obj.filter(record) is True
 
@@ -47,13 +71,25 @@ def test_level_filter_with_both_level_and_not_levels():
 
     # Create a record with INFO level
     record = logging.LogRecord(
-        name="test", level=logging.INFO, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
     assert filter_obj.filter(record) is True
 
     # Create a record with WARNING level
     record = logging.LogRecord(
-        name="test", level=logging.WARNING, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.WARNING,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
     assert filter_obj.filter(record) is False
 
@@ -64,11 +100,23 @@ def test_level_filter_with_no_constraints():
 
     # Any record should pass
     record = logging.LogRecord(
-        name="test", level=logging.DEBUG, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.DEBUG,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
     assert filter_obj.filter(record) is True
 
     record = logging.LogRecord(
-        name="test", level=logging.WARNING, pathname="", lineno=0, msg="test message", args=(), exc_info=None
+        name="test",
+        level=logging.WARNING,
+        pathname="",
+        lineno=0,
+        msg="test message",
+        args=(),
+        exc_info=None,
     )
     assert filter_obj.filter(record) is True

--- a/tests/utils/logs/test_setup.py
+++ b/tests/utils/logs/test_setup.py
@@ -38,7 +38,10 @@ def test_setup_logging_with_timestamps():
     """Test setup_logging with timestamps enabled."""
     mock_handlers = [patch("logging.StreamHandler").start() for _ in range(3)]
 
-    with patch("logging.root.handlers", mock_handlers), patch("logging.root.setLevel") as mock_set_level:
+    with (
+        patch("logging.root.handlers", mock_handlers),
+        patch("logging.root.setLevel") as mock_set_level,
+    ):
         setup_logging(verbosity=ConsoleVerbosity.NORMAL, timestamps=True)
 
         # Should set level
@@ -53,7 +56,10 @@ def test_setup_logging_without_timestamps():
     """Test setup_logging with timestamps disabled."""
     mock_handlers = [patch("logging.StreamHandler").start() for _ in range(3)]
 
-    with patch("logging.root.handlers", mock_handlers), patch("logging.root.setLevel") as mock_set_level:
+    with (
+        patch("logging.root.handlers", mock_handlers),
+        patch("logging.root.setLevel") as mock_set_level,
+    ):
         setup_logging(verbosity=ConsoleVerbosity.NORMAL, timestamps=False)
 
         # Should set level
@@ -68,7 +74,10 @@ def test_setup_logging_default_timestamps():
     """Test setup_logging with default timestamps parameter."""
     mock_handlers = [patch("logging.StreamHandler").start() for _ in range(3)]
 
-    with patch("logging.root.handlers", mock_handlers), patch("logging.root.setLevel") as mock_set_level:
+    with (
+        patch("logging.root.handlers", mock_handlers),
+        patch("logging.root.setLevel") as mock_set_level,
+    ):
         setup_logging(verbosity=ConsoleVerbosity.NORMAL)
 
         # Should set level
@@ -83,7 +92,10 @@ def test_setup_logging_handles_all_handlers():
     """Test that setup_logging affects all root handlers."""
     mock_handlers = [patch("logging.StreamHandler").start() for _ in range(5)]
 
-    with patch("logging.root.handlers", mock_handlers), patch("logging.root.setLevel") as mock_set_level:
+    with (
+        patch("logging.root.handlers", mock_handlers),
+        patch("logging.root.setLevel") as mock_set_level,
+    ):
         setup_logging(verbosity=ConsoleVerbosity.NORMAL, timestamps=True)
 
         # Should set level
@@ -105,7 +117,10 @@ def test_setup_logging_formatter_override():
     """Test that setup_logging properly overrides previous formatter settings."""
     mock_handlers = [patch("logging.StreamHandler").start() for _ in range(3)]
 
-    with patch("logging.root.handlers", mock_handlers), patch("logging.root.setLevel") as mock_set_level:
+    with (
+        patch("logging.root.handlers", mock_handlers),
+        patch("logging.root.setLevel") as mock_set_level,
+    ):
         setup_logging(verbosity=ConsoleVerbosity.NORMAL, timestamps=True)
 
         # Should set level

--- a/tests/utils/signature/test_get_signature.py
+++ b/tests/utils/signature/test_get_signature.py
@@ -172,7 +172,9 @@ def test_get_signature_no_parameters():
     def test_func() -> None:
         """Test function."""
 
-    with pytest.raises(SignatureError, match=r"Function test_func must have at least one parameter"):
+    with pytest.raises(
+        SignatureError, match=r"Function test_func must have at least one parameter"
+    ):
         get_signature(test_func)
 
 
@@ -186,7 +188,9 @@ def test_get_signature_wrong_first_parameter_name():
             name: The name parameter.
         """
 
-    with pytest.raises(SignatureError, match=r"Function test_func must have 'ctx: Context' as the first parameter"):
+    with pytest.raises(
+        SignatureError, match=r"Function test_func must have 'ctx: Context' as the first parameter"
+    ):
         get_signature(test_func)
 
 

--- a/tests/utils/signature/test_integration.py
+++ b/tests/utils/signature/test_integration.py
@@ -132,7 +132,9 @@ def test_mutually_exclusive_groups_error_handling():
         """
 
     # This should raise an error because positional arguments can't be in mutually exclusive groups
-    with pytest.raises(SignatureError, match="Positional parameter 'name' cannot be in a mutually exclusive group"):
+    with pytest.raises(
+        SignatureError, match="Positional parameter 'name' cannot be in a mutually exclusive group"
+    ):
         get_signature(func)
 
 

--- a/tools/bench.py
+++ b/tools/bench.py
@@ -398,7 +398,9 @@ def compare(
     """
     min_runs = 10
     if runs < min_runs:
-        ctx.error(f"--runs must be >= {min_runs} (got {runs}); steady-state mean needs enough samples")
+        ctx.error(
+            f"--runs must be >= {min_runs} (got {runs}); steady-state mean needs enough samples"
+        )
         ctx.exit(2)
 
     known = {t.name for t in _TOOLS}
@@ -515,7 +517,9 @@ def _row_cells(r: _Row) -> tuple[str, ...]:
 def _render(ctx: Context, rows: list[_Row], *, runs: int) -> None:
     """Render the timing rows as a Rich table sorted by remaining mean ascending."""
     remaining_count = runs - 2
-    table = Table(title=f"`<tool> -h` startup — {runs} runs (remaining = mean of last {remaining_count})")
+    table = Table(
+        title=f"`<tool> -h` startup — {runs} runs (remaining = mean of last {remaining_count})"
+    )
     for header, is_numeric in _COLUMNS:
         table.add_column(header, justify="right" if is_numeric else "left")
     for r in _sorted_rows(rows):
@@ -534,7 +538,10 @@ def _render_markdown(ctx: Context, rows: list[_Row], *, runs: int) -> None:
     cells = [_row_cells(r) for r in _sorted_rows(rows)]
     headers = [h for h, _ in _COLUMNS]
     # Column width = max(header, max-cell-in-column).
-    widths = [max(len(h), *(len(row[i]) for row in cells)) if cells else len(h) for i, h in enumerate(headers)]
+    widths = [
+        max(len(h), *(len(row[i]) for row in cells)) if cells else len(h)
+        for i, h in enumerate(headers)
+    ]
 
     def pad(cell: str, width: int, *, numeric: bool) -> str:
         return cell.rjust(width) if numeric else cell.ljust(width)
@@ -543,7 +550,9 @@ def _render_markdown(ctx: Context, rows: list[_Row], *, runs: int) -> None:
         padded = [pad(v, widths[i], numeric=_COLUMNS[i][1]) for i, v in enumerate(values)]
         return f"| {' | '.join(padded)} |"
 
-    sep_cells = ["-" * widths[i] + (":" if is_numeric else "") for i, (_, is_numeric) in enumerate(_COLUMNS)]
+    sep_cells = [
+        "-" * widths[i] + (":" if is_numeric else "") for i, (_, is_numeric) in enumerate(_COLUMNS)
+    ]
     # The leading position of the colon for right-align is on the right;
     # left-align uses a plain dash run.
 

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -188,13 +188,19 @@ def _select_workflow_mode() -> tuple[Literal["ci", "release"], str]:
     if event_name == "pull_request":
         labels = _pr_labels()
         if FULL_BUILD_LABEL in labels:
-            return "release", f"PR carries the `{FULL_BUILD_LABEL}` label — running the full release matrix on opt-in."
+            return (
+                "release",
+                f"PR carries the `{FULL_BUILD_LABEL}` label — running the full release matrix on opt-in.",
+            )
         return "ci", (
             f"PR (no `{FULL_BUILD_LABEL}` label) — native-triple subset to keep PR builds snappy. "
             f"Apply the `{FULL_BUILD_LABEL}` label and re-run to opt into the full release matrix."
         )
 
-    return "ci", f"event=`{event_name or '(unset)'}`, ref=`{ref or '(unset)'}` — default to the minimal CI matrix."
+    return (
+        "ci",
+        f"event=`{event_name or '(unset)'}`, ref=`{ref or '(unset)'}` — default to the minimal CI matrix.",
+    )
 
 
 class Workflow(StrEnum):
@@ -242,7 +248,9 @@ def generate_build_matrix(
     if workflow == Workflow.RELEASE:
         binary_archive_triples: list[dict[str, object]] = list(_BINARY_ARCHIVE_TRIPLES)
     else:
-        binary_archive_triples = [t for t in _BINARY_ARCHIVE_TRIPLES if t["triple"] in _CI_BINARY_ARCHIVE_TRIPLE_NAMES]
+        binary_archive_triples = [
+            t for t in _BINARY_ARCHIVE_TRIPLES if t["triple"] in _CI_BINARY_ARCHIVE_TRIPLE_NAMES
+        ]
 
     outputs: dict[str, object] = {
         "platform-matrix": _WHEEL_PLATFORM_MATRIX,
@@ -274,7 +282,10 @@ def generate_build_matrix(
         wfh.write("\n### Standalone binary archives\n\n")
         wfh.write("| Triple | GH runner | Archive |\n")
         wfh.write("|--------|-----------|---------|\n")
-        wfh.writelines(f"| `{t['triple']}` | {t['runner']} | `{t['archive']}` |\n" for t in binary_archive_triples)
+        wfh.writelines(
+            f"| `{t['triple']}` | {t['runner']} | `{t['archive']}` |\n"
+            for t in binary_archive_triples
+        )
         wfh.write("\n### Python ABIs\n\n")
         wfh.write(f"- Binary wheel: `{', '.join(BINARY_WHEEL_PYTHONS)}`\n")
         wfh.write(f"- toolr-py wheel: `{', '.join(ALL_CPYTHONS)}`\n\n")
@@ -410,7 +421,9 @@ def check_run_build(ctx: Context, event_name: str, branch: str) -> None:
         ctx.exit(0)
 
     pr_number = prs_list[0]["number"]
-    ctx.info(f"Builds for branch/tag {branch!r} should not run since they will be built on PR #{pr_number}.")
+    ctx.info(
+        f"Builds for branch/tag {branch!r} should not run since they will be built on PR #{pr_number}."
+    )
     if github_step_summary is not None:
         github_repository = os.environ.get("GITHUB_REPOSITORY")
         if github_repository is None:
@@ -429,7 +442,15 @@ def check_run_build(ctx: Context, event_name: str, branch: str) -> None:
 
 
 def _update_action_version(ctx: Context, version: Version) -> int:
-    ret = ctx.run("git", "grep", "-l", "uses: s0undt3ch/ToolR@", ".github/", capture_output=True, stream_output=False)
+    ret = ctx.run(
+        "git",
+        "grep",
+        "-l",
+        "uses: s0undt3ch/ToolR@",
+        ".github/",
+        capture_output=True,
+        stream_output=False,
+    )
     if ret.returncode != 0:
         ctx.error("Failed to grep for 'uses: s0undt3ch/ToolR@' in .github/")
         return 1
@@ -532,7 +553,9 @@ def sync_rolling_tags(ctx: Context, dry_run: bool = False) -> None:
     Args:
         dry_run: Whether to dry run the command.
     """
-    ret = ctx.run("git", "tag", "--list", "--sort=-version:refname", capture_output=True, stream_output=False)
+    ret = ctx.run(
+        "git", "tag", "--list", "--sort=-version:refname", capture_output=True, stream_output=False
+    )
     if ret.returncode != 0:
         ctx.error("Failed to get the list of tags")
         ctx.exit(1)

--- a/tools/version.py
+++ b/tools/version.py
@@ -79,7 +79,9 @@ def _compute_dev_version(ctx: Context) -> str:
     if not describe:
         # No matching tag in history — use the fallback base. ``TODAY_VERSION``
         # already ends in ``.0`` so the patch-bump yields ``.1``.
-        ret = ctx.run("git", "rev-list", "--count", "HEAD", capture_output=True, stream_output=False)
+        ret = ctx.run(
+            "git", "rev-list", "--count", "HEAD", capture_output=True, stream_output=False
+        )
         count: str = ret.stdout.read().rstrip() or "0"  # type: ignore[assignment]
         return f"{_bump_patch(TODAY_VERSION)}-dev{count}"
     # Format: vX.Y.Z-N-gSHA  →  base=X.Y.Z, count=N, sha=gSHA


### PR DESCRIPTION
## Summary

Codifies the soft-100 / hard-120 line-length policy you asked about across every toolchain in the workspace, and reflows the prose that exceeded the new hard cap.

## Per-toolchain knobs

| Layer | Soft target (formatter) | Hard ceiling (lint) |
| --- | --- | --- |
| Rust | `.rustfmt.toml` `max_width = 100` | editor + review (no Clippy lint exists) |
| Python | `tool.ruff.line-length = 100` | `tool.ruff.lint.pycodestyle.max-line-length = 120` |
| Markdown | editor ruler / authoring habit | `.rumdl.toml` `[MD013] line_length = 120` (code/tables/headings excluded) |
| All files | `.editorconfig` `max_line_length = 100` | — |

No tool offers a true "soft/hard" knob; the split is via two settings per language.

## Commits

### `feat(config): add .rustfmt.toml + .editorconfig with 100-col policy`

- `.rustfmt.toml` (dot-prefixed) pins `max_width = 100` and leaves the nightly-only enforcement knobs alone — defaults already match the policy.
- `.editorconfig` sets `max_line_length = 100` across the tree with per-extension indenting overrides matching existing conventions; `skills/*/references/*.md` opt out (xtask-generated content).

### `style(python): split ruff line-length (format 100, lint 120) + reformat`

- `tool.ruff.line-length` drops from 120 to 100.
- New `tool.ruff.lint.pycodestyle.max-line-length = 120` lifts the E501 lint threshold above the formatter target.
- `ruff format` touches 31 files (formatter wrap to 100); 2 long f-string error messages in `crates/toolr-py/python/toolr/utils/_signature.py` needed manual split since ruff doesn't break string literals.
- `uv run pytest -q tests/` clean: 408 passed, 8 skipped.

### `style(docs): enable MD013 with 120-char ceiling + reflow long lines`

- `.rumdl.toml` removes `MD013` from `disable` and pins `line_length = 120` with `code_blocks = false`, `tables = false`, `headings = false`.
- Adds `specs/archive` to the global `exclude` list — archived design docs are immutable post-mortem records (per `specs/README.md`); the policy doesn't apply retroactively. Top-level `specs/<date>-*` files (active designs) are still linted.
- Reflowed prose that exceeded 120 in `README.md`, `SECURITY.md`, `CONTRIBUTING.md`, `docs/cli.md`, `docs/writing-commands/testing.md`, `specs/README.md`. One unwrappable inline-code usage line in `docs/cli.md` was promoted to a fenced `text` block.

## Test plan

- [x] `prek run --all-files` clean (every hook including the new `rumdl` MD013 gate)
- [x] `uv run pytest -q tests/` — 408 passed, 8 skipped
- [ ] CI on this PR matches local result
- [ ] After merge: rebase #233 (worktree-toolr-command-authoring-skill-spec) onto main and reflow its remaining long lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)