### PR TITLE
ci: drop self action-version pin and auto-sync rolling tags on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,6 +446,11 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          # Use the GitHub App token so that the resulting
+          # `release: published` event triggers downstream workflows
+          # (e.g. sync-rolling-tags.yml). Releases created with the
+          # default GITHUB_TOKEN do not fire downstream workflow events.
+          token: ${{ steps.app-token.outputs.token }}
           tag_name: v${{ needs.prepare-release.outputs.release-version }}
           name: ${{ needs.prepare-release.outputs.release-version }}
           body_path: ${{ needs.prepare-release.outputs.release-notes-filename }}

--- a/.github/workflows/sync-rolling-tags.yml
+++ b/.github/workflows/sync-rolling-tags.yml
@@ -3,6 +3,8 @@ run-name: "Sync Rolling Tags (branch: ${{ github.ref_name }})"
 
 on:
   workflow_dispatch:
+  release:
+    types: [published, deleted]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.repository }}
@@ -37,6 +39,7 @@ jobs:
           egress-policy: audit
 
       - name: Check For Admin Permission
+        if: github.event_name == 'workflow_dispatch'
         uses: actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e # v2.4.0
         with:
           require: admin

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -441,45 +441,6 @@ def check_run_build(ctx: Context, event_name: str, branch: str) -> None:
     ctx.exit(0)
 
 
-def _update_action_version(ctx: Context, version: Version) -> int:
-    ret = ctx.run(
-        "git",
-        "grep",
-        "-l",
-        "uses: s0undt3ch/ToolR@",
-        ".github/",
-        capture_output=True,
-        stream_output=False,
-    )
-    if ret.returncode != 0:
-        ctx.error("Failed to grep for 'uses: s0undt3ch/ToolR@' in .github/")
-        return 1
-
-    # Store the list of files before we reuse the ret variable
-    files_to_update = ret.stdout.read().rstrip().splitlines()
-
-    # Get the commit SHA for the version tag
-    tag_name = f"v{version}"
-    ret = ctx.run("git", "rev-parse", tag_name, capture_output=True, stream_output=False)
-    if ret.returncode != 0:
-        ctx.error(f"Failed to get commit SHA for tag {tag_name}")
-        return 1
-    commit_sha = ret.stdout.read().rstrip()
-
-    usage_version = f"{commit_sha} # {tag_name}"
-    for fpath in files_to_update:
-        new_uses_string = f"uses: s0undt3ch/ToolR@{usage_version}"
-        with open(fpath) as rfh:
-            in_contents = rfh.read()
-        out_contents = re.sub(r"uses: s0undt3ch/ToolR@(.*)", new_uses_string, in_contents)
-        if out_contents != in_contents:
-            ctx.info(f"Updating {fpath} version to '{new_uses_string}'")
-            with open(fpath, "w") as wfh:
-                wfh.write(out_contents)
-
-    return 0
-
-
 def _build_rolling_tags_list(tags: list[Version]) -> list[tuple[str, Version]]:
     """
     Build the list of rolling tags that should be created/updated.
@@ -598,10 +559,6 @@ def sync_rolling_tags(ctx: Context, dry_run: bool = False) -> None:
 
     latest_tag = tags[0]
     ctx.info("latest_tag:", latest_tag)
-    exitcode = _update_action_version(ctx, latest_tag)
-    if exitcode != 0:
-        ctx.error(f"Failed to update to Toolr@v{latest_tag} action version")
-        ctx.exit(exitcode)
 
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output is not None:


### PR DESCRIPTION
## Summary

Stop having the `sync-rolling-tags` workflow rewrite our own
`uses: s0undt3ch/ToolR@…` references on every release, and instead run
the workflow automatically when a release is published or deleted so
the major/minor rolling tags (`vX`, `vX.Y`) stay current without
manual `workflow_dispatch` runs.

## Why

- `release.yml` already updates the in-repo action references during
  release preparation, so `_update_action_version` inside
  `sync_rolling_tags` was redundant and a frequent source of
  empty/no-op commits.
- The rolling tags themselves should move automatically whenever the
  release set changes — both on publish (new latest patch) and on
  delete (re-point or remove a rolling tag).

## What changed

- **`tools/ci.py`** — remove the `_update_action_version` helper and
  its call site in `sync_rolling_tags`. The command now only manages
  the rolling major/minor tags.
- **`.github/workflows/sync-rolling-tags.yml`**
  - Add `release: { types: [published, deleted] }` to the triggers.
  - Gate the admin permission check on `workflow_dispatch` only, since
    on a `release` event the triggering actor is the GitHub App rather
    than the human admin and would otherwise fail the check.
- **`.github/workflows/release.yml`** — pass the GitHub App token to
  `softprops/action-gh-release`. Releases created with the default
  `GITHUB_TOKEN` do not fire downstream workflow events, so without
  this the new `release: published` trigger would never actually fire.

## Test plan

- [ ] Manually `workflow_dispatch` `sync-rolling-tags` on the branch
      and confirm it still updates rolling tags (and now does not
      touch `.github/workflows/*.yml`).
- [ ] Cut a test release (or wait for the next real release) and
      confirm `sync-rolling-tags` fires automatically on
      `release: published`.
- [ ] Delete a release and confirm `sync-rolling-tags` fires on
      `release: deleted` and re-points / removes the affected rolling
      tag.