### PR TITLE
fix(complete): always offer `self` / `project` built-ins outside a toolr project

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -39,3 +39,18 @@ Side-effects:
   so the two surfaces can't drift.
 
 See [#292](https://github.com/s0undt3ch/ToolR/issues/292).
+
+## Bug fixes
+
+### Tab completion offers `self` / `project` even outside a toolr project
+
+Running `toolr <TAB>` from a directory with no `tools/` ancestor used to
+return nothing and exit 1, so the shell fell back to filename
+completion. The binary's own `self` / `project` subtree doesn't depend
+on a project root, so it should always complete — only user-defined
+groups need a discoverable `tools/`. `run_complete` now falls back to
+an empty manifest when project discovery fails, then merges in the
+built-in completion entries so `self`, `project`, and their children
+are offered everywhere.
+
+See [#306](https://github.com/s0undt3ch/ToolR/issues/306).

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -13,7 +13,7 @@ use toolr_core::discovery::discover_project_root;
 use toolr_core::execute::{
     resolve_python, spawn_runner, wait_with_signals, write_spec_to_tempfile,
 };
-use toolr_core::manifest::Manifest;
+use toolr_core::manifest::{Manifest, SCHEMA_VERSION};
 use toolr_core::venv::resolve_venv_path;
 
 use crate::execute_build::{OutputOptions, build_dispatch_spec, build_spec, pack_child_args};
@@ -407,13 +407,16 @@ fn run_complete(matches: &clap::ArgMatches) -> anyhow::Result<ExitCode> {
         .get_many::<String>("args")
         .map(|v| v.cloned().collect())
         .unwrap_or_default();
-    let Ok(resolved) = resolve_manifest_at_tab(&cwd) else {
-        return Ok(ExitCode::from(1));
-    };
+    // No `tools/` ancestor → no user-defined commands to complete, but
+    // the binary's own `self` / `project` subtree must still be offered
+    // (it doesn't depend on a project root). Fall back to an empty
+    // manifest so the built-in injection below covers the cwd.
+    let mut manifest = resolve_manifest_at_tab(&cwd)
+        .map(|r| r.manifest)
+        .unwrap_or_else(|_| empty_manifest_for_completion());
     // The engine is purely manifest-driven, but the binary owns its own
     // built-in `self` / `project` subtree. Inject synthetic entries that
     // mirror `cli::build_command` so those subcommands also complete.
-    let mut manifest = resolved.manifest;
     let (extra_groups, extra_commands) =
         crate::builtin_completions::built_in_completion_entries();
     manifest.groups.extend(extra_groups);
@@ -422,6 +425,16 @@ fn run_complete(matches: &clap::ArgMatches) -> anyhow::Result<ExitCode> {
         println!("{candidate}");
     }
     Ok(ExitCode::SUCCESS)
+}
+
+fn empty_manifest_for_completion() -> Manifest {
+    Manifest {
+        schema_version: SCHEMA_VERSION,
+        static_hash: String::new(),
+        third_party_hash: String::new(),
+        groups: Vec::new(),
+        commands: Vec::new(),
+    }
 }
 
 fn run_build_static_manifest() -> anyhow::Result<ExitCode> {

--- a/crates/toolr/tests/complete_smoke.rs
+++ b/crates/toolr/tests/complete_smoke.rs
@@ -130,7 +130,7 @@ def shiny(ctx):
 }
 
 #[test]
-fn silent_failure_when_no_tools_dir_anywhere() {
+fn completes_builtins_when_no_tools_dir_anywhere() {
     let tmp = TempDir::new().unwrap();
     let cwd = tmp.path().to_path_buf();
     // GHA Windows runners ship with `C:\tools\` populated, so the
@@ -161,10 +161,24 @@ fn silent_failure_when_no_tools_dir_anywhere() {
         .args(["__complete", &cwd.to_string_lossy(), ""])
         .output()
         .unwrap();
-    // Exit code 1 with empty stderr — the shell falls back silently.
-    assert_eq!(output.status.code(), Some(1));
-    assert!(output.stdout.is_empty());
-    assert!(output.stderr.is_empty(), "expected silent failure");
+    // Built-in `self` / `project` subtree doesn't depend on a project
+    // root, so completion must still offer them outside any toolr project.
+    // Only user-defined commands need a tools/ ancestor.
+    assert!(
+        output.status.success(),
+        "expected success, got {:?}, stderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    for expected in ["self", "project"] {
+        assert!(
+            lines.contains(&expected),
+            "missing built-in {expected} outside a toolr project; got: {stdout}",
+        );
+    }
+    assert!(output.stderr.is_empty(), "expected silent stderr");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #306.

Running `toolr <TAB>` from a directory with no `tools/` ancestor used to return nothing and exit 1, so the shell fell back to filename completion. The binary's own `self` / `project` subtree doesn't depend on a project root, so it should always complete — only user-defined groups need a discoverable `tools/`.

## Root cause

`crates/toolr/src/dispatch.rs::run_complete` early-returned with `ExitCode::from(1)` whenever `resolve_manifest_at_tab` failed (no `tools/` ancestor). The synthetic built-in entries from `crate::builtin_completions` were never injected, so even completions that don't need a project root (`self …`, `project …`) silently disappeared.

`resolve_manifest_at_tab` (in `toolr_core::complete::freshness`) needing a project root is correct — it manages the on-disk manifest cache. The bug was at the dispatch layer, where the failure was treated as fatal instead of "no user-defined commands, use built-ins only".

## Reproduction (before)

```console
$ cd /tmp                                     # no tools/ anywhere up the tree
$ toolr __complete /tmp ""
$ echo $?
1
```

In a shell: `toolr <TAB>` → nothing.

## After

```console
$ toolr __complete /tmp ""
project
self
$ toolr __complete /tmp self ""
build-manifest
cache
completion
$ toolr __complete /tmp project ""
init
manifest
venv
```

Inside a project, user-defined commands continue to be offered (manifest discovery path unchanged).

## Changes

- `crates/toolr/src/dispatch.rs` — `run_complete` falls back to an empty manifest when `resolve_manifest_at_tab` errors, then merges the built-in entries as before. New `empty_manifest_for_completion` helper.
- `crates/toolr/tests/complete_smoke.rs` — the existing `silent_failure_when_no_tools_dir_anywhere` test asserted the buggy behaviour (exit 1, empty stdout); renamed to `completes_builtins_when_no_tools_dir_anywhere` and rewritten to assert `self` and `project` are offered.
- `UNRELEASED.md` — release-note entry under "Bug fixes".

## Test plan

- [x] `cargo test -p toolr` — all 18 binaries green (including the renamed completion test).
- [x] Manual `toolr __complete` from `/tmp` returns `project` / `self` and exits 0.
- [x] Manual `toolr __complete` inside this repo still returns the user-defined `bench` / `ci` / `version` groups alongside the built-ins.