### PR TITLE
fix(coverage): rewrite venv paths back to source; ratchet codecov per-crate

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,11 +16,14 @@ coverage:
   status:
     project:
       default:
-        # Block PR merges if total coverage drops below 90%.
-        target: 90%
-        # Allow a 1% wobble for noise (random scheduler differences in
-        # signal-driven tests, etc.) without auto-failing the status.
-        threshold: 1%
+        # `auto` pins the bar to the base commit's coverage — any drop
+        # in overall project coverage on a PR fails the status. The
+        # bar ratchets up implicitly: a PR that raises coverage also
+        # raises the floor for the next PR.
+        target: auto
+        # No wobble. With `auto`, a 1% drop is meaningful and should
+        # be visible — there's no "noise" baseline to absorb.
+        threshold: 0%
         # Wait until every flag has reported before computing the status.
         # We upload 8 flags (4 Python × 2 OSes); without this Codecov
         # sometimes flips green/red as the partial uploads land.
@@ -29,11 +32,42 @@ coverage:
 
     patch:
       default:
-        # Lines touched by the PR must themselves hit 90%.
-        target: 90%
+        # Lines touched by the PR must themselves hit 99% — new code is
+        # held to a much higher bar than the overall project so the
+        # ratcheting `project: auto` actually moves upward over time.
+        target: 99%
         threshold: 0%
         if_not_found: success
         if_ci_failed: error
+
+# Per-crate ratcheting. Each component gets an independent `auto`
+# project status so a drop inside one crate (say `toolr-py` losing
+# 1pp) fails its own check even if another crate (say `toolr-core`)
+# compensates by gaining 1pp. Without this split, the headline
+# project number masks regressions inside the weakest crate.
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 0%
+  individual_components:
+    - component_id: toolr_core
+      name: "toolr-core"
+      paths:
+        - "crates/toolr-core/src/**"
+    - component_id: toolr_cli
+      name: "toolr"
+      paths:
+        - "crates/toolr/src/**"
+    - component_id: toolr_py
+      name: "toolr-py"
+      paths:
+        - "crates/toolr-py/python/**"
+    - component_id: xtask
+      name: "xtask"
+      paths:
+        - "crates/xtask/src/**"
 
 # Source files we never measure. Listing them here keeps the displayed
 # coverage focused on production code and prevents un-instrumented
@@ -58,7 +92,7 @@ ignore:
 # Post a Codecov summary comment on every PR and update it in place
 # on each new upload instead of stacking a new comment each push.
 comment:
-  layout: "reach,diff,flags,files"
+  layout: "reach,diff,flags,components,files"
   # `default` edits the existing Codecov comment when one is found
   # (creating one on the first build) — same comment node, refreshed
   # contents. The alternatives are `new` (delete + repost at bottom),

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,22 +4,27 @@ cover_pylib = False
 parallel = True
 concurrency = multiprocessing
 
+# `source` is a *package name* for toolr (not a path) so coverage
+# instruments every file reachable via the `toolr.*` import
+# hierarchy, regardless of whether it lives in the source tree
+# (`crates/toolr-py/python/toolr/...` — local editable install) or
+# the venv (`.venv/lib/python*/site-packages/toolr/...` — CI's wheel
+# install). The path-based form previously here dropped every hit on
+# the wheel-installed copy because the file paths didn't match the
+# configured source root, so `_decorators.py`, `_introspect.py`, and
+# `_runner.py` reported 0% in CI despite the tests actually exercising
+# them.
 source =
-  crates/toolr-py/python/
-  tests/
+  toolr
+  tests
 
 omit =
   setup.py
 
-# Path aliases so `coverage combine` rewrites venv-installed
-# `site-packages/toolr/...` hits back onto the canonical source tree
-# at `crates/toolr-py/python/toolr/...`. Without this, CI's
-# wheel-install of `toolr-py` (which lands in
-# `.venv/lib/python*/site-packages/toolr/`) makes coverage drop every
-# hit as "not in source" — so `_decorators.py`, `_introspect.py`, and
-# `_runner.py` report 0% even though the tests actually exercise them.
-# Local `maturin develop` is unaffected because the editable install
-# already points back at `crates/toolr-py/python/`.
+# Map the venv install location back onto the canonical source tree
+# so `coverage combine` and the codecov upload show a single
+# normalized path (the one a developer would `git grep` for) instead
+# of one row per matrix entry / install location.
 [paths]
 toolr_py =
   crates/toolr-py/python/toolr

--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,24 @@ source =
 omit =
   setup.py
 
+# Path aliases so `coverage combine` rewrites venv-installed
+# `site-packages/toolr/...` hits back onto the canonical source tree
+# at `crates/toolr-py/python/toolr/...`. Without this, CI's
+# wheel-install of `toolr-py` (which lands in
+# `.venv/lib/python*/site-packages/toolr/`) makes coverage drop every
+# hit as "not in source" — so `_decorators.py`, `_introspect.py`, and
+# `_runner.py` report 0% even though the tests actually exercise them.
+# Local `maturin develop` is unaffected because the editable install
+# already points back at `crates/toolr-py/python/`.
+[paths]
+toolr_py =
+  crates/toolr-py/python/toolr
+  */site-packages/toolr
+  */.venv/lib/python*/site-packages/toolr
+tests =
+  tests
+  */tests
+
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =


### PR DESCRIPTION
## Summary

Two coupled coverage infrastructure fixes:

### 1. `.coveragerc`: rewrite venv-installed paths back to source

Found while investigating why `toolr-py` shows 25.8% project coverage on main when local runs of the same test suite hit 90%+ on every affected file:

CI installs `toolr-py` from a prebuilt wheel into `.venv/lib/python*/site-packages/toolr/`. The existing `[run] source = crates/toolr-py/python/` filter dropped every hit landing on the wheel-installed copy as "not in source", so the CI `coverage report` literally showed:

```
crates/toolr-py/python/toolr/_decorators.py     99    99   28   0    0%
crates/toolr-py/python/toolr/_introspect.py     66    66   14   0    0%
crates/toolr-py/python/toolr/_runner.py        229   229   58   0    0%
```

— despite the tests for those modules **passing**. Local `maturin develop` uses an editable install pointing back at the source tree, so the bug was invisible locally.

A `[paths]` aliases block in `.coveragerc` maps the venv install location back onto the canonical source path during `coverage combine`. Local coverage drops in *no* hits (the editable install already produces the canonical path); CI now sees the actual coverage.

### 2. `.codecov.yml`: tighten the gate so coverage can't quietly slide

- `coverage.status.project.default`: `target: 90%` / `threshold: 1%` → `target: auto` / `threshold: 0%`. Overall coverage can never drop on a PR; the bar ratchets up implicitly. The 1% wobble was tolerating slow decay.
- `coverage.status.patch.default`: `target: 90%` → `target: 99%`. New code on every PR must hit 99% of its own lines.
- New `component_management` section pins per-crate baselines so a regression inside the weakest crate (e.g. `toolr-py`) can't be masked by a gain elsewhere. Components: `toolr-core`, `toolr`, `toolr-py`, `xtask`, each with `target: auto` / `threshold: 0%`.
- Comment layout gains a `components` block.

## Expected outcome

After this PR merges, the next codecov run should show `toolr-py` jumping from 25.8% to something in the 80-90% range — the same coverage local runs always saw, just no longer silently filtered out. The new per-crate auto-ratchet pins whatever that real number turns out to be as the floor.

This is **honest** coverage — the tests were already there and passing; we just weren't counting their hits.

## Test plan

- [x] `curl --data-binary @.codecov.yml https://codecov.io/validate` returns "Valid!".
- [x] `.coveragerc` still parses; local `coverage report` against the existing combined data file produces correct numbers.
- [ ] CI green; codecov shows the expected jump in `toolr-py` coverage.