### PR TITLE
fix(complete): offer flags at every node and preserve bare `--`

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,13 @@ this file to empty for the next cycle.
 Empty between releases is the steady-state — there's no header,
 no scaffolding. Just write whatever should appear in the notes.
 -->
+
+Tab completion now offers flag candidates at every level of the
+command tree, not just leaf commands. `toolr --<Tab>` lists the
+binary's own root options (`--debug`, `--quiet`, `--timestamps`, …)
+alongside `--help`, and `--help` is offered at every group node
+(`toolr self --<Tab>`, `toolr self cache --<Tab>`, …) and on every
+leaf in addition to its own flags. A bare `--` typed as the
+in-progress word is now preserved through the engine — previously
+clap consumed it as the end-of-options marker and the shell saw
+an empty candidate list.

--- a/crates/toolr-core/src/complete/engine.rs
+++ b/crates/toolr-core/src/complete/engine.rs
@@ -11,8 +11,20 @@ use crate::manifest::{Argument, ArgumentKind, Command, Manifest};
 /// The returned vector is alphabetically sorted and deduplicated.
 pub fn serve_completions(manifest: &Manifest, tokens: &[String]) -> Vec<String> {
     let mut out = match classify(manifest, tokens) {
-        Slot::Group { prefix } => groups(manifest, &prefix),
-        Slot::Command { group, prefix } => commands(manifest, &group, &prefix),
+        Slot::Group { prefix } => {
+            if is_flag_prefix(&prefix) {
+                group_node_flags(&prefix)
+            } else {
+                groups(manifest, &prefix)
+            }
+        }
+        Slot::Command { group, prefix } => {
+            if is_flag_prefix(&prefix) {
+                group_node_flags(&prefix)
+            } else {
+                commands(manifest, &group, &prefix)
+            }
+        }
         Slot::Flag { command, prefix } => flags(command, &prefix),
         Slot::FlagValue { argument, prefix } => values(argument, &prefix),
         Slot::Positional { argument, prefix } => values(argument, &prefix),
@@ -21,6 +33,22 @@ pub fn serve_completions(manifest: &Manifest, tokens: &[String]) -> Vec<String> 
     out.sort();
     out.dedup();
     out
+}
+
+fn is_flag_prefix(prefix: &str) -> bool {
+    prefix.starts_with("--") || prefix == "-"
+}
+
+/// Group nodes (the root and any sub-group) carry no argument schema in
+/// the manifest, but clap injects `--help` on every subcommand. Offer it
+/// when the user has explicitly typed a flag prefix; binaries layer
+/// additional root-level flags on top via their own completion path.
+fn group_node_flags(prefix: &str) -> Vec<String> {
+    ["--help"]
+        .into_iter()
+        .filter(|f| f.starts_with(prefix))
+        .map(str::to_string)
+        .collect()
 }
 
 enum Slot<'a> {
@@ -373,7 +401,7 @@ fn commands(manifest: &Manifest, group: &str, prefix: &str) -> Vec<String> {
 }
 
 fn flags(command: &Command, prefix: &str) -> Vec<String> {
-    command
+    let mut out: Vec<String> = command
         .arguments
         .iter()
         .filter(|a| {
@@ -383,8 +411,15 @@ fn flags(command: &Command, prefix: &str) -> Vec<String> {
             )
         })
         .map(|a| format!("--{}", a.name.replace('_', "-")))
-        .filter(|flag| flag.starts_with(prefix))
-        .collect()
+        .collect();
+    // clap injects `--help` on every leaf, but only surface it when the
+    // user is explicitly probing flags (`--`/`-` prefix). The empty-prefix
+    // flag fallback that fires for argparse-style children still returns
+    // only the command's own flags, so existing behavior is preserved.
+    if is_flag_prefix(prefix) {
+        out.push("--help".to_string());
+    }
+    out.into_iter().filter(|flag| flag.starts_with(prefix)).collect()
 }
 
 fn values(argument: &Argument, prefix: &str) -> Vec<String> {

--- a/crates/toolr-core/src/complete/tests.rs
+++ b/crates/toolr-core/src/complete/tests.rs
@@ -131,8 +131,11 @@ fn command_prefix_filters_commands() {
 
 #[test]
 fn flag_prefix_lists_argument_flags() {
+    // `--help` is offered alongside the command's own flags whenever the
+    // user is explicitly probing flags (`--` prefix). clap injects it on
+    // every leaf, so the engine reflects that.
     let out = serve_completions(&fixture(), &tokens(&["ci", "hello", "--"]));
-    assert_eq!(out, vec!["--name".to_string()]);
+    assert_eq!(out, vec!["--help".to_string(), "--name".to_string()]);
 }
 
 #[test]
@@ -253,6 +256,49 @@ fn nested_command_completion_filters_by_prefix() {
     assert_eq!(out, vec!["start".to_string()]);
 }
 
+#[test]
+fn root_flag_prefix_offers_help() {
+    // Regression: `toolr --<TAB>` at the very top used to return an
+    // empty candidate list because the classifier landed on
+    // `Slot::Group` and `groups()` filtered out anything that didn't
+    // start with the literal prefix `--`. Group nodes carry no schema,
+    // so the engine emits `--help` directly.
+    let out = serve_completions(&fixture(), &tokens(&["--"]));
+    assert_eq!(out, vec!["--help".to_string()]);
+}
+
+#[test]
+fn nested_group_flag_prefix_offers_help() {
+    // Regression: `toolr docker --<TAB>` (sitting on a group, not a
+    // leaf) also dropped to nothing. `--help` must still surface.
+    let out = serve_completions(&nested_fixture(), &tokens(&["docker", "--"]));
+    assert_eq!(out, vec!["--help".to_string()]);
+}
+
+#[test]
+fn root_single_dash_prefix_offers_help() {
+    // `-` is a valid flag prefix even though no short alias is emitted
+    // by this engine. It must still produce `--help`.
+    let out = serve_completions(&fixture(), &tokens(&["-"]));
+    assert_eq!(out, vec!["--help".to_string()]);
+}
+
+#[test]
+fn group_node_empty_prefix_does_not_offer_help() {
+    // `toolr <TAB>` with an empty prefix must keep listing top-level
+    // groups, not inject `--help`. Help is for explicit flag probes.
+    let out = serve_completions(&fixture(), &tokens(&[""]));
+    assert_eq!(out, vec!["ci".to_string(), "data".to_string()]);
+}
+
+#[test]
+fn leaf_help_prefix_filters_to_help_only() {
+    // `toolr ci hello --he<TAB>` should narrow to `--help` even though
+    // the leaf has no `help` argument of its own.
+    let out = serve_completions(&fixture(), &tokens(&["ci", "hello", "--he"]));
+    assert_eq!(out, vec!["--help".to_string()]);
+}
+
 fn dispatcher_fixture() -> Manifest {
     // Mirrors the dashtastic shape: `jenkins job` is a dispatcher with
     // a couple of its own flags (`--dry-run`, `--cpu`) plus grafted
@@ -361,9 +407,13 @@ fn dispatcher_completion_filters_children_by_prefix() {
 #[test]
 fn dispatcher_flag_prefix_lists_dispatcher_flags_not_children() {
     // `toolr jenkins job --<TAB>` must offer the dispatcher's own
-    // flags, not the grafted child names.
+    // flags, not the grafted child names. `--help` is added by the
+    // engine because clap injects it on every subcommand.
     let out = serve_completions(&dispatcher_fixture(), &tokens(&["jenkins", "job", "--"]));
-    assert_eq!(out, vec!["--cpu".to_string(), "--dry-run".to_string()]);
+    assert_eq!(
+        out,
+        vec!["--cpu".to_string(), "--dry-run".to_string(), "--help".to_string()]
+    );
 }
 
 #[test]

--- a/crates/toolr/src/builtin_completions.rs
+++ b/crates/toolr/src/builtin_completions.rs
@@ -137,6 +137,20 @@ pub fn built_in_completion_entries() -> (Vec<Group>, Vec<Command>) {
     (groups, commands)
 }
 
+/// Root-level flags carried by the `toolr` binary itself (the long-form
+/// names; short aliases are intentionally omitted to match how the
+/// engine renders leaf flags). Mirror [`crate::cli::build_command`]'s
+/// root [`Arg`]s. Engine-level `--help` is offered separately by
+/// [`toolr_core::complete::serve_completions`] at every group node.
+pub const ROOT_LONG_FLAGS: &[&str] = &[
+    "--debug",
+    "--no-output-timeout-secs",
+    "--no-timestamps",
+    "--quiet",
+    "--timeout-secs",
+    "--timestamps",
+];
+
 fn top_group(name: &str, title: &str) -> Group {
     Group {
         name: name.into(),
@@ -337,6 +351,32 @@ mod tests {
                 "missing {expected} in {out:?}"
             );
         }
+    }
+
+    #[test]
+    fn root_long_flags_cover_every_root_arg_in_build_command() {
+        // Guardrail: if someone adds a root-level `Arg::new(...).long(...)`
+        // to `cli::build_command`, this constant must grow to match.
+        // `--help` lives in the engine (every group node gets it for
+        // free), so it's deliberately not listed here.
+        let expected: std::collections::BTreeSet<&str> = [
+            "--debug",
+            "--no-output-timeout-secs",
+            "--no-timestamps",
+            "--quiet",
+            "--timeout-secs",
+            "--timestamps",
+        ]
+        .into_iter()
+        .collect();
+        let actual: std::collections::BTreeSet<&str> =
+            ROOT_LONG_FLAGS.iter().copied().collect();
+        assert_eq!(actual, expected);
+        // Sorted asc so the engine's downstream `sort()` is a no-op
+        // and tests asserting alphabetical output stay deterministic.
+        let mut sorted = ROOT_LONG_FLAGS.to_vec();
+        sorted.sort();
+        assert_eq!(sorted.as_slice(), ROOT_LONG_FLAGS);
     }
 
     #[test]

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -504,10 +504,18 @@ fn run_complete(matches: &clap::ArgMatches) -> anyhow::Result<ExitCode> {
     let Some(cwd) = matches.get_one::<String>("cwd").map(PathBuf::from) else {
         return Ok(ExitCode::from(1));
     };
-    let tokens: Vec<String> = matches
-        .get_many::<String>("args")
-        .map(|v| v.cloned().collect())
-        .unwrap_or_default();
+    // Read tokens directly from argv rather than from clap's parsed
+    // `args` vec. clap consumes a bare `--` as the end-of-options
+    // marker before it reaches the trailing var arg, but shell
+    // completion scripts pass the user's in-progress `--<TAB>` word
+    // through unchanged. Falling back to raw argv keeps every literal
+    // token (including bare `--`) intact.
+    let tokens: Vec<String> = raw_complete_tokens(matches).unwrap_or_else(|| {
+        matches
+            .get_many::<String>("args")
+            .map(|v| v.cloned().collect())
+            .unwrap_or_default()
+    });
     // No `tools/` ancestor → no user-defined commands to complete, but
     // the binary's own `self` / `project` subtree must still be offered
     // (it doesn't depend on a project root). Fall back to an empty
@@ -522,10 +530,67 @@ fn run_complete(matches: &clap::ArgMatches) -> anyhow::Result<ExitCode> {
         crate::builtin_completions::built_in_completion_entries();
     manifest.groups.extend(extra_groups);
     manifest.commands.extend(extra_commands);
-    for candidate in serve_completions(&manifest, &tokens) {
+    let mut candidates = serve_completions(&manifest, &tokens);
+    // The engine emits `--help` at every group node (it's universal for
+    // clap subcommands), but the binary's other root-level flags
+    // (`--debug`, `--quiet`, `--timestamps`, …) live only in
+    // `cli::build_command` and need to be merged in for top-level
+    // `toolr --<TAB>` to surface them.
+    merge_root_flags_at_top_level(&tokens, &mut candidates);
+    for candidate in candidates {
         println!("{candidate}");
     }
     Ok(ExitCode::SUCCESS)
+}
+
+/// Re-derive the completion tokens from raw argv so a literal `--`
+/// typed as the in-progress word survives clap's end-of-options
+/// handling. Returns [`None`] when the structure doesn't look right
+/// (e.g. invoked as a library or via a non-standard entry point), in
+/// which case the caller falls back to clap's parsed view.
+///
+/// An optional explicit `--` separator inserted by completion scripts
+/// between the cwd and the in-progress tokens is stripped so future
+/// script revisions can adopt it without changing engine behavior.
+fn raw_complete_tokens(matches: &clap::ArgMatches) -> Option<Vec<String>> {
+    let cwd = matches.get_one::<String>("cwd")?;
+    let argv: Vec<String> = std::env::args().collect();
+    let marker_pos = argv.iter().position(|a| a == "__complete")?;
+    let after_marker = argv.get(marker_pos + 1..)?;
+    let cwd_pos = after_marker.iter().position(|a| a == cwd)?;
+    let mut rest: Vec<String> = after_marker[cwd_pos + 1..].to_vec();
+    // Strip a leading `--` ONLY when more tokens follow. That preserves
+    // the meaning of a trailing bare `--` (the user's in-progress word
+    // when they type `toolr --<TAB>`) while letting completion scripts
+    // optionally pass an explicit separator before the real tokens.
+    if rest.len() >= 2 && rest[0] == "--" {
+        rest.remove(0);
+    }
+    Some(rest)
+}
+
+/// When the user is completing a flag at the root (`toolr --<TAB>` or
+/// `toolr -<TAB>`), merge the binary's own root flags into the candidate
+/// list returned by the engine. No-op for any other slot.
+fn merge_root_flags_at_top_level(tokens: &[String], candidates: &mut Vec<String>) {
+    let Some(prefix) = tokens.last() else {
+        return;
+    };
+    let committed = &tokens[..tokens.len() - 1];
+    if !committed.is_empty() {
+        return;
+    }
+    let is_flag_prefix = prefix.starts_with("--") || prefix == "-";
+    if !is_flag_prefix {
+        return;
+    }
+    for flag in crate::builtin_completions::ROOT_LONG_FLAGS {
+        if flag.starts_with(prefix.as_str()) {
+            candidates.push((*flag).to_string());
+        }
+    }
+    candidates.sort();
+    candidates.dedup();
 }
 
 fn empty_manifest_for_completion() -> Manifest {

--- a/crates/toolr/tests/complete_smoke.rs
+++ b/crates/toolr/tests/complete_smoke.rs
@@ -182,6 +182,71 @@ fn completes_builtins_when_no_tools_dir_anywhere() {
 }
 
 #[test]
+fn completes_root_flags_on_double_dash_prefix() {
+    // Regression: `toolr --<TAB>` returned nothing because the engine
+    // landed on the top-level group slot and never offered flags. The
+    // binary's root options must surface alongside the engine-level
+    // `--help`.
+    let tmp = fixture();
+    let stdout = complete(&tmp, &["--"]);
+    let mut lines: Vec<&str> = stdout.lines().collect();
+    lines.sort();
+    assert_eq!(
+        lines,
+        vec![
+            "--debug",
+            "--help",
+            "--no-output-timeout-secs",
+            "--no-timestamps",
+            "--quiet",
+            "--timeout-secs",
+            "--timestamps",
+        ]
+    );
+}
+
+#[test]
+fn completes_root_flag_prefix_filters_to_matching_flags() {
+    // Narrower prefix → only matching long flags.
+    let tmp = fixture();
+    let stdout = complete(&tmp, &["--no"]);
+    let mut lines: Vec<&str> = stdout.lines().collect();
+    lines.sort();
+    assert_eq!(lines, vec!["--no-output-timeout-secs", "--no-timestamps"]);
+}
+
+#[test]
+fn completes_help_at_group_node() {
+    // `toolr ci --<TAB>` sits on a group; clap injects `--help` on
+    // every subcommand, so completion must follow suit.
+    let tmp = fixture();
+    let stdout = complete(&tmp, &["ci", "--"]);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        lines.contains(&"--help"),
+        "expected --help under group node, got: {stdout}"
+    );
+}
+
+#[test]
+fn completes_help_alongside_leaf_flags() {
+    // `toolr ci hello --<TAB>` should offer `--help` alongside the
+    // leaf's own flags. `hello` has `name="world"` which the parser
+    // surfaces as the `--name` optional flag.
+    let tmp = fixture();
+    let stdout = complete(&tmp, &["ci", "hello", "--"]);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        lines.contains(&"--help"),
+        "expected --help at leaf node, got: {stdout}"
+    );
+    assert!(
+        lines.contains(&"--name"),
+        "expected --name preserved at leaf node, got: {stdout}"
+    );
+}
+
+#[test]
 fn self_completion_print_emits_bash_script() {
     let tmp = TempDir::new().unwrap();
     let output = Command::cargo_bin("toolr")


### PR DESCRIPTION
## Summary

Tab completion only emitted flag candidates on leaf commands, so:

- `toolr <Tab>` listed groups (`ci`, `project`, `self`, `version`) but `toolr --<Tab>` produced nothing.
- `toolr self <Tab>` listed sub-children, but `toolr self --<Tab>` and `toolr self cache --<Tab>` (and every other group node) were silent.
- Even leaves missed `--help` despite clap injecting it on every subcommand.

A second, latent issue: the user's in-progress `--` word was eaten by clap's end-of-options handling inside `__complete`, so even with engine fixes a bare `--<Tab>` arrived as an empty token list.

| Invocation | Before | After |
| --- | --- | --- |
| `toolr --<Tab>` | _(nothing)_ | `--debug --help --no-output-timeout-secs --no-timestamps --quiet --timeout-secs --timestamps` |
| `toolr self --<Tab>` | _(nothing)_ | `--help` |
| `toolr self cache --<Tab>` | _(nothing)_ | `--help` |
| `toolr self cache prune --<Tab>` | `--all --dry-run --stale-after-days --yes` | adds `--help` |
| `toolr ci hello --<Tab>` | `--name` | adds `--help` |
| `toolr <Tab>` (empty prefix) | unchanged | unchanged |

## Changes

- **`crates/toolr-core/src/complete/engine.rs`** — emit `--help` at every group node when the prefix starts with `--`/`-`; append `--help` to leaf `flags()` under the same condition. The empty-prefix flag fallback used by argparse-style leaves is preserved.
- **`crates/toolr/src/builtin_completions.rs`** — publish `ROOT_LONG_FLAGS` mirroring the root `Arg`s in `cli::build_command`. A test guards against drift.
- **`crates/toolr/src/dispatch.rs`** — `run_complete` re-derives completion tokens from raw argv so a literal `--` typed as the in-progress word survives. A leading `--` followed by more tokens is stripped so future completion-script revisions can adopt an explicit separator without changing engine behavior.

`--help` lives only in the engine (every group/leaf inherits it from clap); `ROOT_LONG_FLAGS` deliberately excludes it to avoid the engine and the binary fighting over the same candidate.

## Test plan

- [x] `cargo test --workspace` — all suites green (6 new completion tests in `toolr-core` + 4 new integration tests in `complete_smoke.rs`).
- [x] `uv run pytest` — 423 passed, 8 skipped.
- [x] `prek run --files <changed>` — clean.
- [x] `cargo xtask build-skill-refs --check` — clean.
- [x] Manual end-to-end probe via `target/debug/toolr __complete <cwd> …` covering top-level, every group depth, and leaf commands with `--`, `--he`, `--d`, `--no`, `-`, and empty prefixes.

Notes for release: queued in `UNRELEASED.md`.