### PR TITLE
chore(deps): bump ruff to v0.15.16 + plug lockfile/grouping gaps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,6 +156,21 @@ repos:
 
   - repo: local
     hooks:
+      # Auto-fix style (mirrors `build-skill-refs`): `cargo fetch`
+      # resolves the dependency graph and minimally rewrites
+      # `Cargo.lock` to match `Cargo.toml` without gratuitously
+      # bumping unrelated transitives the way `cargo update` would.
+      # If the rewrite changes bytes on disk, prek sees the
+      # modification and fails the commit; re-stage the fresh
+      # lockfile and commit again. No compilation — the heavier
+      # `cargo check` hooks below pick that up on `.rs` changes.
+      - id: cargo-lock
+        name: Sync Cargo.lock with Cargo.toml
+        entry: cargo fetch
+        language: system
+        pass_filenames: false
+        files: ^(Cargo\.toml|Cargo\.lock|crates/[^/]+/Cargo\.toml)$
+
       # Does it compile?
       - id: cargo-check
         name: cargo check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.15#db5aa0a5f1b92cb91d910bf0866a967554dd94f5"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.16#6c498ab5394edc5622d7f348e12956bf86203716"
 dependencies = [
  "aho-corasick",
  "bitflags",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_parser"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.15#db5aa0a5f1b92cb91d910bf0866a967554dd94f5"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.16#6c498ab5394edc5622d7f348e12956bf86203716"
 dependencies = [
  "bitflags",
  "bstr",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_trivia"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.15#db5aa0a5f1b92cb91d910bf0866a967554dd94f5"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.16#6c498ab5394edc5622d7f348e12956bf86203716"
 dependencies = [
  "itertools",
  "ruff_source_file",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "ruff_source_file"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.15#db5aa0a5f1b92cb91d910bf0866a967554dd94f5"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.16#6c498ab5394edc5622d7f348e12956bf86203716"
 dependencies = [
  "memchr",
  "ruff_text_size",
@@ -1897,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.15.15#db5aa0a5f1b92cb91d910bf0866a967554dd94f5"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.16#6c498ab5394edc5622d7f348e12956bf86203716"
 dependencies = [
  "get-size2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ libc = "0.2"
 email_address = "0.2"
 pep440_rs = "0.7"
 walkdir = "2"
-ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.15" }
-ruff_python_ast    = { git = "https://github.com/astral-sh/ruff", tag = "0.15.15" }
-ruff_text_size     = { git = "https://github.com/astral-sh/ruff", tag = "0.15.15" }
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.16" }
+ruff_python_ast    = { git = "https://github.com/astral-sh/ruff", tag = "0.15.16" }
+ruff_text_size     = { git = "https://github.com/astral-sh/ruff", tag = "0.15.16" }
 tempfile = "3.20"
 signal-hook = "0.4"
 toml = "1"

--- a/renovate.json5
+++ b/renovate.json5
@@ -49,11 +49,16 @@
     // ---- Grouping to cut PR noise ----
     {
       // The three ruff_* crates share one astral-sh/ruff git tag —
-      // they must move in lockstep.
+      // they must move in lockstep. They're declared as cargo git
+      // deps, so Renovate routes them through the `git-tags`
+      // datasource and the `packageName` becomes the git URL
+      // (`https://github.com/astral-sh/ruff`), not the crate name.
+      // Match by `depName` (the manifest-side crate identifier)
+      // instead — same shape as the `mise tools` rule below.
       description: "Group ruff_* crates",
       groupName: "ruff crates",
       matchManagers: ["cargo"],
-      matchPackageNames: [
+      matchDepNames: [
         "ruff_python_ast",
         "ruff_python_parser",
         "ruff_text_size",


### PR DESCRIPTION
## Summary

Three small changes triggered by bumping the `astral-sh/ruff` git deps to v0.15.16:

1. **`chore(prek): sync Cargo.lock with Cargo.toml via cargo-lock hook`** — adds a local prek hook gated on `Cargo.toml`/`Cargo.lock` that runs `cargo fetch` so the resolver minimally rewrites the lockfile to match the manifest. Auto-fix style (mirrors `build-skill-refs`): if the rewrite changes bytes, prek sees the modification and fails the commit so the contributor re-stages and commits again. Plugs the gap where a pure manifest bump skipped the existing `cargo check` / `clippy` hooks (gated on `types: [rust]`) and let `Cargo.toml` land without a matching `Cargo.lock` update.

2. **`chore(deps): update astral-sh/ruff git deps to v0.15.16`** — bumps `ruff_python_parser`, `ruff_python_ast`, and `ruff_text_size` from `0.15.15` to `0.15.16`. The three crates share a single `astral-sh/ruff` tag and ship together, so this lands as one commit rather than three.

3. **`fix(renovate): match ruff_* crates by depName so grouping fires`** — the ruff crates land in `Cargo.toml` as cargo git-tag deps; Renovate routes those through the `git-tags` datasource and sets `packageName` to the git URL, not the crate name. The old `matchPackageNames` rule listed crate names, so it never matched and Renovate cut three separate PRs per bump (#319 / #320 / #321 in the v0.15.16 cycle). Switched to `matchDepNames`, mirroring the `mise tools` rule below.

## Closes

Closes #319
Closes #320
Closes #321

## Test plan

- [x] `cargo fetch` rewrites `Cargo.lock` minimally on a stale lockfile (only the 5 ruff git entries change; no transitives bumped)
- [x] New `cargo-lock` prek hook fires on `Cargo.toml` changes (manually verified via `prek run cargo-lock --files Cargo.toml`)
- [ ] `mise run test` green (CI)
- [ ] Renovate grouping fix verified next cycle (single grouped PR when next ruff tag lands)