### PR TITLE
fix(dispatch): surface arg() metadata TypeError from dispatcher detection

### DIFF
--- a/crates/toolr-py/python/toolr/utils/_signature.py
+++ b/crates/toolr-py/python/toolr/utils/_signature.py
@@ -855,9 +855,18 @@ def detect_dispatch_parameter(func: Callable[..., Any]) -> str | None:
     # Resolve string annotations (PEP 563 / ``from __future__ import annotations``)
     # so the identity check against ``DispatchCommand`` works regardless of
     # how the caller declared the parameter.
+    #
+    # Forward references that can't be resolved at runtime (NameError /
+    # AttributeError) — typically TYPE_CHECKING-only imports — fall back
+    # to whatever ``inspect.signature`` recorded. A ``TypeError`` here,
+    # however, comes from evaluating ``Annotated[..., metadata(...)]``
+    # where the metadata constructor itself rejected its arguments
+    # (e.g. ``arg(conflicts_with="foo")`` instead of ``[...]``). That's
+    # a real bug in the caller's annotation that masks dispatch detection
+    # if swallowed, so we let it propagate with its original message.
     try:
         resolved = get_type_hints(func)
-    except (NameError, AttributeError, TypeError):
+    except (NameError, AttributeError):
         resolved = {}
 
     found_kw: list[str] = []

--- a/tests/sources/test_detection.py
+++ b/tests/sources/test_detection.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import pytest
 
+from toolr import arg
 from toolr.sources import DispatchCommand
 from toolr.utils._signature import DispatcherDetectionError
 from toolr.utils._signature import detect_dispatch_parameter
@@ -38,4 +41,23 @@ def test_dispatchcommand_in_positional_raises():
     def cmd(ctx, dispatched: DispatchCommand) -> None: ...
 
     with pytest.raises(DispatcherDetectionError, match="keyword-only"):
+        detect_dispatch_parameter(cmd)
+
+
+def test_malformed_arg_metadata_propagates_typeerror():
+    # `arg(conflicts_with=...)` requires a list / tuple / set; a bare
+    # string is rejected with TypeError. Under `from __future__ import
+    # annotations`, evaluating the `Annotated[...]` metadata happens
+    # inside `get_type_hints`. If the detector silently swallowed that
+    # TypeError, dispatch detection would fail and callers would emit
+    # a misleading "manifest out of sync" error instead of the real,
+    # actionable message. Make sure the TypeError surfaces.
+    def cmd(
+        ctx,
+        *,
+        dispatched: DispatchCommand,
+        follow: Annotated[bool, arg(conflicts_with="no_follow")] = False,
+    ) -> None: ...
+
+    with pytest.raises(TypeError, match=r"conflicts_with=.*bare `str`"):
         detect_dispatch_parameter(cmd)


### PR DESCRIPTION
## Summary

`detect_dispatch_parameter` used to swallow `TypeError` from `get_type_hints(func)` together with `NameError` / `AttributeError`. When the underlying cause was a malformed `Annotated[..., metadata(...)]` — e.g. `arg(conflicts_with="no_follow")` instead of `arg(conflicts_with=["no_follow"])` — the swallow turned an actionable, line-pointing `TypeError` into the misleading downstream error:

```
RuntimeError: invoke_dispatcher: 'job' has no DispatchCommand parameter (manifest out of sync?)
```

…even when the manifest was perfectly fresh, sending users down the wrong debugging path (rebuild the manifest, blow away caches, etc.) instead of fixing the one-character bug in their annotation.

## How it failed silently

1. User writes `Annotated[bool, arg(conflicts_with="no_follow")]` — accepted by older toolr, rejected by 0.21 with a `TypeError` that explicitly tells them how to fix it.
2. `detect_dispatch_parameter` calls `get_type_hints(func)`, which evaluates every `Annotated[...]` metadata expression. The `arg(...)` call raises `TypeError`.
3. The `except (NameError, AttributeError, TypeError)` clause swallows it; `resolved` collapses to `{}`.
4. The fallback loop reads `param.annotation`, which under `from __future__ import annotations` is the bare string `'DispatchCommand'`. The identity check `annotation is not DispatchCommand` is `True` for every parameter, so the detector returns `None`.
5. `invoke_dispatcher` (`_runner.py:387`) emits the "manifest out of sync?" error.

## What changed

- `crates/toolr-py/python/toolr/utils/_signature.py` — narrow the except in `detect_dispatch_parameter` to `(NameError, AttributeError)`. Forward-reference failures (TYPE_CHECKING-only imports) still fall back to raw `param.annotation`; metadata-constructor failures now propagate with their original message and traceback.
- `tests/sources/test_detection.py` — regression test asserting that a function annotated with `Annotated[bool, arg(conflicts_with="no_follow")]` causes `detect_dispatch_parameter` to raise `TypeError` matching the "must be a list … bare \`str\`" message rather than silently returning `None`.

## Why not also stop swallowing `NameError` / `AttributeError`

Those genuinely come from forward references that don't resolve at runtime — a normal pattern with `if TYPE_CHECKING:` blocks. The string-fallback path handles them correctly because the only annotation the detector cares about (`DispatchCommand`) must be imported at module load time for the function to be callable, so it's always resolvable even when other annotations aren't.

`TypeError` is different: it can only come from a metadata constructor rejecting its arguments. There is no legitimate fallback — every case is a real bug in the caller's annotation, and the constructor's own error message (e.g. the one `arg(conflicts_with=...)` already produces) is strictly better than anything the detector could synthesize.

## Encountered

Real bite, found while running:

```
toolr jenkins job --cpu 500m --ram 4Gi --log-level debug --on-demand delete_user_email --revoke richard.ding@paddle.com
```

in a downstream repo. The dashtastic-side fix is one line (`conflicts_with=["no_follow"]`) but only became obvious after running `detect_dispatch_parameter` directly under the venv Python — which is exactly the kind of detour this PR closes.

## Test plan

- [x] `uv run pytest tests/sources/ tests/runner/` — 104 passed.
- [x] Pre-commit hooks (`ruff`, `mypy`, `typos`, secret scan, etc.) all clean.
- [x] Verified locally that the dashtastic repro path now raises the actionable `TypeError` from `arg(...)` with a traceback pointing at the offending line, instead of the misleading "manifest out of sync" `RuntimeError`.