### PR TITLE
docs(skills): link agent skills from README and docs landing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,11 @@
 # checkouts with `core.autocrlf=true` would otherwise rewrite the
 # committed files to CRLF and fail the check.
 skills/*/references/*.md text eol=lf
+
+# `skills/*/examples/**/*.py` are read by the manifest snapshot test
+# (`crates/toolr-core/tests/skill_authoring_examples.rs`). The toolr
+# docstring parser preserves source newlines verbatim in the group
+# `description` field, so a CRLF checkout on Windows produces a
+# manifest whose JSON values contain `\r\n` and no longer match the
+# LF-canonical committed snapshot.
+skills/*/examples/**/*.py text eol=lf

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ or delete it and start from scratch.
 - [Quickstart](https://toolr.readthedocs.io/latest/quickstart/)
 - [Writing commands](https://toolr.readthedocs.io/latest/writing-commands/)
 - [Third-party packages](https://toolr.readthedocs.io/latest/third-party/)
+- [Agent skills (for LLM coding assistants)](https://toolr.readthedocs.io/latest/skills/)
 - [Internals (manifest, freshness, cache)](https://toolr.readthedocs.io/latest/internals/)
 - [CLI reference](https://toolr.readthedocs.io/latest/cli/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,8 @@
   Head to the [Quickstart](quickstart.md).
 - **Curious about how it works?**
   Read [How toolr is laid out](concepts.md).
+- **Using an LLM coding assistant?**
+  Install the [agent skills](skills.md).
 
 ## Need help?
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -37,6 +37,14 @@ Substitute your platform's skill-install command if you're not on
 Claude Code-compatible and the references files are plain Markdown
 that any platform can ingest.
 
+## Managing installed skills
+
+Listing, updating, pinning, and removing installed skills is
+`skillshare`'s job — see the
+[`skillshare` documentation](https://github.com/skillsharehub/skillshare)
+for the full command surface. Toolr ships the skills; how you
+manage them on your machine is owned upstream.
+
 ## How the references stay correct
 
 Each skill ships a `references/` directory with files generated from


### PR DESCRIPTION
The merged skills shipped without any entry point on the README or
docs/index.md — the page was only reachable from the left nav. Add
a 'Where to go next' bullet on README.md and a 'Start here' bullet
on docs/index.md, and add a short 'Managing installed skills'
subsection on docs/skills.md that redirects to skillshare's own
docs rather than duplicating its command surface.