### PR TITLE
feat(action): install uv via astral-sh/setup-uv when missing or version-pinned

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,18 @@ inputs:
       would skip (e.g. `--group lint`). Defaults to empty.
     default: ""
 
+  uv-version:
+    description: |
+      uv version to install via `astral-sh/setup-uv` when uv isn't
+      already on PATH (or when this input is non-empty, in which
+      case setup-uv runs regardless and overrides whatever's on
+      PATH). Accepts anything `astral-sh/setup-uv` accepts —
+      bare semver (`0.5.1`), with leading `v` (`v0.5.1`), or
+      `latest`. Empty (the default) means "no version pin": if uv
+      is missing setup-uv installs its own default; if uv is
+      already on PATH the action leaves it alone.
+    default: ""
+
 outputs:
   version:
     description: Resolved ToolR version installed (no leading `v`).
@@ -317,6 +329,35 @@ runs:
         } >> "$GITHUB_OUTPUT"
         echo "setup-toolr: installed toolr ${VERSION} at ${bin_dir}/${BIN}"
 
+    # uv is required for the "Sync tools venv" step further below.
+    # Detect it first so we only invoke `astral-sh/setup-uv` when
+    # necessary — when the caller's environment already provides uv
+    # (mise, a prior setup-uv step, an OS package), respect that.
+    # The exception is `inputs.uv-version`: a non-empty value means
+    # "give me exactly this uv version", so we run setup-uv to
+    # install it regardless of what's already on PATH.
+    - name: Detect uv on PATH
+      id: uv-check
+      shell: bash
+      run: |
+        if command -v uv >/dev/null 2>&1; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "setup-toolr: found uv on PATH at $(command -v uv)"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          echo "setup-toolr: uv not found on PATH"
+        fi
+
+    - name: Install uv via astral-sh/setup-uv
+      if: steps.uv-check.outputs.found == 'false' || inputs.uv-version != ''
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        # Empty `version` lets setup-uv pick its own default — that's
+        # exactly the behaviour we want for "uv is just missing, install
+        # something sensible". Callers wanting a specific version pass
+        # it via setup-toolr's `uv-version` input.
+        version: ${{ inputs.uv-version }}
+
     - name: Resolve tools venv path
       id: venv-path
       if: inputs.cache-tools-venv == 'true'
@@ -390,8 +431,16 @@ runs:
       run: |
         set -euo pipefail
         if ! command -v uv >/dev/null 2>&1; then
-          echo "setup-toolr: 'uv' is required on PATH to materialise the tools venv" >&2
-          echo "setup-toolr: install via mise or your platform's uv channel" >&2
+          # The "Install uv via astral-sh/setup-uv" step earlier in
+          # this action should have ensured uv is on PATH. Reaching
+          # this branch means that step skipped (uv was claimed to be
+          # on PATH already) AND uv has since disappeared — which is
+          # almost certainly a bug in the setup-uv detection or the
+          # caller's environment.
+          echo "setup-toolr: 'uv' is required on PATH but is no longer available" >&2
+          echo "setup-toolr: this should not happen — the earlier setup-uv step" >&2
+          echo "setup-toolr: should have installed uv. Pass an explicit uv-version" >&2
+          echo "setup-toolr: input to force a fresh install, or file a bug." >&2
           exit 1
         fi
         unset VIRTUAL_ENV

--- a/skills/toolr-ci-setup/references/action.md
+++ b/skills/toolr-ci-setup/references/action.md
@@ -18,6 +18,7 @@ Generated from the repository-root `action.yml`.
 | `cache-prefix` | `setup-toolr` | Prefix prepended to the actions/cache keys this action manages — both the toolr-binary cache and the in-tree `tools/.venv` cache. Defaults to `setup-toolr`. Bump the prefix in the caller workflow to force a cache miss without changing the toolr version or the pinned dependencies — useful when invalidating after a runner image upgrade or a corrupted cache entry. |
 | `cache-tools-venv` | `true` | When `true` (the default), cache the in-tree `tools/.venv` keyed on `tools/pyproject.toml` and `tools/uv.lock`. Set to `false` if you want toolr to rebuild the venv on every run. |
 | `sync-args` | _(empty)_ | Extra arguments appended to the `uv sync` invocation the action runs to materialise the tools venv. Whitespace-split shell-style; do not quote each flag. Useful for opting back into a dependency group the default `--no-default-groups` would skip (e.g. `--group lint`). Defaults to empty. |
+| `uv-version` | _(empty)_ | uv version to install via `astral-sh/setup-uv` when uv isn't already on PATH (or when this input is non-empty, in which case setup-uv runs regardless and overrides whatever's on PATH). Accepts anything `astral-sh/setup-uv` accepts — bare semver (`0.5.1`), with leading `v` (`v0.5.1`), or `latest`. Empty (the default) means "no version pin": if uv is missing setup-uv installs its own default; if uv is already on PATH the action leaves it alone. |
 
 ## Outputs
 


### PR DESCRIPTION
Closes #283.

## Summary

The `setup-toolr` action required `uv` on PATH but never installed it. Caller workflows that didn't pre-install uv (via mise, an upstream `astral-sh/setup-uv` step, or an OS package) hit a hard error at the "Sync tools venv" step with no recovery short of editing the caller's workflow. This adds a `uv-version` input and an internal `astral-sh/setup-uv` step so the action is zero-prerequisite by default while still letting callers pin or override uv.

## Truth table

| uv on PATH? | `uv-version` input | Behavior |
|-------------|--------------------|----------|
| No          | (empty)            | setup-uv installs its own default version. |
| No          | `0.5.1`            | setup-uv installs uv 0.5.1. |
| Yes         | (empty)            | Skip setup-uv — respect caller's uv. |
| Yes         | `0.5.1`            | Run setup-uv anyway — caller explicitly asked for a specific version. |

## What changed

- **New `uv-version` input** on the composite action, default `""`. Passed through verbatim to `astral-sh/setup-uv`'s `version` input.
- **New "Detect uv on PATH" step** records whether uv is already available (`steps.uv-check.outputs.found`).
- **New "Install uv via astral-sh/setup-uv" step** gated on `steps.uv-check.outputs.found == 'false' || inputs.uv-version != ''`. Pinned to `astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b` (v8.1.0).
- **Sync tools venv step** keeps its `command -v uv` guard, but the error message is reworded — reaching it now means the setup-uv step skipped and uv has since disappeared. Almost certainly a bug, not a missing prerequisite.

## Why `astral-sh/setup-uv` rather than rolling our own

Caching, attestation verification, and version pinning are all handled by the upstream action — that's the whole reason for choosing it over driving `toolr self install-uv` from the action (which would force us to reinvent all three).

## Test plan

- [x] `prek run --files action.yml` — clean.
- [ ] Manual verify on a runner without uv pre-installed: `setup-toolr` should now install uv and succeed all the way through "Sync tools venv" without any caller-side prep.
- [ ] Manual verify on a runner with uv already on PATH and no `uv-version` input: setup-uv step should be skipped (visible in the action log) and the caller's uv used.
- [ ] Manual verify `uv-version: latest` and `uv-version: 0.5.1` both force a setup-uv install even when uv is already on PATH.

## Related

- #281 / #284 — separate `action.yml` work for SHA-pin handling (bake-in mechanism).
- #280 / #282 — toolr's own Rust auto-installer (musl detection + better errors). Unrelated to this PR because the action drives uv directly, not via toolr.