### PR TITLE
chore(ci): bump GitHub Action pin SHAs and MISE_VERSION

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -6,4 +6,4 @@
 #
 # Bump `MISE_VERSION` here to upgrade every workflow's mise install in
 # a single edit. Lockstep with `mise.toml`'s tooling pins.
-MISE_VERSION=v2026.5.15
+MISE_VERSION=v2026.5.18

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -65,7 +65,7 @@ jobs:
           name: ${{ inputs.release-tarball-name }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         if: ${{ matrix.platform.emulation }}
         with:
           platforms: all

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@bc0b696b4103f5fe60f15749af68a046868d511a # codeql-bundle-v2.25.4
+        uses: github/codeql-action/init@84498526a009a99c875e83ef4821a8ba52de7c22 # codeql-bundle-v2.25.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@bc0b696b4103f5fe60f15749af68a046868d511a # codeql-bundle-v2.25.4
+        uses: github/codeql-action/autobuild@84498526a009a99c875e83ef4821a8ba52de7c22 # codeql-bundle-v2.25.5
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -73,6 +73,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@bc0b696b4103f5fe60f15749af68a046868d511a # codeql-bundle-v2.25.4
+        uses: github/codeql-action/analyze@84498526a009a99c875e83ef4821a8ba52de7c22 # codeql-bundle-v2.25.5
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           egress-policy: audit
 
       - name: Check For Admin Permission
-        uses: actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e # v2.4.0
+        uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103 # v2.3.0
         with:
           require: admin
           username: ${{ github.triggering_actor }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -76,6 +76,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@bc0b696b4103f5fe60f15749af68a046868d511a # codeql-bundle-v2.25.4
+        uses: github/codeql-action/upload-sarif@84498526a009a99c875e83ef4821a8ba52de7c22 # codeql-bundle-v2.25.5
         with:
           sarif_file: results.sarif

--- a/.github/workflows/sync-rolling-tags.yml
+++ b/.github/workflows/sync-rolling-tags.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Check For Admin Permission
         if: github.event_name == 'workflow_dispatch'
-        uses: actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e # v2.4.0
+        uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103 # v2.3.0
         with:
           require: admin
           username: ${{ github.triggering_actor }}


### PR DESCRIPTION
## Summary

Routine pin maintenance for the workflow files under `.github/`. Picked up automatically by the "Pin GitHub Actions to commit SHAs" prek hook and the lockstep MISE_VERSION header in `.github/env`. No workflow logic changes.

## Forward bumps

| File | Pin | From | To |
|---|---|---|---|
| `.github/env` | `MISE_VERSION` | `v2026.5.15` | `v2026.5.18` |
| `_build.yml` | `docker/setup-qemu-action` | `v4.0.0` (`ce360397…`) | `v4.1.0` (`06116385…`) |
| `codeql.yml` | `github/codeql-action/init` | `codeql-bundle-v2.25.4` (`bc0b696b…`) | `codeql-bundle-v2.25.5` (`84498526…`) |
| `codeql.yml` | `github/codeql-action/autobuild` | `codeql-bundle-v2.25.4` (`bc0b696b…`) | `codeql-bundle-v2.25.5` (`84498526…`) |
| `codeql.yml` | `github/codeql-action/analyze` | `codeql-bundle-v2.25.4` (`bc0b696b…`) | `codeql-bundle-v2.25.5` (`84498526…`) |
| `scorecards.yml` | `github/codeql-action/upload-sarif` | `codeql-bundle-v2.25.4` (`bc0b696b…`) | `codeql-bundle-v2.25.5` (`84498526…`) |

## Re-pin (note)

`release.yml` and `sync-rolling-tags.yml` pin `actions-cool/check-user-permission`. Previously labelled `v2.4.0` (`c21884f3…`); the prek hook re-resolved this to `v2.3.0` (`7b90a27f…`). The v2.4.0 tag is no longer published in the upstream repo, so `v2.3.0` is the highest currently-resolvable ref. Functionally the same admin-permission gate; the SHA now matches the actual tag pointer.

## Test plan

- [x] `prek run --all-files` — all relevant hooks (SHA pin verifier, actionlint, secret scan, codespell, typos) pass.
- [ ] CI matrix on this PR exercises every touched workflow: `_build.yml` runs on push (PR build), `codeql.yml` on push and weekly schedule, `scorecards.yml` weekly. `release.yml` / `sync-rolling-tags.yml` only fire on explicit dispatch, so they're verified indirectly via the SHA pin verifier rather than a live run.

## Out of scope

- Anything beyond pin SHAs / `MISE_VERSION`. Workflow logic is untouched.