### PR TITLE
ci: bench `toolr` startup against built artifacts on Linux/macOS/Windows

### DIFF
--- a/.github/workflows/_bench.yml
+++ b/.github/workflows/_bench.yml
@@ -1,0 +1,192 @@
+name: Bench
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+        description: 'Operating system to run bench on'
+      display-name:
+        required: true
+        type: string
+        description: 'Display name for the bench job (Linux / macOS / Windows)'
+      cache-seed:
+        required: true
+        type: string
+        description: 'Seed mixed into every cache key. Bump in the caller workflow to invalidate.'
+      mise-version:
+        required: true
+        type: string
+        description: 'Version of mise to install (forwarded to the setup-virtualenv composite). Pass the caller workflow''s MISE_VERSION env var.'
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    name: ${{ inputs.display-name }}
+    runs-on: ${{ inputs.os }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Derive the artifact identifiers we'll download below from the
+      # runner OS. Centralised here so the rest of the job can reference
+      # `steps.artifacts.outputs.*` instead of repeating the same `case
+      # $RUNNER_OS` everywhere. Mirrors `_test.yml`'s pattern.
+      - name: Compute artifact identifiers
+        id: artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$RUNNER_OS" in
+            Linux)   triple=x86_64-unknown-linux-gnu;  wheelplat=manylinux_x86_64 ;;
+            macOS)   triple=aarch64-apple-darwin;      wheelplat=macosx_arm64 ;;
+            Windows) triple=x86_64-pc-windows-msvc;    wheelplat=win_amd64 ;;
+            *) echo "unknown RUNNER_OS=$RUNNER_OS" >&2; exit 1 ;;
+          esac
+          {
+            echo "toolr-triple=$triple"
+            echo "wheel-platform=$wheelplat"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/setup-virtualenv
+        with:
+          cache-prefix: bench-${{ inputs.display-name }}
+          cache-seed: ${{ inputs.cache-seed }}
+          # No workspace install — we bring in toolr-py from the
+          # prebuilt wheel, not by recompiling via maturin.
+          uv-sync-args: "--no-install-workspace"
+          mise-version: ${{ inputs.mise-version }}
+
+      - name: Compute Python cp-tag
+        id: cp-tag
+        shell: bash
+        # Mirror the docs job: derive the wheel ABI tag from the
+        # venv's active Python so a mise.toml python bump picks the
+        # matching wheel artifact without a second edit.
+        run: |
+          pyver=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+          echo "cp-tag=cp${pyver//./}" >> "$GITHUB_OUTPUT"
+
+      - name: Download toolr-py wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cibw-wheel-py-${{ steps.cp-tag.outputs.cp-tag }}-${{ steps.artifacts.outputs.wheel-platform }}
+          path: ${{ runner.temp }}/toolr-py-wheel
+
+      - name: Download toolr binary archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: toolr-archive-${{ steps.artifacts.outputs.toolr-triple }}
+          path: ${{ runner.temp }}/toolr-archive
+
+      # Extract the standalone `toolr` binary from the archive and put
+      # it on PATH. Subsequent steps reference `toolr` directly rather
+      # than carrying around a `TOOLR_BIN` env var.
+      - name: Extract toolr binary onto PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          dest="$RUNNER_TEMP/toolr-bin"
+          mkdir -p "$dest"
+          archive=$(find "$RUNNER_TEMP/toolr-archive" -maxdepth 1 -type f \
+            \( -name 'toolr-*.tar.gz' -o -name 'toolr-*.zip' \) -print -quit)
+          if [ -z "$archive" ]; then
+            echo "no toolr archive found under $RUNNER_TEMP/toolr-archive/" >&2
+            find "$RUNNER_TEMP/toolr-archive" -maxdepth 2 -mindepth 1 -print >&2 || true
+            exit 1
+          fi
+          case "$archive" in
+            *.tar.gz)
+              tar -xzf "$archive" -C "$dest" --strip-components=1
+              ;;
+            *.zip)
+              unzip -q "$archive" -d "$dest"
+              # `Compress-Archive` retains the top-level dir; flatten
+              # so `toolr.exe` lands directly in $dest.
+              inner=$(find "$dest" -maxdepth 1 -mindepth 1 -type d | head -n1)
+              if [ -n "$inner" ]; then
+                mv "$inner"/* "$dest"/
+                rmdir "$inner"
+              fi
+              ;;
+          esac
+          chmod +x "$dest"/toolr* 2>/dev/null || true
+          echo "$dest" >> "$GITHUB_PATH"
+
+      - name: Add uv tool bin dir to PATH
+        shell: bash
+        # `--install` shells `uv tool install <pkg>`, which drops
+        # binaries under `uv tool dir --bin`. That directory is NOT
+        # on PATH on a fresh runner, so `_resolve_binary` would warn
+        # "installed but not on PATH" and the Python task-runners
+        # would be excluded from the comparison. Add it up front.
+        run: uv tool dir --bin >> "$GITHUB_PATH"
+
+      - name: Sync tools venv (pulls toolr-py from PyPI)
+        shell: bash
+        # First run of `toolr` against a `tools/` directory bootstraps
+        # the tools venv (creates it, runs `uv sync`). Force that to
+        # happen explicitly so the wheel-swap step below has a venv
+        # to install into.
+        run: toolr project venv sync
+
+      - name: Install local toolr-py wheel into tools venv
+        shell: bash
+        # `project venv sync` resolved `toolr-py` from PyPI. Swap in
+        # the just-built wheel so the bench measures THIS PR's
+        # `toolr` + `toolr-py`, not the released versions.
+        run: |
+          set -euo pipefail
+          venv=$(toolr project venv path)
+          wheel=$(find "$RUNNER_TEMP/toolr-py-wheel" -maxdepth 1 -type f -name 'toolr_py-*.whl' -print -quit)
+          if [ -z "$wheel" ]; then
+            echo "no toolr_py wheel found under $RUNNER_TEMP/toolr-py-wheel/" >&2
+            find "$RUNNER_TEMP/toolr-py-wheel" -maxdepth 2 -mindepth 1 -print >&2 || true
+            exit 1
+          fi
+          # `--python` accepts either an interpreter path or a venv
+          # root; venv root is the portable form across Linux/macOS
+          # (`bin/python`) and Windows (`Scripts/python.exe`).
+          uv pip install --python "$venv" --force-reinstall "$wheel"
+
+      - name: Run startup bench
+        id: bench
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/bench.md"
+          workdir=$(mktemp -d)
+          toolr bench compare \
+            --path "$workdir" \
+            --markdown \
+            --install \
+            | tee "$out"
+          echo "out=$out" >> "$GITHUB_OUTPUT"
+
+      - name: Publish bench results to step summary
+        if: always() && steps.bench.outputs.out != ''
+        shell: bash
+        env:
+          DISPLAY_NAME: ${{ inputs.display-name }}
+          TRIPLE: ${{ steps.artifacts.outputs.toolr-triple }}
+          CP_TAG: ${{ steps.cp-tag.outputs.cp-tag }}
+          WHEEL_PLATFORM: ${{ steps.artifacts.outputs.wheel-platform }}
+          BENCH_OUT: ${{ steps.bench.outputs.out }}
+        run: |
+          {
+            echo "## ⏱️ \`toolr bench compare\` — $DISPLAY_NAME (\`$TRIPLE\`)"
+            echo
+            echo "Built from this branch's \`toolr\` archive + \`toolr_py-${CP_TAG}-${WHEEL_PLATFORM}\` wheel."
+            echo
+            cat "$BENCH_OUT"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,16 @@ jobs:
 
       - name: Check if the build should run
         id: check-build
-        run: |
-          toolr ci check-run-build ${{ github.event_name }} ${{ github.ref_name }}
         env:
+          # Route through `env:` so `github.ref_name` (which is
+          # attacker-controllable — branch names can contain shell
+          # metacharacters) doesn't get spliced into the shell line
+          # at interpolation time. The `toolr` CLI receives them as
+          # ordinary argv.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: toolr ci check-run-build "$EVENT_NAME" "$REF_NAME"
 
       - name: Generate Build Matrix
         id: generate-build-matrix
@@ -655,6 +661,189 @@ jobs:
           packages-dir: dist/
           skip-existing: true
           verbose: true
+
+  bench:
+    name: Bench (${{ matrix.display-name }})
+    # Informational only: posts the `toolr bench compare --markdown`
+    # table to the job's step summary so reviewers can see startup
+    # numbers next to other CI signal. Intentionally NOT in
+    # `set-pipeline-exit-status.needs` — perf numbers swing with
+    # runner load and we don't want flaky benchmarks gating PRs.
+    needs:
+      - prepare-ci
+      - build-binary-archive
+      - build-py-wheel-linux
+      - build-py-wheel-macos
+      - build-py-wheel-windows
+    if: fromJSON(needs.prepare-ci.outputs.should-run-build)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            display-name: Linux
+            triple: x86_64-unknown-linux-gnu
+            archive-ext: tar.gz
+            wheel-platform: manylinux_x86_64
+          - os: macos-latest
+            display-name: macOS
+            triple: aarch64-apple-darwin
+            archive-ext: tar.gz
+            wheel-platform: macosx_arm64
+          - os: windows-latest
+            display-name: Windows
+            triple: x86_64-pc-windows-msvc
+            archive-ext: zip
+            wheel-platform: win_amd64
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Load shared env vars
+        shell: bash
+        run: sed -n '/^[A-Z]/p' .github/env >> "$GITHUB_ENV"
+
+      - name: Setup Virtual Environment
+        uses: ./.github/actions/setup-virtualenv
+        with:
+          cache-prefix: bench-${{ matrix.display-name }}
+          cache-seed: ${{ needs.prepare-ci.outputs.cache-seed }}
+          # No workspace install — we bring in toolr-py from the
+          # prebuilt wheel, not by recompiling via maturin.
+          uv-sync-args: "--no-install-workspace"
+          mise-version: ${{ needs.prepare-ci.outputs.mise-version }}
+
+      - name: Compute Python cp-tag
+        id: cp-tag
+        shell: bash
+        # Mirror docs: derive the wheel ABI tag from the venv's
+        # active Python so a mise.toml python bump picks the matching
+        # wheel artifact without a second edit.
+        run: |
+          pyver=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+          echo "cp-tag=cp${pyver//./}" >> "$GITHUB_OUTPUT"
+
+      - name: Download toolr-py wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cibw-wheel-py-${{ steps.cp-tag.outputs.cp-tag }}-${{ matrix.wheel-platform }}
+          path: ${{ runner.temp }}/toolr-py-wheel
+
+      - name: Download toolr binary archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: toolr-archive-${{ matrix.triple }}
+          path: ${{ runner.temp }}/toolr-archive
+
+      - name: Extract toolr binary
+        id: toolr-binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          dest="$RUNNER_TEMP/toolr-bin"
+          mkdir -p "$dest"
+          archive=$(find "$RUNNER_TEMP/toolr-archive" -maxdepth 1 -type f \
+            \( -name 'toolr-*.tar.gz' -o -name 'toolr-*.zip' \) -print -quit)
+          if [ -z "$archive" ]; then
+            echo "no toolr-* archive found under $RUNNER_TEMP/toolr-archive/" >&2
+            find "$RUNNER_TEMP/toolr-archive" -maxdepth 2 -mindepth 1 -print >&2 || true
+            exit 1
+          fi
+          case "$archive" in
+            *.tar.gz) tar -xzf "$archive" -C "$dest" --strip-components=1 ;;
+            *.zip)    unzip -j -o "$archive" -d "$dest" >/dev/null ;;
+          esac
+          # `toolr.exe` on Windows; `toolr` everywhere else.
+          if [ -f "$dest/toolr.exe" ]; then
+            echo "$dest" >> "$GITHUB_PATH"
+            echo "bin=$dest/toolr.exe" >> "$GITHUB_OUTPUT"
+          else
+            chmod +x "$dest/toolr"
+            echo "$dest" >> "$GITHUB_PATH"
+            echo "bin=$dest/toolr" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Add uv tool bin dir to PATH
+        shell: bash
+        # `--install` shells `uv tool install <pkg>`, which drops
+        # binaries under `uv tool dir --bin`. That directory is NOT
+        # on PATH on a fresh runner, so `_resolve_binary` would warn
+        # "installed but not on PATH" and the Python task-runners
+        # would be excluded from the comparison. Add it up front.
+        run: uv tool dir --bin >> "$GITHUB_PATH"
+
+      - name: Sync tools venv (pulls toolr-py from PyPI)
+        shell: bash
+        # First run of `toolr` against a `tools/` directory bootstraps
+        # the tools venv (creates it, runs `uv sync`). This step
+        # forces that to happen explicitly so the wheel-swap step
+        # below has a venv to install into.
+        env:
+          TOOLR_BIN: ${{ steps.toolr-binary.outputs.bin }}
+        run: '"$TOOLR_BIN" project venv sync'
+
+      - name: Install local toolr-py wheel into tools venv
+        shell: bash
+        # `project venv sync` resolved `toolr-py` from PyPI. Swap in
+        # the just-built wheel so the bench measures THIS PR's
+        # toolr + toolr-py, not the released versions.
+        env:
+          TOOLR_BIN: ${{ steps.toolr-binary.outputs.bin }}
+        run: |
+          set -euo pipefail
+          venv=$("$TOOLR_BIN" project venv path)
+          wheel=$(find "$RUNNER_TEMP/toolr-py-wheel" -maxdepth 1 -type f -name 'toolr_py-*.whl' -print -quit)
+          if [ -z "$wheel" ]; then
+            echo "no toolr_py wheel found under $RUNNER_TEMP/toolr-py-wheel/" >&2
+            find "$RUNNER_TEMP/toolr-py-wheel" -maxdepth 2 -mindepth 1 -print >&2 || true
+            exit 1
+          fi
+          # `--python` accepts either an interpreter path or a venv
+          # root; venv root is the portable form across Linux/macOS
+          # (`bin/python`) and Windows (`Scripts/python.exe`).
+          uv pip install --python "$venv" --force-reinstall "$wheel"
+
+      - name: Run startup bench
+        id: bench
+        shell: bash
+        env:
+          TOOLR_BIN: ${{ steps.toolr-binary.outputs.bin }}
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/bench.md"
+          workdir=$(mktemp -d)
+          "$TOOLR_BIN" bench compare \
+            --path "$workdir" \
+            --markdown \
+            --install \
+            | tee "$out"
+          echo "out=$out" >> "$GITHUB_OUTPUT"
+
+      - name: Publish bench results to step summary
+        if: always() && steps.bench.outputs.out != ''
+        shell: bash
+        env:
+          DISPLAY_NAME: ${{ matrix.display-name }}
+          TRIPLE: ${{ matrix.triple }}
+          CP_TAG: ${{ steps.cp-tag.outputs.cp-tag }}
+          WHEEL_PLATFORM: ${{ matrix.wheel-platform }}
+          BENCH_OUT: ${{ steps.bench.outputs.out }}
+        run: |
+          {
+            echo "## ⏱️ \`toolr bench compare\` — $DISPLAY_NAME (\`$TRIPLE\`)"
+            echo
+            echo "Built from this branch's \`toolr\` archive + \`toolr_py-${CP_TAG}-${WHEEL_PLATFORM}\` wheel."
+            echo
+            cat "$BENCH_OUT"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   set-pipeline-exit-status:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,9 +666,7 @@ jobs:
     name: Bench (${{ matrix.display-name }})
     # Informational only: posts the `toolr bench compare --markdown`
     # table to the job's step summary so reviewers can see startup
-    # numbers next to other CI signal. Intentionally NOT in
-    # `set-pipeline-exit-status.needs` — perf numbers swing with
-    # runner load and we don't want flaky benchmarks gating PRs.
+    # numbers next to other CI signal.
     needs:
       - prepare-ci
       - build-binary-archive
@@ -862,6 +860,7 @@ jobs:
       - test-windows
       - docs
       - publish
+      - bench
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,186 +662,53 @@ jobs:
           skip-existing: true
           verbose: true
 
-  bench:
-    name: Bench (${{ matrix.display-name }})
-    # Informational only: posts the `toolr bench compare --markdown`
-    # table to the job's step summary so reviewers can see startup
-    # numbers next to other CI signal.
+  # Bench-* jobs run `toolr bench compare --markdown --install` against
+  # this PR's built `toolr` + `toolr-py` artifacts and post the result
+  # to each runner's step summary.
+  bench-linux:
+    name: Bench
     needs:
       - prepare-ci
       - build-binary-archive
       - build-py-wheel-linux
-      - build-py-wheel-macos
-      - build-py-wheel-windows
-    if: fromJSON(needs.prepare-ci.outputs.should-run-build)
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            display-name: Linux
-            triple: x86_64-unknown-linux-gnu
-            archive-ext: tar.gz
-            wheel-platform: manylinux_x86_64
-          - os: macos-latest
-            display-name: macOS
-            triple: aarch64-apple-darwin
-            archive-ext: tar.gz
-            wheel-platform: macosx_arm64
-          - os: windows-latest
-            display-name: Windows
-            triple: x86_64-pc-windows-msvc
-            archive-ext: zip
-            wheel-platform: win_amd64
-    runs-on: ${{ matrix.os }}
+    uses: ./.github/workflows/_bench.yml
+    with:
+      os: ubuntu-latest
+      display-name: Linux
+      cache-seed: ${{ needs.prepare-ci.outputs.cache-seed }}
+      mise-version: ${{ needs.prepare-ci.outputs.mise-version }}
     permissions:
       contents: read
 
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
+  bench-macos:
+    name: Bench
+    needs:
+      - prepare-ci
+      - build-binary-archive
+      - build-py-wheel-macos
+    uses: ./.github/workflows/_bench.yml
+    with:
+      os: macos-latest
+      display-name: macOS
+      cache-seed: ${{ needs.prepare-ci.outputs.cache-seed }}
+      mise-version: ${{ needs.prepare-ci.outputs.mise-version }}
+    permissions:
+      contents: read
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Load shared env vars
-        shell: bash
-        run: sed -n '/^[A-Z]/p' .github/env >> "$GITHUB_ENV"
-
-      - name: Setup Virtual Environment
-        uses: ./.github/actions/setup-virtualenv
-        with:
-          cache-prefix: bench-${{ matrix.display-name }}
-          cache-seed: ${{ needs.prepare-ci.outputs.cache-seed }}
-          # No workspace install — we bring in toolr-py from the
-          # prebuilt wheel, not by recompiling via maturin.
-          uv-sync-args: "--no-install-workspace"
-          mise-version: ${{ needs.prepare-ci.outputs.mise-version }}
-
-      - name: Compute Python cp-tag
-        id: cp-tag
-        shell: bash
-        # Mirror docs: derive the wheel ABI tag from the venv's
-        # active Python so a mise.toml python bump picks the matching
-        # wheel artifact without a second edit.
-        run: |
-          pyver=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-          echo "cp-tag=cp${pyver//./}" >> "$GITHUB_OUTPUT"
-
-      - name: Download toolr-py wheel
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: cibw-wheel-py-${{ steps.cp-tag.outputs.cp-tag }}-${{ matrix.wheel-platform }}
-          path: ${{ runner.temp }}/toolr-py-wheel
-
-      - name: Download toolr binary archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: toolr-archive-${{ matrix.triple }}
-          path: ${{ runner.temp }}/toolr-archive
-
-      - name: Extract toolr binary
-        id: toolr-binary
-        shell: bash
-        run: |
-          set -euo pipefail
-          dest="$RUNNER_TEMP/toolr-bin"
-          mkdir -p "$dest"
-          archive=$(find "$RUNNER_TEMP/toolr-archive" -maxdepth 1 -type f \
-            \( -name 'toolr-*.tar.gz' -o -name 'toolr-*.zip' \) -print -quit)
-          if [ -z "$archive" ]; then
-            echo "no toolr-* archive found under $RUNNER_TEMP/toolr-archive/" >&2
-            find "$RUNNER_TEMP/toolr-archive" -maxdepth 2 -mindepth 1 -print >&2 || true
-            exit 1
-          fi
-          case "$archive" in
-            *.tar.gz) tar -xzf "$archive" -C "$dest" --strip-components=1 ;;
-            *.zip)    unzip -j -o "$archive" -d "$dest" >/dev/null ;;
-          esac
-          # `toolr.exe` on Windows; `toolr` everywhere else.
-          if [ -f "$dest/toolr.exe" ]; then
-            echo "$dest" >> "$GITHUB_PATH"
-            echo "bin=$dest/toolr.exe" >> "$GITHUB_OUTPUT"
-          else
-            chmod +x "$dest/toolr"
-            echo "$dest" >> "$GITHUB_PATH"
-            echo "bin=$dest/toolr" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Add uv tool bin dir to PATH
-        shell: bash
-        # `--install` shells `uv tool install <pkg>`, which drops
-        # binaries under `uv tool dir --bin`. That directory is NOT
-        # on PATH on a fresh runner, so `_resolve_binary` would warn
-        # "installed but not on PATH" and the Python task-runners
-        # would be excluded from the comparison. Add it up front.
-        run: uv tool dir --bin >> "$GITHUB_PATH"
-
-      - name: Sync tools venv (pulls toolr-py from PyPI)
-        shell: bash
-        # First run of `toolr` against a `tools/` directory bootstraps
-        # the tools venv (creates it, runs `uv sync`). This step
-        # forces that to happen explicitly so the wheel-swap step
-        # below has a venv to install into.
-        env:
-          TOOLR_BIN: ${{ steps.toolr-binary.outputs.bin }}
-        run: '"$TOOLR_BIN" project venv sync'
-
-      - name: Install local toolr-py wheel into tools venv
-        shell: bash
-        # `project venv sync` resolved `toolr-py` from PyPI. Swap in
-        # the just-built wheel so the bench measures THIS PR's
-        # toolr + toolr-py, not the released versions.
-        env:
-          TOOLR_BIN: ${{ steps.toolr-binary.outputs.bin }}
-        run: |
-          set -euo pipefail
-          venv=$("$TOOLR_BIN" project venv path)
-          wheel=$(find "$RUNNER_TEMP/toolr-py-wheel" -maxdepth 1 -type f -name 'toolr_py-*.whl' -print -quit)
-          if [ -z "$wheel" ]; then
-            echo "no toolr_py wheel found under $RUNNER_TEMP/toolr-py-wheel/" >&2
-            find "$RUNNER_TEMP/toolr-py-wheel" -maxdepth 2 -mindepth 1 -print >&2 || true
-            exit 1
-          fi
-          # `--python` accepts either an interpreter path or a venv
-          # root; venv root is the portable form across Linux/macOS
-          # (`bin/python`) and Windows (`Scripts/python.exe`).
-          uv pip install --python "$venv" --force-reinstall "$wheel"
-
-      - name: Run startup bench
-        id: bench
-        shell: bash
-        env:
-          TOOLR_BIN: ${{ steps.toolr-binary.outputs.bin }}
-        run: |
-          set -euo pipefail
-          out="$RUNNER_TEMP/bench.md"
-          workdir=$(mktemp -d)
-          "$TOOLR_BIN" bench compare \
-            --path "$workdir" \
-            --markdown \
-            --install \
-            | tee "$out"
-          echo "out=$out" >> "$GITHUB_OUTPUT"
-
-      - name: Publish bench results to step summary
-        if: always() && steps.bench.outputs.out != ''
-        shell: bash
-        env:
-          DISPLAY_NAME: ${{ matrix.display-name }}
-          TRIPLE: ${{ matrix.triple }}
-          CP_TAG: ${{ steps.cp-tag.outputs.cp-tag }}
-          WHEEL_PLATFORM: ${{ matrix.wheel-platform }}
-          BENCH_OUT: ${{ steps.bench.outputs.out }}
-        run: |
-          {
-            echo "## ⏱️ \`toolr bench compare\` — $DISPLAY_NAME (\`$TRIPLE\`)"
-            echo
-            echo "Built from this branch's \`toolr\` archive + \`toolr_py-${CP_TAG}-${WHEEL_PLATFORM}\` wheel."
-            echo
-            cat "$BENCH_OUT"
-          } >> "$GITHUB_STEP_SUMMARY"
+  bench-windows:
+    name: Bench
+    needs:
+      - prepare-ci
+      - build-binary-archive
+      - build-py-wheel-windows
+    uses: ./.github/workflows/_bench.yml
+    with:
+      os: windows-latest
+      display-name: Windows
+      cache-seed: ${{ needs.prepare-ci.outputs.cache-seed }}
+      mise-version: ${{ needs.prepare-ci.outputs.mise-version }}
+    permissions:
+      contents: read
 
   set-pipeline-exit-status:
     permissions:
@@ -858,9 +725,11 @@ jobs:
       - test-linux
       - test-macos
       - test-windows
+      - bench-linux
+      - bench-macos
+      - bench-windows
       - docs
       - publish
-      - bench
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
## Summary

Adds three `bench-{linux,macos,windows}` callers in `ci.yml` plus
a new reusable workflow `.github/workflows/_bench.yml` (mirrors
the test-* / build-* callable-workflow split). Each caller runs
`toolr bench compare --markdown --install` against this PR's
built `toolr` binary archive and matching `toolr-py` wheel and
posts the markdown table to its runner's step summary.

### How it gates the build

`bench-{linux,macos,windows}` are listed in
`set-pipeline-exit-status.needs` — a *job failure* (archive
missing, install crash, `toolr` crash, etc.) fails the build.
The benchmark *numbers themselves* never fail the build: `toolr
bench compare` exits zero regardless of how fast each tool ran,
so slow startup numbers won't gate PRs — only broken benches do.

### Job choreography

- Bootstrap the tools venv via `toolr project venv sync`, then
  swap the PyPI-resolved `toolr-py` for the just-built wheel via
  `uv pip install --python <venv> --force-reinstall`. The bench
  measures THIS PR's binary + wheel, not the released versions.
- Prepend `uv tool dir --bin` to `$GITHUB_PATH` so the
  `--install`-driven `uv tool install <pkg>` placements for
  invoke/duty/doit/nox/python-tools-scripts are discoverable by
  `_resolve_binary`.
- The cp-tag is derived from the venv's active Python after
  `setup-virtualenv` (same as the docs job) so a `mise.toml`
  python bump auto-selects the matching wheel artifact.

`_bench.yml` mirrors `_test.yml` exactly: `workflow_call` with
`os` / `display-name` / `cache-seed` / `mise-version` inputs,
a single `case "$RUNNER_OS"` step emitting `toolr-triple` +
`wheel-platform` outputs, and the same archive-extraction
pattern (handles both `.tar.gz` and `.zip`, flattens the inner
dir on Windows). Subsequent steps reference `toolr` directly
via PATH.

### Drive-by

Routes `github.event_name` / `github.ref_name` through `env:`
in `prepare-ci`'s "Check if the build should run" step. Branch
names are attacker-controllable, so interpolating them into a
shell `run:` is a CWE-78-shaped risk; the `toolr` CLI receives
them as ordinary argv either way. Caught by the local Semgrep
hook while authoring this PR.

## Stack

Stacked on #311 (the `:`-alignment fix in `tools/bench.py`) —
the bench output rendered to step summaries looks right only
with that fix in.

## Test plan

- [x] `prek run --files .github/workflows/ci.yml .github/workflows/_bench.yml`
  — actionlint / pin-shas / shellcheck / typos all green.
- [ ] CI: confirm the `Bench (Linux|macOS|Windows)` jobs run,
  produce a populated step summary, and the markdown table
  alignment is correct on every runner.
- [ ] CI: confirm a forced bench failure (e.g. wrong artifact
  name) fails the overall pipeline via
  `set-pipeline-exit-status`.

_claude --resume 9710922d-2b5f-400b-99f5-7db6d6ea8af8_