### PR TITLE
fix(uv): detect musl libc in auto-installer and add actionable exec-failure hint

### DIFF
--- a/crates/toolr-core/src/project.rs
+++ b/crates/toolr-core/src/project.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 use crate::discovery::discover_project_root;
-use crate::uv::{UvBinary, ensure_uv, install::ConsentMode};
+use crate::uv::{UvBinary, UvError, ensure_uv, install::ConsentMode};
 use crate::venv::{
     ResolvedVenv, perform_editable_installs, resolve_venv_path,
     sync::sync_if_needed, validate::validate_venv, warn_failures,
@@ -22,7 +22,7 @@ pub fn ensure_venv_ready(
         .context("locating project root for the tools venv")?;
     let resolved = resolve_venv_path(&repo_root)
         .context("resolving the tools venv path")?;
-    let uv = ensure_uv(consent).map_err(|e| anyhow::anyhow!(e.user_message()))?;
+    let uv = ensure_uv(consent).map_err(UvError::into_anyhow)?;
     let tools = repo_root.join("tools");
     sync_if_needed(&uv, &tools, &resolved, force_sync)
         .with_context(|| format!("uv sync against {}", tools.display()))?;

--- a/crates/toolr-core/src/uv/discover.rs
+++ b/crates/toolr-core/src/uv/discover.rs
@@ -29,7 +29,15 @@ pub fn find_managed_uv() -> Result<Option<UvBinary>, UvError> {
 
 /// Run `<path> --version`, parse output, validate against the minimum.
 pub fn probe(path: &Path, source: UvSource) -> Result<UvBinary, UvError> {
-    let output = Command::new(path).arg("--version").output()?;
+    // `Command::output()` returns `ErrorKind::NotFound` when the binary
+    // exists on disk but `execve` reports ENOENT — almost always a libc
+    // mismatch (missing dynamic loader). Tag that distinctly so the
+    // user-facing error spells out the recovery path instead of
+    // bottoming out as "I/O error: No such file or directory".
+    let output = Command::new(path)
+        .arg("--version")
+        .output()
+        .map_err(|e| UvError::exec_failed(path, e))?;
     if !output.status.success() {
         return Err(UvError::UnparsableVersion(
             String::from_utf8_lossy(&output.stderr).into_owned(),
@@ -252,12 +260,78 @@ mod tests {
     }
 
     #[test]
-    fn probe_returns_io_when_binary_is_missing() {
+    fn probe_returns_exec_failed_when_binary_is_missing() {
         let tmp = tempfile::tempdir().unwrap();
-        let err = probe(&tmp.path().join("does-not-exist"), UvSource::Path).unwrap_err();
-        // Command::output() returns Err for ENOENT, which maps via
-        // #[from std::io::Error] to UvError::Io.
-        assert!(matches!(err, UvError::Io(_)));
+        let candidate = tmp.path().join("does-not-exist");
+        let err = probe(&candidate, UvSource::Path).unwrap_err();
+        // `Command::output()` returns ENOENT, which now maps to
+        // `ExecFailed` rather than the bare `Io` variant — so
+        // `user_message()` can render a libc-mismatch hint.
+        match err {
+            UvError::ExecFailed { path, source } => {
+                assert_eq!(path, candidate);
+                assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+            }
+            other => panic!("expected ExecFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exec_failed_user_message_is_a_libc_hint_without_path_duplication() {
+        let err = UvError::exec_failed(
+            std::path::Path::new("/managed/uv"),
+            std::io::Error::from(std::io::ErrorKind::NotFound),
+        );
+        let hint = err.user_message();
+        // The hint mentions both the env override and the OS package
+        // fallback so the user has at least two paths forward.
+        assert!(hint.contains("TOOLR_UV_LIBC"), "missing env override hint in: {hint}");
+        assert!(hint.contains("musl"), "missing musl/gnu mention in: {hint}");
+        // Path and io error are intentionally NOT duplicated in the hint
+        // — they reach the user via the wrapped ExecFailed's Display,
+        // which `into_anyhow()` keeps in the chain.
+        assert!(!hint.contains("/managed/uv"), "path leaked into hint: {hint}");
+    }
+
+    #[test]
+    fn exec_failed_into_anyhow_chain_contains_both_hint_and_path() {
+        let err = UvError::exec_failed(
+            std::path::Path::new("/managed/uv"),
+            std::io::Error::from(std::io::ErrorKind::NotFound),
+        );
+        let formatted = format!("{:#}", err.into_anyhow());
+        // `{:#}` joins the whole chain with `: ` — the hint should
+        // appear first (outermost context) and the technical detail
+        // (path + io error) should follow.
+        assert!(formatted.contains("TOOLR_UV_LIBC"), "hint missing in chain: {formatted}");
+        assert!(formatted.contains("/managed/uv"), "path missing in chain: {formatted}");
+        // The io::Error display varies across platforms / kinds — the
+        // synthetic `Error::from(NotFound)` here renders as "entity not
+        // found" while a real ENOENT from execve renders as "No such
+        // file or directory". Either way, the chain ends with the
+        // ExecFailed Display followed by the source io::Error, so the
+        // path appears twice (in ExecFailed display + already asserted)
+        // and the io::Error tail follows.
+        assert!(
+            formatted.matches("entity not found").count() >= 1
+                || formatted.contains("No such file"),
+            "io error missing in chain: {formatted}"
+        );
+    }
+
+    #[test]
+    fn exec_failed_non_notfound_falls_back_to_display() {
+        // For non-ENOENT exec failures (permission denied, etc.) we
+        // still want SOMETHING actionable, but the libc-mismatch hint
+        // would be misleading. Confirm we fall through to the plain
+        // Display formatting in that case.
+        let err = UvError::exec_failed(
+            std::path::Path::new("/forbidden/uv"),
+            std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+        );
+        let msg = err.user_message();
+        assert!(msg.contains("/forbidden/uv"));
+        assert!(!msg.contains("TOOLR_UV_LIBC"));
     }
 
     #[test]

--- a/crates/toolr-core/src/uv/install.rs
+++ b/crates/toolr-core/src/uv/install.rs
@@ -98,19 +98,120 @@ pub fn decide_install_auto(
     )
 }
 
+/// Linux libc variant. Picked at runtime via [`detect_linux_libc`] so
+/// the auto-installer fetches a uv binary whose dynamic loader exists
+/// on the running host — a glibc binary on a musl box `execve`s as
+/// `ENOENT` (missing `/lib64/ld-linux-x86-64.so.2`), surfacing as the
+/// notoriously unhelpful "I/O error: No such file or directory".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinuxLibc {
+    Gnu,
+    Musl,
+}
+
 /// Host triple selection. Returns an Astral release asset name without the
 /// extension, plus the extension itself.
 ///
 /// Reference: <https://github.com/astral-sh/uv/releases>
 pub fn host_asset() -> Option<(&'static str, &'static str)> {
-    match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("linux", "x86_64") => Some(("uv-x86_64-unknown-linux-gnu", "tar.gz")),
-        ("linux", "aarch64") => Some(("uv-aarch64-unknown-linux-gnu", "tar.gz")),
+    host_asset_for(
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        detect_linux_libc(),
+    )
+}
+
+/// Inner table used by [`host_asset`]. Split out so tests can pin
+/// `(os, arch, libc)` and exercise every row deterministically without
+/// touching env vars, `/etc`, or running `ldd`.
+pub(crate) fn host_asset_for(
+    os: &str,
+    arch: &str,
+    linux_libc: LinuxLibc,
+) -> Option<(&'static str, &'static str)> {
+    match (os, arch) {
+        ("linux", "x86_64") => Some((
+            match linux_libc {
+                LinuxLibc::Gnu => "uv-x86_64-unknown-linux-gnu",
+                LinuxLibc::Musl => "uv-x86_64-unknown-linux-musl",
+            },
+            "tar.gz",
+        )),
+        ("linux", "aarch64") => Some((
+            match linux_libc {
+                LinuxLibc::Gnu => "uv-aarch64-unknown-linux-gnu",
+                LinuxLibc::Musl => "uv-aarch64-unknown-linux-musl",
+            },
+            "tar.gz",
+        )),
         ("macos", "x86_64") => Some(("uv-x86_64-apple-darwin", "tar.gz")),
         ("macos", "aarch64") => Some(("uv-aarch64-apple-darwin", "tar.gz")),
         ("windows", "x86_64") => Some(("uv-x86_64-pc-windows-msvc", "zip")),
         _ => None,
     }
+}
+
+/// Detect the Linux libc of the running host.
+///
+/// Order of precedence:
+/// 1. `TOOLR_UV_LIBC=musl|gnu` env override — escape hatch for hosts
+///    where automatic detection guesses wrong (custom distros, chroots,
+///    forced cross-libc setups).
+/// 2. `/etc/alpine-release` exists → musl. Cheap and deterministic;
+///    matches the `setup-toolr` GitHub Action's own detection.
+/// 3. `ldd --version` mentions `musl` → musl. Catches non-Alpine musl
+///    distros (Void Linux musl edition, Chimera, distroless-musl).
+/// 4. Otherwise → gnu (the historical default).
+///
+/// Non-Linux targets always report [`LinuxLibc::Gnu`]; the value is
+/// unused there because [`host_asset_for`]'s `"linux"` arms never fire
+/// on non-Linux builds.
+pub fn detect_linux_libc() -> LinuxLibc {
+    detect_linux_libc_from(
+        std::env::var_os("TOOLR_UV_LIBC")
+            .and_then(|v| v.into_string().ok())
+            .as_deref(),
+        || Path::new("/etc/alpine-release").exists(),
+        ldd_reports_musl,
+    )
+}
+
+/// Pure decision logic for [`detect_linux_libc`]. Each side-effect is
+/// injected as a closure so tests can run the table without touching
+/// env vars, the filesystem, or spawning `ldd`.
+fn detect_linux_libc_from(
+    env_override: Option<&str>,
+    alpine_release_exists: impl FnOnce() -> bool,
+    ldd_reports_musl: impl FnOnce() -> bool,
+) -> LinuxLibc {
+    if let Some(value) = env_override {
+        match value.trim() {
+            "musl" => return LinuxLibc::Musl,
+            "gnu" => return LinuxLibc::Gnu,
+            // Anything else (empty, typo, unknown) falls through to
+            // auto-detection rather than getting silently coerced.
+            _ => {}
+        }
+    }
+    if alpine_release_exists() {
+        return LinuxLibc::Musl;
+    }
+    if ldd_reports_musl() {
+        return LinuxLibc::Musl;
+    }
+    LinuxLibc::Gnu
+}
+
+/// Spawn `ldd --version` and return `true` if either stream mentions
+/// `musl`. glibc's ldd writes to stdout, musl's ldd writes to stderr
+/// (and exits non-zero), so we concatenate both before searching.
+fn ldd_reports_musl() -> bool {
+    let Ok(output) = std::process::Command::new("ldd").arg("--version").output() else {
+        return false;
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    stdout.to_lowercase().contains("musl") || stderr.to_lowercase().contains("musl")
 }
 
 /// Where to download from. Parametrised so tests can override.
@@ -325,6 +426,110 @@ mod tests {
                 let _ = result;
             }
         }
+    }
+
+    #[test]
+    fn host_asset_for_linux_gnu_x86_64() {
+        assert_eq!(
+            host_asset_for("linux", "x86_64", LinuxLibc::Gnu),
+            Some(("uv-x86_64-unknown-linux-gnu", "tar.gz"))
+        );
+    }
+
+    #[test]
+    fn host_asset_for_linux_musl_x86_64() {
+        assert_eq!(
+            host_asset_for("linux", "x86_64", LinuxLibc::Musl),
+            Some(("uv-x86_64-unknown-linux-musl", "tar.gz"))
+        );
+    }
+
+    #[test]
+    fn host_asset_for_linux_gnu_aarch64() {
+        assert_eq!(
+            host_asset_for("linux", "aarch64", LinuxLibc::Gnu),
+            Some(("uv-aarch64-unknown-linux-gnu", "tar.gz"))
+        );
+    }
+
+    #[test]
+    fn host_asset_for_linux_musl_aarch64() {
+        assert_eq!(
+            host_asset_for("linux", "aarch64", LinuxLibc::Musl),
+            Some(("uv-aarch64-unknown-linux-musl", "tar.gz"))
+        );
+    }
+
+    #[test]
+    fn host_asset_for_non_linux_ignores_libc() {
+        // The libc value is irrelevant on non-Linux targets; passing
+        // either variant must still return the platform-canonical asset.
+        for libc in [LinuxLibc::Gnu, LinuxLibc::Musl] {
+            assert_eq!(
+                host_asset_for("macos", "aarch64", libc),
+                Some(("uv-aarch64-apple-darwin", "tar.gz"))
+            );
+            assert_eq!(
+                host_asset_for("windows", "x86_64", libc),
+                Some(("uv-x86_64-pc-windows-msvc", "zip"))
+            );
+        }
+    }
+
+    #[test]
+    fn host_asset_for_unknown_combo_returns_none() {
+        assert_eq!(host_asset_for("freebsd", "x86_64", LinuxLibc::Gnu), None);
+        assert_eq!(host_asset_for("linux", "riscv64", LinuxLibc::Gnu), None);
+    }
+
+    #[test]
+    fn detect_linux_libc_env_override_wins() {
+        // Even on a "musl" looking host, an explicit gnu override sticks.
+        let libc = detect_linux_libc_from(Some("gnu"), || true, || true);
+        assert_eq!(libc, LinuxLibc::Gnu);
+
+        // And vice versa on a "gnu" looking host.
+        let libc = detect_linux_libc_from(Some("musl"), || false, || false);
+        assert_eq!(libc, LinuxLibc::Musl);
+    }
+
+    #[test]
+    fn detect_linux_libc_env_override_trims_whitespace() {
+        let libc = detect_linux_libc_from(Some("  musl\n"), || false, || false);
+        assert_eq!(libc, LinuxLibc::Musl);
+    }
+
+    #[test]
+    fn detect_linux_libc_unknown_env_override_falls_through() {
+        // Typos / unknown values must not short-circuit the rest of the
+        // detection — otherwise `TOOLR_UV_LIBC=glibc` would silently
+        // force gnu on an actually-musl host.
+        let libc = detect_linux_libc_from(Some("glibc"), || true, || false);
+        assert_eq!(libc, LinuxLibc::Musl);
+    }
+
+    #[test]
+    fn detect_linux_libc_alpine_release_means_musl() {
+        let libc = detect_linux_libc_from(None, || true, || false);
+        assert_eq!(libc, LinuxLibc::Musl);
+    }
+
+    #[test]
+    fn detect_linux_libc_ldd_musl_means_musl() {
+        let libc = detect_linux_libc_from(None, || false, || true);
+        assert_eq!(libc, LinuxLibc::Musl);
+    }
+
+    #[test]
+    fn detect_linux_libc_default_is_gnu() {
+        let libc = detect_linux_libc_from(None, || false, || false);
+        assert_eq!(libc, LinuxLibc::Gnu);
+    }
+
+    #[test]
+    fn detect_linux_libc_empty_env_override_falls_through() {
+        let libc = detect_linux_libc_from(Some(""), || true, || false);
+        assert_eq!(libc, LinuxLibc::Musl);
     }
 
     #[test]

--- a/crates/toolr-core/src/uv/mod.rs
+++ b/crates/toolr-core/src/uv/mod.rs
@@ -1,6 +1,6 @@
 //! `uv` integration: discovery, consent-based install, and sync invocation.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
@@ -49,10 +49,33 @@ pub enum UvError {
     UserRefusedInstall,
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    /// `Command::output()` failed even though the candidate binary was
+    /// on disk and looked executable. Almost always a libc / dynamic-
+    /// loader mismatch (a glibc-linked uv on a musl host, or vice
+    /// versa). Distinct from `Io` so `user_message` can render an
+    /// actionable hint instead of the bare `os error 2`.
+    #[error("failed to execute uv at {path}: {source}")]
+    ExecFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("HTTP error during uv install: {0}")]
     Http(String),
     #[error("uv sync failed with exit code {0:?}")]
     SyncFailed(Option<i32>),
+}
+
+impl UvError {
+    /// Construct an [`UvError::ExecFailed`] carrying the path that
+    /// failed to exec. Tiny helper so call sites don't repeat the
+    /// `path.to_path_buf()` boilerplate.
+    pub(crate) fn exec_failed(path: &Path, source: std::io::Error) -> Self {
+        Self::ExecFailed {
+            path: path.to_path_buf(),
+            source,
+        }
+    }
 }
 
 impl UvError {
@@ -77,7 +100,48 @@ impl UvError {
                  >= {}.{}.{}. Upgrade uv and try again.",
                 found.0, found.1, found.2, required.0, required.1, required.2,
             ),
+            // ENOENT from `execve` on a binary that demonstrably exists
+            // on disk almost always means the dynamic loader the binary
+            // needs is missing — typically a glibc-linked uv on a musl
+            // host (or vice versa). Spell that out instead of leaving
+            // the user with a bare "No such file or directory". The
+            // path + io::Error live in the wrapped `ExecFailed` Display
+            // and reach the user via the anyhow chain (see
+            // [`Self::into_anyhow`]); the hint here is purely the
+            // recovery advice.
+            Self::ExecFailed { source, .. }
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                "uv exists on disk but couldn't be executed. This \
+                 usually means the binary's dynamic loader is missing \
+                 — for example a glibc-linked uv on a musl host, or \
+                 vice versa. Set TOOLR_UV_LIBC=musl (or =gnu) to \
+                 override toolr's libc detection, or install uv via \
+                 your OS package manager."
+                    .into()
+            }
             other => other.to_string(),
+        }
+    }
+
+    /// Convert into an `anyhow::Error` while preserving the underlying
+    /// chain. When [`Self::user_message`] adds recovery advice on top
+    /// of the technical Display string, attach it as a context layer
+    /// so it surfaces first; otherwise just wrap the error so callers
+    /// don't double-print the same line.
+    ///
+    /// Use this at the toolr-binary boundary in place of
+    /// `anyhow::anyhow!(e.user_message())` — that pattern collapses
+    /// the entire chain and obscures which io::Error / which path was
+    /// the actual cause.
+    pub fn into_anyhow(self) -> anyhow::Error {
+        let hint = self.user_message();
+        let display = self.to_string();
+        let err = anyhow::Error::new(self);
+        if hint == display {
+            err
+        } else {
+            err.context(hint)
         }
     }
 }

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -446,7 +446,7 @@ fn run_install_uv_now() -> anyhow::Result<std::process::ExitCode> {
         auto_install_env: true,
     };
     let uv = toolr_core::uv::ensure_uv(consent)
-        .map_err(|e| anyhow::anyhow!(e.user_message()))?;
+        .map_err(toolr_core::uv::UvError::into_anyhow)?;
     println!(
         "toolr: uv {}.{}.{} ready at {} (source: {:?})",
         uv.version.0,


### PR DESCRIPTION
Closes #280. Related action.yml follow-ups tracked separately: #281 (SHA-pin handling), #283 (auto-install uv via `astral-sh/setup-uv`).

## Summary

When toolr's auto-installer downloads uv on a musl host (Alpine,
distroless-musl, etc.), `host_asset()` previously hard-coded the
glibc Linux asset. The downloaded binary expects
`/lib64/ld-linux-x86-64.so.2`, which doesn't exist on musl, so
`execve` returns `ENOENT`. The error then bottoms out as the
unhelpful `toolr: I/O error: No such file or directory (os error 2)`
because (a) the variant is the generic `UvError::Io` with no
context, and (b) `ensure_venv_ready` flattens the chain through
`anyhow::anyhow!(e.user_message())`. Real-world reproducer: Jenkins
on a musl agent with `TOOLR_AUTO_INSTALL_UV=1`.

This PR is scoped to toolr's *own* Rust auto-installer
(`crates/toolr-core/src/uv/`). The `setup-toolr` GitHub Action
drives `uv sync` directly and never goes through this code path —
its uv-acquisition story is the subject of #283.

## What changed

- **Detect musl in `host_asset()`** (`crates/toolr-core/src/uv/install.rs`)
  New `LinuxLibc` enum + `detect_linux_libc()` with precedence:
  1. `TOOLR_UV_LIBC=musl|gnu` env override — escape hatch for hosts
     where automatic detection guesses wrong.
  2. `/etc/alpine-release` exists → musl. Cheap, matches what
     `setup-toolr` action.yml already does.
  3. `ldd --version` mentions `musl` → musl. Catches non-Alpine
     musl distros.
  4. Default → gnu.
  Asset table extended with the four missing musl entries
  (`uv-{x86_64,aarch64}-unknown-linux-musl`). Detection is isolated
  behind `detect_linux_libc_from()` so unit tests exercise every row
  deterministically.

- **Add `UvError::ExecFailed { path, source }`** (`crates/toolr-core/src/uv/mod.rs`)
  `probe()` now tags `Command::output()` failures with the candidate
  path, distinct from generic `Io`. `user_message()` renders a
  libc-mismatch hint for the ENOENT case naming both the env
  override (`TOOLR_UV_LIBC`) and the OS-package fallback so the user
  has at least two paths forward.

- **Stop flattening the error chain** (`crates/toolr-core/src/project.rs`,
  `crates/toolr/src/dispatch.rs`)
  New `UvError::into_anyhow()` helper preserves the chain, attaching
  `user_message` as a context layer only when it adds information
  beyond `Display`. Replaces the two existing
  `anyhow::anyhow!(e.user_message())` call sites.

## User-visible result

On a musl host hitting the ENOENT path the user now sees:

```
toolr: uv exists on disk but couldn't be executed. This usually
means the binary's dynamic loader is missing — for example a
glibc-linked uv on a musl host, or vice versa. Set
TOOLR_UV_LIBC=musl (or =gnu) to override toolr's libc detection,
or install uv via your OS package manager.: failed to execute uv at
/home/.../toolr/bin/uv: <io::Error>
```

…instead of `toolr: I/O error: No such file or directory (os error 2)`.

## Out of scope

- `setup-toolr` action.yml's missing-uv handling — tracked in #283.
- `setup-toolr` action.yml's SHA-pin resolve bug — tracked in #281.
- Both will be addressed in separate PRs.

## Test plan

- [x] `cargo test --workspace` — green (450+ toolr-core, 7+2 toolr).
- [x] `cargo clippy -p toolr-core --lib -- -D warnings` — clean.
- [x] `cargo clippy -p toolr -- -D warnings` — clean.
- [ ] Manual verify on a musl host (or Docker `alpine:latest`) that
      `TOOLR_AUTO_INSTALL_UV=1 toolr project deps sync` succeeds
      (musl asset downloaded + execs), or surfaces the new
      libc-mismatch hint if detection misses for any reason.
- [ ] Manual verify the `TOOLR_UV_LIBC=musl` / `=gnu` env override
      forces the chosen libc regardless of host detection.