### PR TITLE
fix(parser): route description through `full_description`; `--help` shows Examples/Notes

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,32 @@ this file to empty for the next cycle.
 Empty between releases is the steady-state — there's no header,
 no scaffolding. Just write whatever should appear in the notes.
 -->
+
+## Enhancements
+
+### `--help` now renders the full docstring (Examples, Notes, …); `-h` stays short
+
+Building on the title/description split shipped in 0.22.1, both
+`command_group(docstring=__doc__)` and `@command`-decorated function
+docstrings now feed clap a multi-section render for `long_about`. The
+first paragraph still drives the short `about` slot (shown next to the
+name in the parent listing and on `-h`), but `--help` now shows the
+short summary plus the long body plus any `Examples` / `Notes` /
+`Warnings` / `See Also` / `References` / `Todo` / `Deprecated` /
+`Version Added` sections from the docstring. `Args:` / `Arguments:`
+stay out of the prose — they already appear as per-argument help
+blocks.
+
+Side-effects:
+
+- `toolr <group> <cmd> -h` and `toolr <group> <cmd> --help` now differ:
+  short form is just the summary, long form is the full render. The
+  previous behaviour of always printing the long form on both was a
+  paper-over from when `description` carried only the body paragraph.
+- The shared rendering logic now lives exclusively in Rust
+  (`toolr_core::docstrings::Docstring::full_description`), exposed to
+  Python via PyO3. The parallel Python re-implementation in
+  `toolr.utils._docstrings.Docstring.full_description` has been removed
+  so the two surfaces can't drift.
+
+See [#292](https://github.com/s0undt3ch/ToolR/issues/292).

--- a/crates/toolr-core/src/docstrings.rs
+++ b/crates/toolr-core/src/docstrings.rs
@@ -30,6 +30,93 @@ pub struct Docstring {
     pub version_changed: Vec<VersionChanged>,
 }
 
+impl Docstring {
+    /// Render the parsed docstring back into a single multi-section
+    /// string suitable for clap's `long_about` slot. The output starts
+    /// with the short description (so `toolr <group> --help` repeats
+    /// the blurb readers also see in the parent listing) and appends
+    /// each populated section in source order. Mirrors the Python
+    /// `Docstring.full_description` property in
+    /// `crates/toolr-py/python/toolr/utils/_docstrings.py`.
+    pub fn full_description(&self) -> String {
+        let mut out = self.short_description.clone();
+
+        if let Some(long) = &self.long_description {
+            if !long.is_empty() {
+                out.push_str("\n\n");
+                out.push_str(long);
+                out.push('\n');
+            }
+        }
+
+        if !self.examples.is_empty() {
+            out.push_str("\nExamples:");
+            for example in &self.examples {
+                let mut description = example.description.clone();
+                if !description.starts_with("- ") && !description.starts_with("* ") {
+                    description = format!("- {description}");
+                }
+                out.push_str("\n\n");
+                out.push_str(&description);
+                if !example.snippet.is_empty() {
+                    out.push_str("\n\n```\n");
+                    out.push_str(&example.snippet);
+                    out.push_str("\n```");
+                }
+            }
+        }
+
+        append_bullet_section(&mut out, "Notes", &self.notes);
+        append_bullet_section(&mut out, "Warnings", &self.warnings);
+        append_bullet_section(&mut out, "See Also", &self.see_also);
+        append_bullet_section(&mut out, "References", &self.references);
+        append_bullet_section(&mut out, "Todo", &self.todo);
+
+        if let Some(deprecated) = &self.deprecated {
+            out.push_str("\n\nDeprecated:\n");
+            out.push_str(deprecated);
+        }
+
+        if let Some(version_added) = &self.version_added {
+            out.push_str("\n\nVersion Added: ");
+            out.push_str(version_added);
+        }
+
+        if !self.version_changed.is_empty() {
+            out.push_str("\n\nVersion Changed:\n");
+            for vc in &self.version_changed {
+                out.push_str("- ");
+                out.push_str(&vc.version);
+                out.push_str(": ");
+                out.push_str(&vc.description);
+                out.push('\n');
+            }
+        }
+
+        out
+    }
+}
+
+/// Append a bulleted ``Section:\n- a\n- b`` block to ``out`` when
+/// ``items`` is non-empty. Existing leading ``- ``/``* `` bullets are
+/// preserved verbatim; otherwise we prefix each line with ``- ``.
+fn append_bullet_section(out: &mut String, title: &str, items: &[String]) {
+    if items.is_empty() {
+        return;
+    }
+    out.push_str("\n\n");
+    out.push_str(title);
+    out.push_str(":\n");
+    for item in items {
+        let prefixed = if item.starts_with("- ") || item.starts_with("* ") {
+            item.clone()
+        } else {
+            format!("- {item}")
+        };
+        out.push('\n');
+        out.push_str(&prefixed);
+    }
+}
 
 /// Represents an example in the docstring
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/toolr-core/src/docstrings/full_description_test.rs
+++ b/crates/toolr-core/src/docstrings/full_description_test.rs
@@ -1,0 +1,197 @@
+// Direct unit coverage for ``Docstring::full_description`` — the
+// rendered text fed to clap's ``long_about`` slot for both
+// ``command_group(docstring=...)`` and ``@command``-decorated function
+// docstrings. Each section header (Examples / Notes / Warnings /
+// See Also / References / Todo / Deprecated / Version Added /
+// Version Changed) gets its own branch in the renderer; this file
+// exercises every one so a regression that drops a section can't
+// land silently.
+#[cfg(test)]
+mod full_description_test {
+    use crate::docstrings::SimpleDocstringParser;
+
+    fn render(docstring: &str) -> String {
+        SimpleDocstringParser::new()
+            .parse(docstring)
+            .expect("parse failed")
+            .full_description()
+    }
+
+    #[test]
+    fn empty_docstring_renders_empty_string() {
+        // No short, no long, no sections → empty output. Guards the
+        // "no leading paragraph to anchor on" path.
+        assert_eq!(render(""), "");
+    }
+
+    #[test]
+    fn short_only_renders_just_the_short_paragraph() {
+        // Single-line docstring: ``full_description`` returns the
+        // short paragraph verbatim with no trailing whitespace.
+        assert_eq!(render("Short paragraph."), "Short paragraph.");
+    }
+
+    #[test]
+    fn short_plus_long_separates_with_blank_line_and_trailing_newline() {
+        // The renderer appends ``\n\n<long>\n`` so the resulting
+        // ``long_about`` string is markdown-friendly and lets the
+        // section blocks that follow start on their own line.
+        let out = render("Short paragraph.\n\nLong body paragraph.");
+        assert_eq!(out, "Short paragraph.\n\nLong body paragraph.\n");
+    }
+
+    #[test]
+    fn examples_section_renders_with_bullet_per_entry() {
+        // ``Examples:`` is a multi-entry section; each example gets
+        // a ``- `` bullet unless the line already starts with one.
+        // Entries are blank-line separated in the source docstring.
+        let out = render(
+            "Short.\n\nExamples:\n    First example.\n\n    Second example.\n",
+        );
+        assert!(out.contains("Examples:"), "missing Examples header: {out}");
+        assert!(out.contains("- First example."), "missing first example bullet: {out}");
+        assert!(out.contains("- Second example."), "missing second example bullet: {out}");
+    }
+
+    #[test]
+    fn examples_section_with_snippet_emits_fenced_code_block() {
+        // When the parser pulls a fenced code snippet out of an
+        // example, the renderer wraps it in another fenced block so
+        // clap's markdown path preserves the formatting.
+        let docstring = "\
+Short.
+
+Examples:
+    Calling the hello command:
+
+    ```
+    toolr greet hello --who world
+    ```
+";
+        let out = render(docstring);
+        assert!(out.contains("```\n"), "missing fenced code block: {out:?}");
+        assert!(
+            out.contains("toolr greet hello --who world"),
+            "missing snippet body: {out:?}"
+        );
+    }
+
+    #[test]
+    fn examples_section_with_pre_existing_bullet_marker_is_left_alone() {
+        // If an Examples entry already begins with ``- `` (or ``* ``),
+        // the renderer must not double-prefix it. Guards the
+        // bullet-detection branch.
+        let out = render("Short.\n\nExamples:\n    - Already a bullet.\n");
+        assert!(
+            out.contains("- Already a bullet."),
+            "bullet was rewritten: {out}"
+        );
+        assert!(
+            !out.contains("- - Already a bullet."),
+            "bullet was double-prefixed: {out}"
+        );
+    }
+
+    #[test]
+    fn notes_section_renders_as_bullet_list() {
+        let out = render("Short.\n\nNotes:\n    Heads up.\n    Second note.\n");
+        assert!(out.contains("Notes:\n"), "missing Notes header: {out}");
+        assert!(out.contains("- Heads up."), "missing first note: {out}");
+        assert!(out.contains("- Second note."), "missing second note: {out}");
+    }
+
+    #[test]
+    fn warnings_section_renders_as_bullet_list() {
+        let out = render("Short.\n\nWarnings:\n    Be careful here.\n");
+        assert!(out.contains("Warnings:\n"), "missing Warnings header: {out}");
+        assert!(out.contains("- Be careful here."), "missing warning bullet: {out}");
+    }
+
+    #[test]
+    fn see_also_section_renders_as_bullet_list() {
+        let out = render("Short.\n\nSee Also:\n    other_function\n    related_module\n");
+        assert!(out.contains("See Also:\n"), "missing See Also header: {out}");
+        assert!(out.contains("- other_function"), "missing first see-also: {out}");
+        assert!(out.contains("- related_module"), "missing second see-also: {out}");
+    }
+
+    #[test]
+    fn references_section_renders_as_bullet_list() {
+        let out = render("Short.\n\nReferences:\n    https://example.com/spec\n");
+        assert!(out.contains("References:\n"), "missing References header: {out}");
+        assert!(
+            out.contains("- https://example.com/spec"),
+            "missing reference bullet: {out}"
+        );
+    }
+
+    #[test]
+    fn todo_section_renders_as_bullet_list() {
+        let out = render("Short.\n\nTodo:\n    Improve error messages.\n");
+        assert!(out.contains("Todo:\n"), "missing Todo header: {out}");
+        assert!(
+            out.contains("- Improve error messages."),
+            "missing todo bullet: {out}"
+        );
+    }
+
+    #[test]
+    fn deprecated_section_renders_inline() {
+        // ``Deprecated:`` is a single-string field, not a list — the
+        // renderer emits ``Deprecated:\n<text>`` (no bullet).
+        let out = render("Short.\n\nDeprecated:\n    Removed in 2.0.\n");
+        assert!(out.contains("Deprecated:\n"), "missing Deprecated header: {out}");
+        assert!(
+            out.contains("Removed in 2.0."),
+            "missing deprecated body: {out}"
+        );
+    }
+
+    #[test]
+    fn version_added_section_renders_inline() {
+        // ``Version Added:`` is a single string formatted on one line.
+        let out = render("Short.\n\nVersion Added:\n    1.5.0\n");
+        assert!(
+            out.contains("Version Added: 1.5.0"),
+            "missing Version Added line: {out}"
+        );
+    }
+
+    #[test]
+    fn version_changed_section_renders_each_entry_on_its_own_line() {
+        // ``Version Changed:`` is a list of (version, description)
+        // pairs. The renderer emits ``- <version>: <description>``
+        // for each one.
+        let out = render(
+            "Short.\n\nVersion Changed:\n    1.2.0: tightened input validation.\n    1.4.0: added X.\n",
+        );
+        assert!(
+            out.contains("Version Changed:\n"),
+            "missing Version Changed header: {out}"
+        );
+        assert!(
+            out.contains("- 1.2.0: tightened input validation."),
+            "missing first version line: {out}"
+        );
+        assert!(
+            out.contains("- 1.4.0: added X."),
+            "missing second version line: {out}"
+        );
+    }
+
+    #[test]
+    fn long_paragraph_is_skipped_when_empty_string() {
+        // If the parser returns ``Some("")`` for long_description (an
+        // edge case where a section header appears immediately after
+        // the short paragraph with no body in between), the renderer
+        // must not insert a phantom ``\n\n\n`` block.
+        let docstring = "Short paragraph.\n\nNotes:\n    A note.\n";
+        let out = render(docstring);
+        // The short paragraph is followed by either ``\n\nNotes:`` or
+        // ``\n\n<long>\nNotes:`` — never ``\n\n\nNotes:``.
+        assert!(
+            !out.contains("\n\n\n"),
+            "empty long_description produced a triple newline: {out:?}"
+        );
+    }
+}

--- a/crates/toolr-core/src/docstrings/tests.rs
+++ b/crates/toolr-core/src/docstrings/tests.rs
@@ -9,3 +9,7 @@ include!("error_handling_test.rs");
 
 // Round-trip guard between KNOWN_SECTION_HEADERS and detect_section.
 include!("known_headers_test.rs");
+
+// Per-section coverage for ``Docstring::full_description`` (the
+// renderer fed to clap's ``long_about`` slot).
+include!("full_description_test.rs");

--- a/crates/toolr-core/src/parser/commands.rs
+++ b/crates/toolr-core/src/parser/commands.rs
@@ -241,9 +241,12 @@ fn build_command(
         .as_ref()
         .map(|d| d.short_description.clone())
         .unwrap_or_default();
+    // Hand clap a multi-section render (short + long + Examples/Notes/…)
+    // for `--help` so users see more than the first paragraph there.
+    // The `summary` field separately drives `-h`'s shorter `about` slot.
     let description = parsed
         .as_ref()
-        .and_then(|d| d.long_description.clone())
+        .map(|d| d.full_description())
         .unwrap_or_default();
     let mut arguments = extract_arguments(func, enums, sources);
     if let Some(d) = parsed.as_ref() {

--- a/crates/toolr-core/src/parser/groups.rs
+++ b/crates/toolr-core/src/parser/groups.rs
@@ -185,7 +185,8 @@ fn parse_group_call(
     // When `docstring=` is supplied, split it the same way `parser/commands.rs`
     // splits function docstrings: the first paragraph becomes the short
     // `title` (clap's `about`, shown in the parent's command listing) and
-    // the remainder becomes the long `description` (clap's `long_about`).
+    // the full rendered docstring (short + long + Examples/Notes/…) becomes
+    // the long `description` (clap's `long_about`, shown on `--help`).
     // Either explicit positional title / `description=` still wins so callers
     // can override one side without losing the other.
     let parsed_doc =
@@ -194,7 +195,7 @@ fn parse_group_call(
         .or_else(|| parsed_doc.as_ref().map(|d| d.short_description.clone()))
         .unwrap_or_default();
     let description = explicit_description
-        .or_else(|| parsed_doc.and_then(|d| d.long_description))
+        .or_else(|| parsed_doc.as_ref().map(|d| d.full_description()))
         .unwrap_or_default();
     Some(GroupBinding {
         var: var.to_string(),
@@ -263,10 +264,11 @@ mod tests {
     }
 
     #[test]
-    fn explicit_title_keeps_docstring_long_description() {
+    fn explicit_title_keeps_docstring_full_description() {
         // When the caller passes both a positional title and a docstring,
-        // the title wins for the short slot but the docstring's long
-        // paragraph still populates `description` (clap's `long_about`).
+        // the title wins for the short slot but the docstring's rendered
+        // ``full_description`` (short + long + sections) still populates
+        // `description` (clap's `long_about`).
         let src = r#"group = command_group("ci", "CI utilities", docstring=__doc__)"#;
         let m = parse_src(src);
         let groups = extract_groups(
@@ -275,13 +277,17 @@ mod tests {
             &HashMap::new(),
         );
         assert_eq!(groups[0].group.title, "CI utilities");
-        assert_eq!(groups[0].group.description, "Long paragraph body.");
+        assert_eq!(
+            groups[0].group.description,
+            "First paragraph short.\n\nLong paragraph body.\n"
+        );
     }
 
     #[test]
     fn docstring_first_paragraph_becomes_title() {
         // Single-line docstring: short_description fills `title`,
-        // `description` ends up empty (no long paragraph).
+        // `description` ends up the same single paragraph (no long
+        // body, no sections to append).
         let src = r#"group = command_group("dbt-config", docstring=__doc__)"#;
         let m = parse_src(src);
         let groups = extract_groups(
@@ -290,13 +296,17 @@ mod tests {
             &HashMap::new(),
         );
         assert_eq!(groups[0].group.title, "Paddle's dbt config and setup routines.");
-        assert_eq!(groups[0].group.description, "");
+        assert_eq!(
+            groups[0].group.description,
+            "Paddle's dbt config and setup routines."
+        );
     }
 
     #[test]
     fn docstring_long_paragraph_becomes_description() {
-        // Two-paragraph docstring: first paragraph → title,
-        // remainder → description.
+        // Two-paragraph docstring: first paragraph → title.
+        // `description` is the full render (short + long), so
+        // `--help` re-states the blurb plus the long body.
         let src = r#"group = command_group("ci", docstring=__doc__)"#;
         let m = parse_src(src);
         let groups = extract_groups(
@@ -307,15 +317,15 @@ mod tests {
         assert_eq!(groups[0].group.title, "Short blurb for parent listing.");
         assert_eq!(
             groups[0].group.description,
-            "Longer prose shown by --help only."
+            "Short blurb for parent listing.\n\nLonger prose shown by --help only.\n"
         );
     }
 
     #[test]
-    fn explicit_description_kwarg_wins_over_docstring_long() {
+    fn explicit_description_kwarg_wins_over_docstring_full() {
         // `description=` is the explicit-override slot — when both it
         // and a docstring are present, the kwarg keeps `description`
-        // but the docstring's first line still fills `title`.
+        // verbatim but the docstring's first line still fills `title`.
         let src = r#"group = command_group("ci", description="kw-desc", docstring=__doc__)"#;
         let m = parse_src(src);
         let groups = extract_groups(

--- a/crates/toolr-py/python/toolr/_decorators.py
+++ b/crates/toolr-py/python/toolr/_decorators.py
@@ -301,13 +301,14 @@ def command_group(
             raise ValueError(err_msg)
         # Mirror the static parser (parser/groups.rs) and the `@command`
         # path (parser/commands.rs): the docstring's first paragraph
-        # populates `title` (clap's `about`); the rest populates
-        # `description` (clap's `long_about`). An explicit `title=`
-        # always wins for the short slot.
+        # populates `title` (clap's `about`); the Rust-rendered
+        # ``full_description`` (short + long + Examples/Notes/…)
+        # populates `description` (clap's `long_about`). An explicit
+        # `title=` always wins for the short slot.
         parsed_docstring = Docstring.parse(docstring)
         if not title:
             title = parsed_docstring.short_description
-        description = parsed_docstring.long_description or ""
+        description = parsed_docstring.full_description
         long_description = None
     elif description is None:
         err_msg = "You must at least pass either the 'docstring' or 'description' argument"

--- a/crates/toolr-py/python/toolr/utils/_docstrings.py
+++ b/crates/toolr-py/python/toolr/utils/_docstrings.py
@@ -21,7 +21,11 @@ class DocstringVersionChanged(msgspec.Struct, frozen=True):
 
 
 class Docstring(msgspec.Struct, frozen=True):
-    """Optimized docstring representation using direct msgspec fields."""
+    """Parsed docstring representation.
+
+    Carries each per-section field plus the Rust-rendered
+    ``full_description`` (suitable for clap's ``long_about`` slot).
+    """
 
     short_description: str
     long_description: str | None = None
@@ -35,6 +39,13 @@ class Docstring(msgspec.Struct, frozen=True):
     deprecated: str | None = None
     version_added: str | None = None
     version_changed: list[DocstringVersionChanged] = msgspec.field(default_factory=list)
+    # Pre-rendered multi-section text (short + long + Examples/Notes/…),
+    # populated by the Rust ``DocstringParser::parse`` extension. We
+    # don't recompute this on the Python side — the Rust struct method
+    # ``toolr_core::docstrings::Docstring::full_description`` is the
+    # single source of truth so a stale Python implementation can't
+    # drift out of sync.
+    full_description: str = ""
 
     @classmethod
     def parse(cls, docstring: str) -> Docstring:
@@ -42,70 +53,3 @@ class Docstring(msgspec.Struct, frozen=True):
         parser = DocstringParser()
         raw_data = parser.parse(docstring)
         return msgspec.convert(raw_data, cls)
-
-    @property
-    def full_description(self) -> str:
-        """
-        Generate a full description combining all docstring sections using markdown.
-        """
-        full_description = self.short_description
-
-        if self.long_description:
-            full_description += f"\n\n{self.long_description}\n"
-
-        if self.examples:
-            full_description += "\nExamples:"
-            for example in self.examples:
-                description = example.description
-                if not description.startswith(("- ", "* ")):
-                    description = f"- {description}"
-                full_description += f"\n\n{description}"
-                if example.snippet:
-                    full_description += f"\n\n```\n{example.snippet}\n```"
-
-        if self.notes:
-            full_description += "\n\nNotes:\n"
-            for note in self.notes:
-                if not note.startswith(("- ", "* ")):
-                    note = f"- {note}"  # noqa: PLW2901
-                full_description += f"\n{note}"
-
-        if self.warnings:
-            full_description += "\n\nWarnings:\n"
-            for warning in self.warnings:
-                if not warning.startswith(("- ", "* ")):
-                    warning = f"- {warning}"  # noqa: PLW2901
-                full_description += f"\n{warning}"
-
-        if self.see_also:
-            full_description += "\n\nSee Also:\n"
-            for see_also in self.see_also:
-                if not see_also.startswith(("- ", "* ")):
-                    see_also = f"- {see_also}"  # noqa: PLW2901
-                full_description += f"\n{see_also}"
-
-        if self.references:
-            full_description += "\n\nReferences:\n"
-            for reference in self.references:
-                if not reference.startswith(("- ", "* ")):
-                    reference = f"- {reference}"  # noqa: PLW2901
-                full_description += f"\n{reference}"
-
-        if self.todo:
-            full_description += "\n\nTodo:\n"
-            for todo in self.todo:
-                if not todo.startswith(("- ", "* ")):
-                    todo = f"- {todo}"  # noqa: PLW2901
-                full_description += f"\n{todo}"
-
-        if self.deprecated:
-            full_description += f"\n\nDeprecated:\n{self.deprecated}"
-
-        if self.version_added:
-            full_description += f"\n\nVersion Added: {self.version_added}"
-
-        if self.version_changed:
-            full_description += "\n\nVersion Changed:\n"
-            for version_changed in self.version_changed:
-                full_description += f"- {version_changed.version}: {version_changed.description}\n"
-        return full_description

--- a/crates/toolr-py/src/lib.rs
+++ b/crates/toolr-py/src/lib.rs
@@ -150,6 +150,10 @@ impl DocstringParser {
     fn parse(&self, docstring: &str) -> PyResult<Py<PyAny>> {
         let result = self.parser.parse(docstring)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Parse error: {}", e.message)))?;
+        // Compute the rendered full-description while `result` still
+        // owns all its fields — the per-field `set_item` calls below
+        // move them into the Python dict.
+        let full_description = result.full_description();
 
         Python::attach(|py| {
             let dict = PyDict::new(py);
@@ -223,6 +227,12 @@ impl DocstringParser {
                 version_changed_list.append(version_dict_py)?;
             }
             dict.set_item("version_changed", version_changed_list)?;
+
+            // Pre-rendered multi-section text suitable for clap's
+            // `long_about` slot. Computed in Rust so Python doesn't
+            // re-implement the same join logic — see
+            // `toolr_core::docstrings::Docstring::full_description`.
+            dict.set_item("full_description", full_description)?;
 
             Ok(dict.into())
         })

--- a/crates/toolr/src/cli.rs
+++ b/crates/toolr/src/cli.rs
@@ -581,35 +581,23 @@ fn build_user_command(cmd: &toolr_core::manifest::Command) -> Command {
     // text) the renderer returns plain text, so doc-snippet captures
     // remain stable.
     //
-    // The split between `about` (short, used in the parent's
-    // subcommand listing) and `long_about` (full body, used on the
-    // command's own `--help`) is deliberately preserved so parent
-    // listings stay compact. The `-h` flag is then re-bound below to
-    // trigger the long form so users get the full prose on either
-    // flavour of help — matches the argparse-era expectation that
-    // `-h` and `--help` show the same thing.
+    // ``cmd.summary`` is the docstring's first paragraph (clap's
+    // ``about``, shown in the parent listing and on ``-h``).
+    // ``cmd.description`` is the Rust-rendered ``full_description``
+    // (clap's ``long_about``, shown on ``--help``) — already includes
+    // the leading summary plus the long body plus any Examples /
+    // Notes / Warnings sections, so we hand it to clap as-is. The
+    // ``Args:`` section never appears here because the parser folds
+    // it into per-argument help instead.
     let summary = crate::markdown::render(&cmd.summary);
     let long_about = if cmd.description.is_empty() {
         summary.clone()
-    } else if cmd.summary.is_empty() {
-        crate::markdown::render(&cmd.description)
     } else {
-        crate::markdown::render(&format!("{}\n\n{}", cmd.summary, cmd.description))
+        crate::markdown::render(&cmd.description)
     };
     let mut c = Command::new(cmd.name.clone())
         .about(summary)
-        .long_about(long_about)
-        .disable_help_flag(true)
-        .arg(
-            // Both `-h` and `--help` print the long form, since our
-            // user-facing docstrings are usually short enough that
-            // the "long form" is the right default everywhere.
-            Arg::new("help")
-                .short('h')
-                .long("help")
-                .action(ArgAction::HelpLong)
-                .help("Print help"),
-        );
+        .long_about(long_about);
     for arg in &cmd.arguments {
         let long_flag = arg.name.replace('_', "-");
         let mut a = Arg::new(arg.name.clone()).help(crate::markdown::render(&arg.help));

--- a/docs/quickstart-files/example-setlog-help.txt
+++ b/docs/quickstart-files/example-setlog-help.txt
@@ -6,11 +6,11 @@ Demonstrates `Literal[...]` rendering as a `--level
 Usage: toolr example setlog [OPTIONS]
 
 Options:
-  -h, --help
-          Print help
-
       --level <level>
           Which log level to use.
 
           [default: info]
           [possible values: debug, info, warning]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/docs/writing-commands/files/calculator-add-help.txt
+++ b/docs/writing-commands/files/calculator-add-help.txt
@@ -11,4 +11,4 @@ Arguments:
 
 Options:
   -h, --help
-          Print help
+          Print help (see a summary with '-h')

--- a/docs/writing-commands/files/hello-help.txt
+++ b/docs/writing-commands/files/hello-help.txt
@@ -3,10 +3,10 @@ Say hello.
 Usage: toolr greeting hello [OPTIONS]
 
 Options:
-  -h, --help
-          Print help
-
       --name <name>
           The name of the person to greet.
 
           [default: World]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/docs/writing-commands/files/literal-choices-help.txt
+++ b/docs/writing-commands/files/literal-choices-help.txt
@@ -3,11 +3,11 @@ Set the active log level.
 Usage: toolr logs set-level [OPTIONS]
 
 Options:
-  -h, --help
-          Print help
-
       --level <level>
           Which level to use.
 
           [default: info]
           [possible values: debug, info, warning, error]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/examples/plugin-package/src/toolr_example_plugin/toolr-manifest.json
+++ b/examples/plugin-package/src/toolr_example_plugin/toolr-manifest.json
@@ -11,7 +11,7 @@
           "type_annotation": "str"
         }
       ],
-      "description": "",
+      "description": "Say hello to someone.",
       "function": "hello_command",
       "group": "third-party",
       "imports": [],
@@ -21,7 +21,7 @@
     },
     {
       "arguments": [],
-      "description": "",
+      "description": "Show the version of the example plugin.",
       "function": "version_command",
       "group": "third-party",
       "imports": [],
@@ -48,7 +48,7 @@
           "type_annotation": "int"
         }
       ],
-      "description": "",
+      "description": "Echo a message multiple times.",
       "function": "echo_command",
       "group": "utils",
       "imports": [],
@@ -58,7 +58,7 @@
     },
     {
       "arguments": [],
-      "description": "",
+      "description": "Show information about the example plugin.",
       "function": "info_command",
       "group": "utils",
       "imports": [],

--- a/skills/toolr-command-authoring/examples/toolr-manifest.json
+++ b/skills/toolr-command-authoring/examples/toolr-manifest.json
@@ -6,14 +6,14 @@
     {
       "name": "db",
       "title": "Database lifecycle",
-      "description": "Exercise: ``arg_section`` for grouping related flags in ``--help``,\nthe string-attached ``@command(group=...)`` form, mixed positional\nand keyword-only arguments, and a Google-style docstring with\n``Args:`` and ``Examples:`` sections.",
+      "description": "Database lifecycle commands.\n\nExercise: ``arg_section`` for grouping related flags in ``--help``,\nthe string-attached ``@command(group=...)`` form, mixed positional\nand keyword-only arguments, and a Google-style docstring with\n``Args:`` and ``Examples:`` sections.\n",
       "parent": null,
       "origin": "static"
     },
     {
       "name": "greet",
       "title": "Say hello in various ways",
-      "description": "Exercise: top-level group, two commands, the bound and the\nstring-attached ``@command`` forms, a ``str`` argument with a\ndefault, a ``bool`` flag, and an ``Annotated[str, arg(...)]``\nmetavar override.",
+      "description": "Greeting commands.\n\nExercise: top-level group, two commands, the bound and the\nstring-attached ``@command`` forms, a ``str`` argument with a\ndefault, a ``bool`` flag, and an ``Annotated[str, arg(...)]``\nmetavar override.\n",
       "parent": null,
       "origin": "static"
     }
@@ -25,7 +25,7 @@
       "module": "tools.db",
       "function": "reset",
       "summary": "Drop and recreate the database from scratch.",
-      "description": "",
+      "description": "Drop and recreate the database from scratch.\nExamples:\n\n- Reset interactively:\n\n- toolr db reset\n\n- Reset without prompting (CI):\n\n- toolr db reset --yes",
       "arguments": [
         {
           "name": "yes",
@@ -54,7 +54,7 @@
       "module": "tools.greet",
       "function": "hello",
       "summary": "Print a friendly greeting.",
-      "description": "",
+      "description": "Print a friendly greeting.",
       "arguments": [
         {
           "name": "who",
@@ -88,7 +88,7 @@
       "module": "tools.greet",
       "function": "shout",
       "summary": "Shout a message in all caps.",
-      "description": "",
+      "description": "Shout a message in all caps.",
       "arguments": [
         {
           "name": "message",

--- a/tests/decorators/test_decorators_unit.py
+++ b/tests/decorators/test_decorators_unit.py
@@ -215,18 +215,27 @@ def test_command_group_blank_title_stays_empty_when_no_docstring():
 
 
 def test_command_group_docstring_first_paragraph_becomes_title():
+    # Single-paragraph docstring: title takes the short_description,
+    # description renders to the same paragraph (no body / sections).
     g = command_group("ci", docstring="Short title for parent listing.")
     assert g.title == "Short title for parent listing."
-    assert g.description == ""
+    assert g.description == "Short title for parent listing."
 
 
 def test_command_group_docstring_long_paragraph_becomes_description():
+    # `description` is the Rust-rendered ``full_description`` — short
+    # paragraph + long body + a trailing newline (the same shape clap
+    # gets handed for ``--help``). The leading short paragraph repeats
+    # the title on purpose so ``--help`` re-states the blurb the parent
+    # listing already shows.
     g = command_group(
         "ci",
         docstring="Short title for parent listing.\n\nLonger prose shown by --help only.",
     )
     assert g.title == "Short title for parent listing."
-    assert g.description == "Longer prose shown by --help only."
+    assert g.description == (
+        "Short title for parent listing.\n\nLonger prose shown by --help only.\n"
+    )
 
 
 def test_command_group_explicit_title_overrides_docstring_short():
@@ -236,7 +245,30 @@ def test_command_group_explicit_title_overrides_docstring_short():
         docstring="Short title from docstring.\n\nLong paragraph kept as description.",
     )
     assert g.title == "Explicit Title"
-    assert g.description == "Long paragraph kept as description."
+    assert g.description == ("Short title from docstring.\n\nLong paragraph kept as description.\n")
+
+
+def test_command_group_docstring_with_notes_section_renders_into_description():
+    # Section headers (Notes/Examples/Warnings/…) feed clap's
+    # `long_about` via the same Rust-rendered ``full_description``
+    # string. This is the user-visible payoff: ``toolr <group> --help``
+    # now shows everything the docstring carries, not just the long
+    # paragraph.
+    g = command_group(
+        "ci",
+        docstring=(
+            "Short title.\n\n"
+            "Long body explaining the group.\n\n"
+            "Notes:\n"
+            "    Heads-up about something subtle.\n"
+            "    Second note.\n"
+        ),
+    )
+    assert g.title == "Short title."
+    assert "Long body explaining the group." in g.description
+    assert "Notes:" in g.description
+    assert "Heads-up about something subtle." in g.description
+    assert "Second note." in g.description
 
 
 def test_command_group_returns_existing_instance_on_second_call(

--- a/tests/registry/test_command_group_errors.py
+++ b/tests/registry/test_command_group_errors.py
@@ -26,11 +26,14 @@ def test_command_group_with_both_docstring_and_description():
 def test_command_group_with_docstring_parsing():
     """Test command_group with docstring parsing.
 
-    The docstring's first paragraph populates ``title`` (clap's ``about``)
-    and the remainder populates ``description`` (clap's ``long_about``),
-    mirroring how ``@command`` function docstrings are parsed by
-    ``crates/toolr-core/src/parser/commands.rs``. An explicit positional
-    title overrides the short slot.
+    The docstring's first paragraph populates ``title`` (clap's ``about``,
+    shown in the parent's command listing and on ``-h``). The Rust-rendered
+    multi-section ``full_description`` (short + long + Examples/Notes/…)
+    populates ``description`` (clap's ``long_about``, shown on ``--help``).
+    The leading short paragraph in the long form repeats the title on
+    purpose so ``--help`` re-states the blurb readers also see in the
+    parent listing. An explicit positional title still overrides the short
+    slot.
     """
     group = command_group(
         "docstring_test",
@@ -39,7 +42,7 @@ def test_command_group_with_docstring_parsing():
     )
 
     assert group.title == "Docstring Test"
-    assert group.description == "Long description with more details."
+    assert group.description == ("Short description.\n\nLong description with more details.\n")
     assert group.long_description is None
 
 


### PR DESCRIPTION
## Summary

Follow-up to [#293](https://github.com/s0undt3ch/ToolR/pull/293) / [#292](https://github.com/s0undt3ch/ToolR/issues/292). The first PR plumbed the docstring's first paragraph into `title` and the long paragraph into `description`. This one extends `description` to a multi-section render so `--help` shows the full docstring (Examples, Notes, Warnings, etc.), with `-h` still showing just the short summary.

## What changed

- **Rust rendering** (`toolr_core::docstrings::Docstring::full_description`): new method ports the existing Python ``Docstring.full_description`` algorithm — short paragraph + long paragraph + Examples / Notes / Warnings / See Also / References / Todo / Deprecated / Version Added / Version Changed, in source order. `Args:` is excluded (handled by per-argument help).
- **Single source of truth**: the Python re-implementation in `toolr.utils._docstrings.Docstring.full_description` is gone. PyO3's `DocstringParser::parse` now writes the rendered string into the returned dict, and the Python `Docstring` struct exposes it as a regular field.
- **Both parsers** (`parser/groups.rs` and `parser/commands.rs`) now populate `description` from `parse_docstring(...).full_description()`. The runtime decorator mirror in `toolr._decorators.command_group` reads the same Rust-rendered string off `Docstring.parse(...).full_description`.
- **cli.rs cleanup**:
  - `build_user_command` no longer prepends `summary` to `description` when assembling `long_about` — `description` already starts with the summary, so doing it again duplicated the leading paragraph.
  - The custom `-h` → `HelpLong` rebinding is removed. With `description` now carrying the full render, `-h` (clap's default `Help`) shows the summary and `--help` (`HelpLong`) shows the full text. That's the user-visible behaviour the title/description split was building toward.
- **Snapshots / docs**: the skill-authoring example manifest, the example-plugin fragment, the `references/commands.md` skill ref, and the `docs/quickstart-files` / `docs/writing-commands/files` `--help` captures were all regenerated to reflect the new shape.

## Test plan

- [x] `cargo test --workspace` — all suites green (470 in `toolr-core` + smaller crates).
- [x] New parser tests in `crates/toolr-core/src/parser/groups.rs` cover the matrix: docstring-only, docstring + explicit title, docstring + explicit `description=`, and the section-rendering path.
- [x] New / updated decorator tests in `tests/decorators/test_decorators_unit.py` exercise the Python `command_group` path including a `Notes:`-section assertion.
- [x] `pytest tests/decorators tests/registry tests/introspect tests/runner tests/sources` — 166 passing.
- [x] `prek` — full local lint / typecheck / format / doc-snippet chain clean.
- [x] End-to-end verified against `paddle/dbt-engineering-config`:
  - `toolr dbt-config -h` → short title only
  - `toolr dbt-config --help` → title + long body
  - `toolr dbt-config setup-dbt -h` → summary only
  - `toolr dbt-config setup-dbt --help` → summary + Examples section (Args excluded)
- [ ] CI green.