### PR TITLE
fix(parser): split command_group docstring into title + description

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,26 @@ this file to empty for the next cycle.
 Empty between releases is the steady-state — there's no header,
 no scaffolding. Just write whatever should appear in the notes.
 -->
+
+## Bug fixes
+
+### `command_group(docstring=...)` now splits the docstring into title + description
+
+`command_group("name", docstring=__doc__)` previously stuffed the entire
+docstring into the group's `description` field and left `title` empty,
+so the blurb never appeared next to the group in the parent `--help`
+listing (clap shows `about`, which is what `title` populates). The
+parser now mirrors how `@command` function docstrings are handled — the
+first paragraph becomes the group's `title` (clap's `about`) and the
+remainder becomes the `description` (clap's `long_about`). An explicit
+positional `title=` / `description=` still wins for either side.
+
+Both the static parser (`parser/groups.rs`) and the runtime decorator
+(`toolr._decorators.command_group`) now go through the same shared
+`parse_docstring` helper, so static-manifest output and runtime
+introspection agree. The runtime's old `title = name` fallback —
+which would have produced a redundant `dbt-config  dbt-config` in
+the parent listing — has been removed; an unset title now stays
+empty, matching the static parser.
+
+See [#292](https://github.com/s0undt3ch/ToolR/issues/292).

--- a/crates/toolr-core/src/parser/commands.rs
+++ b/crates/toolr-core/src/parser/commands.rs
@@ -5,12 +5,12 @@ use std::collections::HashMap;
 use ruff_python_ast::{Decorator, Expr, ModModule, Stmt, StmtFunctionDef};
 
 use super::groups::GroupBinding;
+use super::parse_docstring;
 use super::signatures::extract_arguments;
 use super::symbols::ArgSectionTable;
 use super::symbols::EnumTable;
 use super::symbols::TypeAliasTable;
 use super::types::{SourcesImports, TypeImports, TypeResolutionError, resolve_arguments};
-use crate::SimpleDocstringParser;
 use crate::manifest::{Command, Origin};
 
 type GlobalVars = HashMap<String, String>;
@@ -236,7 +236,7 @@ fn build_command(
     errors: &mut Vec<TypeResolutionError>,
 ) -> Command {
     let raw_doc = function_docstring(func);
-    let parsed = SimpleDocstringParser::new().parse(&raw_doc).ok();
+    let parsed = parse_docstring(&raw_doc);
     let summary = parsed
         .as_ref()
         .map(|d| d.short_description.clone())

--- a/crates/toolr-core/src/parser/groups.rs
+++ b/crates/toolr-core/src/parser/groups.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use ruff_python_ast::{Expr, ExprCall, ModModule, Stmt, StmtAssign};
 
+use super::parse_docstring;
 use crate::manifest::{Group, Origin};
 
 /// A group binding extracted from source. The `var` is the Python local name
@@ -178,21 +179,22 @@ fn parse_group_call(
     } else {
         (raw_name, parent)
     };
-    let title = call
-        .arguments
-        .args
-        .get(1)
-        .and_then(literal_str)
+    let positional_title = call.arguments.args.get(1).and_then(literal_str);
+    let explicit_description =
+        description_kwarg(call).or_else(|| call.arguments.args.get(2).and_then(literal_str));
+    // When `docstring=` is supplied, split it the same way `parser/commands.rs`
+    // splits function docstrings: the first paragraph becomes the short
+    // `title` (clap's `about`, shown in the parent's command listing) and
+    // the remainder becomes the long `description` (clap's `long_about`).
+    // Either explicit positional title / `description=` still wins so callers
+    // can override one side without losing the other.
+    let parsed_doc =
+        docstring_kwarg(call, module_docstring).and_then(|raw| parse_docstring(&raw));
+    let title = positional_title
+        .or_else(|| parsed_doc.as_ref().map(|d| d.short_description.clone()))
         .unwrap_or_default();
-    // Description precedence (matches the Python decorator's resolution
-    // order in `toolr._decorators.command_group`):
-    //   1. `description=` kwarg (explicit, wins).
-    //   2. Third positional argument.
-    //   3. `docstring=` kwarg (may resolve to module __doc__).
-    //   4. Empty string.
-    let description = description_kwarg(call)
-        .or_else(|| call.arguments.args.get(2).and_then(literal_str))
-        .or_else(|| docstring_kwarg(call, module_docstring))
+    let description = explicit_description
+        .or_else(|| parsed_doc.and_then(|d| d.long_description))
         .unwrap_or_default();
     Some(GroupBinding {
         var: var.to_string(),
@@ -261,11 +263,68 @@ mod tests {
     }
 
     #[test]
-    fn resolves_docstring_keyword_to_module_doc() {
+    fn explicit_title_keeps_docstring_long_description() {
+        // When the caller passes both a positional title and a docstring,
+        // the title wins for the short slot but the docstring's long
+        // paragraph still populates `description` (clap's `long_about`).
         let src = r#"group = command_group("ci", "CI utilities", docstring=__doc__)"#;
         let m = parse_src(src);
-        let groups = extract_groups(&m, "module-level doc", &HashMap::new());
-        assert_eq!(groups[0].group.description, "module-level doc");
+        let groups = extract_groups(
+            &m,
+            "First paragraph short.\n\nLong paragraph body.",
+            &HashMap::new(),
+        );
+        assert_eq!(groups[0].group.title, "CI utilities");
+        assert_eq!(groups[0].group.description, "Long paragraph body.");
+    }
+
+    #[test]
+    fn docstring_first_paragraph_becomes_title() {
+        // Single-line docstring: short_description fills `title`,
+        // `description` ends up empty (no long paragraph).
+        let src = r#"group = command_group("dbt-config", docstring=__doc__)"#;
+        let m = parse_src(src);
+        let groups = extract_groups(
+            &m,
+            "Paddle's dbt config and setup routines.",
+            &HashMap::new(),
+        );
+        assert_eq!(groups[0].group.title, "Paddle's dbt config and setup routines.");
+        assert_eq!(groups[0].group.description, "");
+    }
+
+    #[test]
+    fn docstring_long_paragraph_becomes_description() {
+        // Two-paragraph docstring: first paragraph → title,
+        // remainder → description.
+        let src = r#"group = command_group("ci", docstring=__doc__)"#;
+        let m = parse_src(src);
+        let groups = extract_groups(
+            &m,
+            "Short blurb for parent listing.\n\nLonger prose shown by --help only.",
+            &HashMap::new(),
+        );
+        assert_eq!(groups[0].group.title, "Short blurb for parent listing.");
+        assert_eq!(
+            groups[0].group.description,
+            "Longer prose shown by --help only."
+        );
+    }
+
+    #[test]
+    fn explicit_description_kwarg_wins_over_docstring_long() {
+        // `description=` is the explicit-override slot — when both it
+        // and a docstring are present, the kwarg keeps `description`
+        // but the docstring's first line still fills `title`.
+        let src = r#"group = command_group("ci", description="kw-desc", docstring=__doc__)"#;
+        let m = parse_src(src);
+        let groups = extract_groups(
+            &m,
+            "Short title from docstring.\n\nLong paragraph ignored.",
+            &HashMap::new(),
+        );
+        assert_eq!(groups[0].group.title, "Short title from docstring.");
+        assert_eq!(groups[0].group.description, "kw-desc");
     }
 
     #[test]

--- a/crates/toolr-core/src/parser/mod.rs
+++ b/crates/toolr-core/src/parser/mod.rs
@@ -6,6 +6,16 @@ use anyhow::{Context, Result};
 use ruff_python_ast::ModModule;
 use ruff_python_parser::parse_module;
 
+/// Parse a raw docstring into the project's `Docstring` struct via the
+/// shared `SimpleDocstringParser`. Returns `None` only if the parser
+/// rejects the input (very unusual — in practice it accepts every
+/// docstring shape). Used by both `@command` function docstrings and
+/// `command_group(docstring=...)` so the "first paragraph → short,
+/// remainder → long" contract is enforced in one place.
+pub(crate) fn parse_docstring(raw: &str) -> Option<crate::Docstring> {
+    crate::SimpleDocstringParser::new().parse(raw).ok()
+}
+
 pub mod groups;
 pub use groups::{GroupBinding, extract_groups};
 

--- a/crates/toolr-py/python/toolr/_decorators.py
+++ b/crates/toolr-py/python/toolr/_decorators.py
@@ -246,14 +246,19 @@ def command_group(
     before the final dot is the parent's full path; explicit
     ``parent=`` is ignored in that case.
 
-    If you pass ``docstring``, you won't be allowed to pass ``description`` or ``long_description``.
-    Those will be parsed by [docstring-parser](https://pypi.org/project/docstring-parser/).
-    The first line of the docstring will be used as the description, the rest will be used as the long description.
+    If you pass ``docstring``, you won't be allowed to pass ``description`` or
+    ``long_description``. The docstring is parsed with the same parser used for
+    ``@command`` function docstrings: the first paragraph becomes the group's
+    ``title`` (clap's ``about``, shown next to the group name in the parent's
+    command listing) and the remainder becomes the ``description`` (clap's
+    ``long_about``, shown when the user runs ``toolr <group> --help``). Pass an
+    explicit ``title=`` or ``description=`` to override either side.
 
     Args:
         name: Name of the command group; may include dotted parent path.
-        title: Optional short title shown in --help. Defaults to the
-            leaf name when omitted.
+        title: Optional short title shown next to the group name in the
+            parent ``--help`` listing. Defaults to the docstring's first
+            paragraph when ``docstring=`` is supplied, otherwise empty.
         description: Description for the command group
         long_description: Long description for the command group
         docstring: Docstring for the command group
@@ -281,8 +286,6 @@ def command_group(
         parent = f"tools.{parent}"
     elif parent is None:
         parent = "tools"
-    if not title:
-        title = name
 
     collector = _get_command_group_storage()
 
@@ -296,9 +299,16 @@ def command_group(
         if description is not None or long_description is not None:
             err_msg = "You can't pass both docstring and description or long_description"
             raise ValueError(err_msg)
+        # Mirror the static parser (parser/groups.rs) and the `@command`
+        # path (parser/commands.rs): the docstring's first paragraph
+        # populates `title` (clap's `about`); the rest populates
+        # `description` (clap's `long_about`). An explicit `title=`
+        # always wins for the short slot.
         parsed_docstring = Docstring.parse(docstring)
-        description = parsed_docstring.short_description
-        long_description = parsed_docstring.long_description
+        if not title:
+            title = parsed_docstring.short_description
+        description = parsed_docstring.long_description or ""
+        long_description = None
     elif description is None:
         err_msg = "You must at least pass either the 'docstring' or 'description' argument"
         raise ValueError(err_msg)

--- a/skills/toolr-command-authoring/examples/toolr-manifest.json
+++ b/skills/toolr-command-authoring/examples/toolr-manifest.json
@@ -6,14 +6,14 @@
     {
       "name": "db",
       "title": "Database lifecycle",
-      "description": "Database lifecycle commands.\n\nExercise: ``arg_section`` for grouping related flags in ``--help``,\nthe string-attached ``@command(group=...)`` form, mixed positional\nand keyword-only arguments, and a Google-style docstring with\n``Args:`` and ``Examples:`` sections.\n",
+      "description": "Exercise: ``arg_section`` for grouping related flags in ``--help``,\nthe string-attached ``@command(group=...)`` form, mixed positional\nand keyword-only arguments, and a Google-style docstring with\n``Args:`` and ``Examples:`` sections.",
       "parent": null,
       "origin": "static"
     },
     {
       "name": "greet",
       "title": "Say hello in various ways",
-      "description": "Greeting commands.\n\nExercise: top-level group, two commands, the bound and the\nstring-attached ``@command`` forms, a ``str`` argument with a\ndefault, a ``bool`` flag, and an ``Annotated[str, arg(...)]``\nmetavar override.\n",
+      "description": "Exercise: top-level group, two commands, the bound and the\nstring-attached ``@command`` forms, a ``str`` argument with a\ndefault, a ``bool`` flag, and an ``Annotated[str, arg(...)]``\nmetavar override.",
       "parent": null,
       "origin": "static"
     }

--- a/skills/toolr-command-authoring/references/commands.md
+++ b/skills/toolr-command-authoring/references/commands.md
@@ -283,14 +283,19 @@ path (``"ci.helm-diff-pr-comment"``). When dotted, everything
 before the final dot is the parent's full path; explicit
 ``parent=`` is ignored in that case.
 
-If you pass ``docstring``, you won't be allowed to pass ``description`` or ``long_description``.
-Those will be parsed by [docstring-parser](https://pypi.org/project/docstring-parser/).
-The first line of the docstring will be used as the description, the rest will be used as the long description.
+If you pass ``docstring``, you won't be allowed to pass ``description`` or
+``long_description``. The docstring is parsed with the same parser used for
+``@command`` function docstrings: the first paragraph becomes the group's
+``title`` (clap's ``about``, shown next to the group name in the parent's
+command listing) and the remainder becomes the ``description`` (clap's
+``long_about``, shown when the user runs ``toolr <group> --help``). Pass an
+explicit ``title=`` or ``description=`` to override either side.
 
 Args:
     name: Name of the command group; may include dotted parent path.
-    title: Optional short title shown in --help. Defaults to the
-        leaf name when omitted.
+    title: Optional short title shown next to the group name in the
+        parent ``--help`` listing. Defaults to the docstring's first
+        paragraph when ``docstring=`` is supplied, otherwise empty.
     description: Description for the command group
     long_description: Long description for the command group
     docstring: Docstring for the command group

--- a/tests/decorators/test_decorators_unit.py
+++ b/tests/decorators/test_decorators_unit.py
@@ -28,13 +28,16 @@ from toolr._decorators import command_group
 from toolr._exc import ToolrDeprecationWarning
 
 
-@pytest.fixture
-def clean_registry() -> Iterator[None]:
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
     """Snapshot + restore the process-wide command-group storage.
 
-    Without this, registrations from one test leak into another and
-    `command_group(name, ...)` returns the cached instance instead of
-    walking the freshly-exercised code paths.
+    Autouse: every test in this module exercises ``command_group``
+    registration, and without isolation a registration from one test
+    leaks into the next so ``command_group(name, ...)`` returns the
+    cached instance instead of walking the freshly-exercised code
+    paths. The fixture has no value to inject, so consumers don't need
+    to name it as a parameter.
     """
     storage = _get_command_group_storage()
     saved = dict(storage)
@@ -70,8 +73,7 @@ def test_command_group_full_name_for_nested_returns_dotted_path():
 # --------------------------------------------------------------------
 
 
-def test_group_command_decorator_returns_callable_unchanged(clean_registry: None):
-    del clean_registry
+def test_group_command_decorator_returns_callable_unchanged():
     g = command_group("legacy", "Legacy", description="Legacy group for tests")
 
     with warnings.catch_warnings():
@@ -86,8 +88,7 @@ def test_group_command_decorator_returns_callable_unchanged(clean_registry: None
     assert f.__name__ == "f"
 
 
-def test_group_command_with_explicit_name_returns_decorator(clean_registry: None):
-    del clean_registry
+def test_group_command_with_explicit_name_returns_decorator():
     g = command_group("legacy", "Legacy", description="Legacy group for tests")
     with warnings.catch_warnings():
         warnings.simplefilter("error", ToolrDeprecationWarning)
@@ -99,10 +100,9 @@ def test_group_command_with_explicit_name_returns_decorator(clean_registry: None
     assert decorator(f) is f
 
 
-def test_parent_command_group_method_still_emits_deprecation(clean_registry: None):
+def test_parent_command_group_method_still_emits_deprecation():
     """The bound-subgroup form (`parent.command_group("child", ...)`) is
     still on track for removal in toolr 1.0 — guard the warning stays."""
-    del clean_registry
     parent = command_group("legacy_parent", "Parent", description="Parent group")
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", ToolrDeprecationWarning)
@@ -163,10 +163,7 @@ def test_command_parameterised_form_with_string_first_arg():
 # --------------------------------------------------------------------
 
 
-def test_command_group_with_dotted_name_splits_into_parent_and_leaf(
-    clean_registry: None,
-):
-    del clean_registry
+def test_command_group_with_dotted_name_splits_into_parent_and_leaf():
     g = command_group("docker.diff", "Docker Diff", description="Docker diff group")
     assert g.name == "diff"
     assert g.parent == "tools.docker"
@@ -174,10 +171,8 @@ def test_command_group_with_dotted_name_splits_into_parent_and_leaf(
 
 
 def test_command_group_dotted_name_overrides_explicit_parent_with_warning(
-    clean_registry: None,
     caplog: pytest.LogCaptureFixture,
 ):
-    del clean_registry
     with caplog.at_level(logging.WARNING, logger="toolr._decorators"):
         g = command_group(
             "docker.diff", "Docker Diff", description="Docker diff group", parent="wrong"
@@ -187,10 +182,8 @@ def test_command_group_dotted_name_overrides_explicit_parent_with_warning(
 
 
 def test_command_group_dotted_name_explicit_parent_matches_no_warning(
-    clean_registry: None,
     caplog: pytest.LogCaptureFixture,
 ):
-    del clean_registry
     with caplog.at_level(logging.WARNING, logger="toolr._decorators"):
         g = command_group("docker.diff", "Docker Diff", description="Docker diff", parent="docker")
     assert g.parent == "tools.docker"
@@ -198,35 +191,57 @@ def test_command_group_dotted_name_explicit_parent_matches_no_warning(
     assert not any("dotted path" in r.message for r in caplog.records)
 
 
-def test_command_group_parent_kwarg_gets_tools_prefix(clean_registry: None):
-    del clean_registry
+def test_command_group_parent_kwarg_gets_tools_prefix():
     g = command_group("diff", description="Diff", parent="docker")
     assert g.parent == "tools.docker"
 
 
-def test_command_group_parent_already_prefixed_left_alone(clean_registry: None):
-    del clean_registry
+def test_command_group_parent_already_prefixed_left_alone():
     g = command_group("diff", description="Diff", parent="tools.docker")
     assert g.parent == "tools.docker"
 
 
-def test_command_group_with_no_parent_defaults_to_tools(clean_registry: None):
-    del clean_registry
+def test_command_group_with_no_parent_defaults_to_tools():
     g = command_group("ci", description="CI")
     assert g.parent == "tools"
 
 
-def test_command_group_blank_title_defaults_to_leaf_name(clean_registry: None):
-    del clean_registry
+def test_command_group_blank_title_stays_empty_when_no_docstring():
+    # With no `docstring=` to populate it, an unset title stays empty —
+    # clap renders the group name on its own in the parent listing rather
+    # than duplicating the leaf name as a redundant "about" string.
     g = command_group("ci", description="CI")
-    assert g.title == "ci"
+    assert g.title == ""
+
+
+def test_command_group_docstring_first_paragraph_becomes_title():
+    g = command_group("ci", docstring="Short title for parent listing.")
+    assert g.title == "Short title for parent listing."
+    assert g.description == ""
+
+
+def test_command_group_docstring_long_paragraph_becomes_description():
+    g = command_group(
+        "ci",
+        docstring="Short title for parent listing.\n\nLonger prose shown by --help only.",
+    )
+    assert g.title == "Short title for parent listing."
+    assert g.description == "Longer prose shown by --help only."
+
+
+def test_command_group_explicit_title_overrides_docstring_short():
+    g = command_group(
+        "ci",
+        "Explicit Title",
+        docstring="Short title from docstring.\n\nLong paragraph kept as description.",
+    )
+    assert g.title == "Explicit Title"
+    assert g.description == "Long paragraph kept as description."
 
 
 def test_command_group_returns_existing_instance_on_second_call(
-    clean_registry: None,
     caplog: pytest.LogCaptureFixture,
 ):
-    del clean_registry
     first = command_group("ci", "CI", description="CI")
     with caplog.at_level(logging.DEBUG, logger="toolr._decorators"):
         second = command_group("ci", "CI", description="CI")

--- a/tests/introspect/test_introspect_unit.py
+++ b/tests/introspect/test_introspect_unit.py
@@ -8,8 +8,8 @@ the in-process test runner. This file calls the module's helpers
 directly so the coverage counter actually moves.
 
 Tests run against a clean copy of the command-group registry per
-test, restored via `_with_clean_registry` so user-defined tools
-fixtures from one test don't leak into another.
+test (opt in via ``@pytest.mark.usefixtures("clean_registry")``) so
+user-defined tools fixtures from one test don't leak into another.
 """
 
 from __future__ import annotations
@@ -21,7 +21,6 @@ import sys
 import textwrap
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -41,17 +40,21 @@ from toolr._introspect import main
 
 
 @pytest.fixture
-def clean_registry() -> Iterator[dict[str, Any]]:
+def clean_registry() -> Iterator[None]:
     """Snapshot + restore the command-group registry across each test.
 
     `command_group(...)` calls inside test fixtures register into a
     process-wide dict. Without this fixture, registrations leak into
     later tests and `_walk_registry` produces non-deterministic output.
+
+    Apply via ``@pytest.mark.usefixtures("clean_registry")`` — the
+    fixture has no value to inject so consumers don't need to name it
+    as a parameter.
     """
     storage = _get_command_group_storage()
     saved = dict(storage)
     storage.clear()
-    yield storage
+    yield
     storage.clear()
     storage.update(saved)
 
@@ -121,18 +124,16 @@ def tools_fixture(tmp_path: Path, isolated_sys_path: None) -> Path:
 # --------------------------------------------------------------------
 
 
-def test_ensure_tools_on_syspath_noop_when_path_is_empty(isolated_sys_path: None) -> None:
-    del isolated_sys_path
+@pytest.mark.usefixtures("isolated_sys_path")
+def test_ensure_tools_on_syspath_noop_when_path_is_empty() -> None:
     before = list(sys.path)
     _ensure_tools_on_syspath(None)
     _ensure_tools_on_syspath("")
     assert sys.path == before
 
 
-def test_ensure_tools_on_syspath_inserts_parent_of_tools_root(
-    tmp_path: Path, isolated_sys_path: None
-) -> None:
-    del isolated_sys_path
+@pytest.mark.usefixtures("isolated_sys_path")
+def test_ensure_tools_on_syspath_inserts_parent_of_tools_root(tmp_path: Path) -> None:
     tools_root = tmp_path / "tools"
     tools_root.mkdir()
     _ensure_tools_on_syspath(str(tools_root))
@@ -219,11 +220,8 @@ def test_command_entry_falls_back_to_empty_string_when_module_is_falsy() -> None
 # --------------------------------------------------------------------
 
 
-def test_import_tools_modules_returns_silently_when_no_tools_package(
-    tmp_path: Path,
-    isolated_sys_path: None,
-) -> None:
-    del isolated_sys_path
+@pytest.mark.usefixtures("isolated_sys_path")
+def test_import_tools_modules_returns_silently_when_no_tools_package(tmp_path: Path) -> None:
     # Place a directory that is NOT named `tools` on sys.path — import
     # of `tools` will hit ModuleNotFoundError and bail without errors.
     sys.path.insert(0, str(tmp_path))
@@ -232,11 +230,8 @@ def test_import_tools_modules_returns_silently_when_no_tools_package(
     assert warnings == []
 
 
-def test_import_tools_modules_walks_user_tools(
-    tools_fixture: Path,
-    clean_registry: dict[str, Any],
-) -> None:
-    del clean_registry
+@pytest.mark.usefixtures("clean_registry")
+def test_import_tools_modules_walks_user_tools(tools_fixture: Path) -> None:
     _ensure_tools_on_syspath(str(tools_fixture))
     warnings: list[str] = []
     _import_tools_modules(warnings)
@@ -246,12 +241,8 @@ def test_import_tools_modules_walks_user_tools(
     assert any(name.endswith(".demo") or name == "tools.demo" for name in storage)
 
 
-def test_import_tools_modules_collects_warnings_for_broken_modules(
-    tmp_path: Path,
-    isolated_sys_path: None,
-    clean_registry: dict[str, Any],
-) -> None:
-    del isolated_sys_path, clean_registry
+@pytest.mark.usefixtures("isolated_sys_path", "clean_registry")
+def test_import_tools_modules_collects_warnings_for_broken_modules(tmp_path: Path) -> None:
     tools = tmp_path / "tools"
     tools.mkdir()
     (tools / "__init__.py").write_text("")
@@ -267,20 +258,15 @@ def test_import_tools_modules_collects_warnings_for_broken_modules(
 # --------------------------------------------------------------------
 
 
-def test_walk_registry_returns_empty_for_unpopulated_registry(
-    clean_registry: dict[str, Any],
-) -> None:
-    del clean_registry
+@pytest.mark.usefixtures("clean_registry")
+def test_walk_registry_returns_empty_for_unpopulated_registry() -> None:
     groups, commands = _walk_registry()
     assert groups == []
     assert commands == []
 
 
-def test_walk_registry_yields_groups_and_commands(
-    tools_fixture: Path,
-    clean_registry: dict[str, Any],
-) -> None:
-    del clean_registry
+@pytest.mark.usefixtures("clean_registry")
+def test_walk_registry_yields_groups_and_commands(tools_fixture: Path) -> None:
     _ensure_tools_on_syspath(str(tools_fixture))
     _import_tools_modules([])
     groups, commands = _walk_registry()
@@ -292,11 +278,8 @@ def test_walk_registry_yields_groups_and_commands(
     assert demo["origin"] == "dynamic"
 
 
-def test_build_payload_returns_schema_and_collected_state(
-    tools_fixture: Path,
-    clean_registry: dict[str, Any],
-) -> None:
-    del clean_registry
+@pytest.mark.usefixtures("clean_registry")
+def test_build_payload_returns_schema_and_collected_state(tools_fixture: Path) -> None:
     payload = build_payload(str(tools_fixture))
     assert payload["payload_schema_version"] == PAYLOAD_SCHEMA_VERSION
     assert any(g["name"] == "demo" for g in payload["groups"])
@@ -304,12 +287,10 @@ def test_build_payload_returns_schema_and_collected_state(
     assert payload["warnings"] == []
 
 
+@pytest.mark.usefixtures("clean_registry", "isolated_sys_path")
 def test_build_payload_with_no_tools_root_returns_empty_state(
-    clean_registry: dict[str, Any],
-    isolated_sys_path: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    del clean_registry, isolated_sys_path
     # `build_payload(None)` still tries to import `tools`. The dev workspace
     # has a real `tools` package on sys.path that would register groups and
     # invalidate the "empty state" assertion — stub the import out.
@@ -332,12 +313,11 @@ def test_build_payload_with_no_tools_root_returns_empty_state(
 # --------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures("clean_registry")
 def test_main_emits_json_payload_to_stdout(
     capsys: pytest.CaptureFixture[str],
     tools_fixture: Path,
-    clean_registry: dict[str, Any],
 ) -> None:
-    del clean_registry
     rc = main(["--tools-root", str(tools_fixture)])
     assert rc == 0
     captured = capsys.readouterr()
@@ -346,13 +326,11 @@ def test_main_emits_json_payload_to_stdout(
     assert any(g["name"] == "demo" for g in payload["groups"])
 
 
+@pytest.mark.usefixtures("clean_registry", "isolated_sys_path")
 def test_main_emits_empty_payload_when_no_tools_root(
     capsys: pytest.CaptureFixture[str],
-    clean_registry: dict[str, Any],
-    isolated_sys_path: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    del clean_registry, isolated_sys_path
     real_import_module = importlib.import_module
 
     def fake_import_module(name: str, package: str | None = None) -> object:

--- a/tests/registry/test_command_group_errors.py
+++ b/tests/registry/test_command_group_errors.py
@@ -24,15 +24,23 @@ def test_command_group_with_both_docstring_and_description():
 
 
 def test_command_group_with_docstring_parsing():
-    """Test command_group with docstring parsing."""
+    """Test command_group with docstring parsing.
+
+    The docstring's first paragraph populates ``title`` (clap's ``about``)
+    and the remainder populates ``description`` (clap's ``long_about``),
+    mirroring how ``@command`` function docstrings are parsed by
+    ``crates/toolr-core/src/parser/commands.rs``. An explicit positional
+    title overrides the short slot.
+    """
     group = command_group(
         "docstring_test",
         "Docstring Test",
         docstring="Short description.\n\nLong description with more details.",
     )
 
-    assert group.description == "Short description."
-    assert group.long_description == "Long description with more details."
+    assert group.title == "Docstring Test"
+    assert group.description == "Long description with more details."
+    assert group.long_description is None
 
 
 def test_command_group_full_name_with_parent():


### PR DESCRIPTION
## Summary

Fixes [#292](https://github.com/s0undt3ch/ToolR/issues/292) — `command_group("name", docstring=__doc__)` now splits the docstring into `title` + `description` the same way `@command` splits function docstrings.

- **Static parser** (`crates/toolr-core/src/parser/groups.rs`): the `docstring=` kwarg is run through the shared parser. First paragraph → `title` (clap's `about`, shown in the parent's command listing). Remainder → `description` (clap's `long_about`). Explicit positional `title=` / `description=` still win.
- **Runtime decorator** (`toolr._decorators.command_group`): mirrors the same split so runtime introspection matches the static manifest. Drops the `title = name` fallback that would otherwise produce a redundant `dbt-config  dbt-config` row in `toolr -h`.
- **Shared helper** (`parser/mod.rs::parse_docstring`): both `parser/groups.rs` and `parser/commands.rs` now go through this single helper, so the "first paragraph → short, rest → long" convention lives in one place.

The skill-authoring example manifest snapshot was regenerated to reflect the new (correct) titles, and the public docstring + `references/commands.md` were updated.

### Fixture cleanup (second commit)

While in the area, the `del clean_registry` / `del isolated_sys_path` pattern in `tests/decorators/test_decorators_unit.py` and `tests/introspect/test_introspect_unit.py` is gone. The decorators file makes `clean_registry` `autouse=True` (every test in it needs the snapshot/restore isolation); the introspect file uses `@pytest.mark.usefixtures(...)` where only some tests need each fixture. 22 `del <fixture>` lines removed; no behavioural change to the tests.

## Test plan

- [x] `cargo test -p toolr-core` — 470 + 4 + 1 + 0 passing.
- [x] New unit tests in `parser/groups.rs`: short docstring → title, multi-paragraph docstring → title + description, explicit `description=` overrides docstring-long, explicit positional `title` overrides docstring-short.
- [x] New / updated decorator tests in `tests/decorators/test_decorators_unit.py` and `tests/registry/test_command_group_errors.py` cover the same matrix from the Python side.
- [x] Skill-examples snapshot regenerated (`cargo test -p toolr-core --test skill_authoring_examples -- --ignored regenerate`) and re-asserted.
- [x] `pytest tests/decorators tests/registry tests/introspect tests/runner tests/sources` — 165 passing.
- [x] `prek run --files ...` — full local lint/typecheck/format chain passes.
- [ ] CI green.