### PR TITLE
Runner path hygiene: -P, repo-root on sys.path, run from repo root

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -31,6 +31,16 @@ comment.
   execution-free third-party glob). Repository code runs only on explicit
   command dispatch, through a provenance-verified interpreter. A committed
   `tools/.venv` is refused unless toolr provisioned it (`toolr project venv sync`).
+- The toolr runner no longer puts the invocation directory on `sys.path` (the
+  interpreter is started with `-P`), preventing a stray `.py` file in your
+  current directory from shadowing stdlib/site-packages modules.
+
+### Changed
+
+- Commands now run with the working directory set to the repo root (like
+  `make`/`cargo`). Relative path arguments resolve from the repo root, not your
+  current directory; toolr prints a one-line note if you pass a relative path
+  from a subdirectory.
 
 ### Removed
 

--- a/crates/toolr-core/src/execute/spawn.rs
+++ b/crates/toolr-core/src/execute/spawn.rs
@@ -4,15 +4,22 @@ use std::io;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
-/// Spawn `<python> -m toolr._runner` with:
+/// The fixed argv (after the interpreter) for the runner.
+///
+/// `-P` enables safe-path mode (drops the implicit CWD `sys.path` entry); it is
+/// a flag, so it is NOT inherited by child processes the command spawns.
+fn runner_args() -> [&'static str; 3] {
+    ["-P", "-m", "toolr._runner"]
+}
+
+/// Spawn `<python> -P -m toolr._runner` with:
 ///
 /// - `TOOLR_SPEC_FILE` set to `spec_path`.
 /// - stdin/stdout/stderr inherited untouched (so Rich's TTY detection,
 ///   tools that read stdin, etc., all work).
 pub fn spawn_runner(python: &Path, spec_path: &Path) -> io::Result<Child> {
     Command::new(python)
-        .arg("-m")
-        .arg("toolr._runner")
+        .args(runner_args())
         .env("TOOLR_SPEC_FILE", spec_path)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -30,5 +37,12 @@ mod tests {
         let bogus = PathBuf::from("/definitely/not/a/real/python-binary-xyz");
         let result = spawn_runner(&bogus, Path::new("/tmp/whatever.json"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn spawn_runner_passes_safe_path_flag_before_module() {
+        // We can't run a real interpreter here; assert the argv we build.
+        let args = runner_args();
+        assert_eq!(args, ["-P", "-m", "toolr._runner"]);
     }
 }

--- a/crates/toolr-core/src/execute/spawn.rs
+++ b/crates/toolr-core/src/execute/spawn.rs
@@ -14,12 +14,18 @@ fn runner_args() -> [&'static str; 3] {
 
 /// Spawn `<python> -P -m toolr._runner` with:
 ///
+/// - working directory set to `repo_root`, so the command runs from the
+///   project root regardless of where the user invoked toolr (the
+///   make/cargo convention). Child processes the command spawns inherit
+///   this cwd. The runner itself no longer chdirs.
 /// - `TOOLR_SPEC_FILE` set to `spec_path`.
 /// - stdin/stdout/stderr inherited untouched (so Rich's TTY detection,
 ///   tools that read stdin, etc., all work).
-pub fn spawn_runner(python: &Path, spec_path: &Path) -> io::Result<Child> {
+pub fn spawn_runner(python: &Path, spec_path: &Path, repo_root: &Path) -> io::Result<Child> {
+    // nosemgrep: rust.actix.command-injection.rust-actix-command-injection.rust-actix-command-injection
     Command::new(python)
         .args(runner_args())
+        .current_dir(repo_root)
         .env("TOOLR_SPEC_FILE", spec_path)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -35,7 +41,7 @@ mod tests {
     #[test]
     fn spawn_with_nonexistent_python_returns_io_error() {
         let bogus = PathBuf::from("/definitely/not/a/real/python-binary-xyz");
-        let result = spawn_runner(&bogus, Path::new("/tmp/whatever.json"));
+        let result = spawn_runner(&bogus, Path::new("/tmp/whatever.json"), Path::new("/tmp"));
         assert!(result.is_err());
     }
 

--- a/crates/toolr-core/src/project.rs
+++ b/crates/toolr-core/src/project.rs
@@ -277,4 +277,38 @@ mod tests {
         // Manifest rebuilt as the final step.
         assert!(tools.join(".toolr-manifest.json").is_file());
     }
+
+    #[test]
+    #[cfg(unix)]
+    fn finalize_sync_preserves_an_existing_sidecar() {
+        // When a sidecar already exists, finalize_sync takes the
+        // `Meta::load -> Ok(existing)` branch and preserves `created_at`
+        // (rather than minting a fresh one), restamping the interpreter.
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let venv_dir = tmp.path().join("cache-entry").join("venv");
+        let bin = venv_dir.join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let py = bin.join("python");
+        std::fs::write(&py, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&py, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let repo_root = tmp.path().join("proj");
+        let tools = repo_root.join("tools");
+        std::fs::create_dir_all(&tools).unwrap();
+        std::fs::write(tools.join("ci.py"), "\"\"\"CI.\"\"\"\ngroup = command_group(\"ci\", \"CI\")\n").unwrap();
+
+        // Pre-seed a sidecar so the `Ok(existing)` branch runs.
+        let cache_dir = venv_dir.parent().unwrap();
+        Meta::new(&repo_root, "old-version", "3.13").write(cache_dir).unwrap();
+        let created = Meta::load(cache_dir).unwrap().created_at;
+
+        let resolved = make_resolved_cache(venv_dir.clone(), "abc");
+        finalize_sync(&repo_root, &resolved).unwrap();
+
+        let meta = Meta::load(cache_dir).unwrap();
+        assert_eq!(meta.created_at, created, "created_at preserved from the existing sidecar");
+        assert!(meta.interpreter_path.is_some(), "interpreter restamped");
+    }
 }

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -410,6 +410,19 @@ def _print_missing_dep_hint(exc: ImportError, stream: Any) -> None:
     )
 
 
+def _append_repo_root(repo_root: str, path_list: list[str] | None = None) -> None:
+    """Append ``repo_root`` to ``sys.path`` so ``import tools.*`` resolves.
+
+    Append (not insert) so stdlib and site-packages win — only ``tools.*``,
+    which nothing else provides, resolves from the repo. Idempotent.
+    """
+    import sys  # noqa: PLC0415
+
+    target = sys.path if path_list is None else path_list
+    if repo_root not in target:
+        target.append(repo_root)
+
+
 def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
     """Execute the command described by ``spec``. Returns a process exit code.
 

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -410,6 +410,36 @@ def _print_missing_dep_hint(exc: ImportError, stream: Any) -> None:
     )
 
 
+def _warn_if_paths_relative_to_invocation(
+    invocation_cwd: Path,
+    repo_root: Path,
+    values: list[Any],
+    stream: Any,
+) -> None:
+    """Emit one note iff cwd != repo_root AND a coerced arg is a relative Path.
+
+    Type-driven, never heuristic: only ``pathlib.Path`` instances (which all
+    ``toolr.types`` path-constrained args coerce to) count. ``str`` args are
+    never inspected for path-likeness.
+    """
+    if invocation_cwd.resolve() == repo_root.resolve():
+        return
+
+    def _is_rel_path(value: Any) -> bool:
+        if isinstance(value, Path):
+            return not value.is_absolute()
+        if isinstance(value, (list, tuple)):
+            return any(isinstance(x, Path) and not x.is_absolute() for x in value)
+        return False
+
+    if any(_is_rel_path(value) for value in values):
+        print(
+            f"toolr: note: commands run from the repo root ({repo_root}); "
+            f"relative path arguments resolve from there, not {invocation_cwd}",
+            file=stream,
+        )
+
+
 def _append_repo_root(repo_root: str, path_list: list[str] | None = None) -> None:
     """Append ``repo_root`` to ``sys.path`` so ``import tools.*`` resolves.
 

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -15,9 +15,17 @@ on are all supported "for free" via msgspec's coercion rules.
 
 from __future__ import annotations
 
+import datetime
+import importlib
 import inspect
+import ipaddress
 import os
+import pathlib
+import sys
+import traceback
+import uuid
 import warnings
+from argparse import ArgumentParser
 from pathlib import Path
 from types import UnionType
 from typing import TYPE_CHECKING
@@ -29,16 +37,18 @@ from typing import get_origin
 from typing import get_type_hints
 
 import msgspec
+from packaging.version import Version
 
+from toolr._context import Context
 from toolr._exc import ToolrDeprecationWarning
 from toolr.sources import CommandSchema
 from toolr.sources import DispatchCommand
+from toolr.utils._console import Consoles
+from toolr.utils._console import ConsoleVerbosity
 from toolr.utils._signature import detect_dispatch_parameter
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from toolr._context import Context
 
 # Promote toolr's own deprecation warnings to visible-by-default. The
 # stdlib silences DeprecationWarning by default for non-__main__ code,
@@ -183,15 +193,6 @@ def load_spec_from_env() -> RunnerSpec:
 
 def _build_context(spec: RunnerSpec) -> Context:
     """Construct a minimal :class:`toolr.Context` from a :class:`RunnerSpec`."""
-    # Late imports — keep module-load fast and avoid pulling rich into pure
-    # spec-decoding code paths.
-    import pathlib  # noqa: PLC0415
-    from argparse import ArgumentParser  # noqa: PLC0415
-
-    from toolr._context import Context  # noqa: PLC0415
-    from toolr.utils._console import Consoles  # noqa: PLC0415
-    from toolr.utils._console import ConsoleVerbosity  # noqa: PLC0415
-
     verbosity_map = {
         "quiet": ConsoleVerbosity.QUIET,
         "normal": ConsoleVerbosity.NORMAL,
@@ -220,10 +221,11 @@ def _build_context(spec: RunnerSpec) -> Context:
 
 def _import_target(spec: RunnerSpec) -> Any:
     """Import ``spec.module`` and return the attribute named ``spec.function``."""
-    import importlib  # noqa: PLC0415
-
     try:
-        module = importlib.import_module(spec.module)
+        # `spec.module` comes from the toolr-controlled manifest/spec (written by
+        # the toolr binary), not untrusted external input. SEC-05 tracks
+        # defense-in-depth confinement of the import target.
+        module = importlib.import_module(spec.module)  # nosemgrep
     except ImportError as exc:
         msg = f"failed to import {spec.module}: {exc}"
         raise SpecError(msg) from exc
@@ -261,30 +263,23 @@ def _dec_hook(target_type: type, obj: Any) -> Any:  # noqa: PLR0911
     into the matching Python type so the command function receives the
     expected type.
     """
-    import datetime as _dt  # noqa: PLC0415
-    import ipaddress as _ip  # noqa: PLC0415
-    import pathlib as _path  # noqa: PLC0415
-    import uuid as _uuid  # noqa: PLC0415
-
-    from packaging.version import Version as _PkgVersion  # noqa: PLC0415
-
     if isinstance(obj, str):
-        if isinstance(target_type, type) and issubclass(target_type, _path.PurePath):
+        if isinstance(target_type, type) and issubclass(target_type, pathlib.PurePath):
             return target_type(obj)
-        if target_type is _dt.datetime:
-            return _dt.datetime.fromisoformat(obj)
-        if target_type is _dt.date:
-            return _dt.date.fromisoformat(obj)
-        if target_type is _dt.time:
-            return _dt.time.fromisoformat(obj)
-        if target_type is _uuid.UUID:
-            return _uuid.UUID(obj)
-        if target_type is _ip.IPv4Address:
-            return _ip.IPv4Address(obj)
-        if target_type is _ip.IPv6Address:
-            return _ip.IPv6Address(obj)
-        if target_type is _PkgVersion:
-            return _PkgVersion(obj)
+        if target_type is datetime.datetime:
+            return datetime.datetime.fromisoformat(obj)
+        if target_type is datetime.date:
+            return datetime.date.fromisoformat(obj)
+        if target_type is datetime.time:
+            return datetime.time.fromisoformat(obj)
+        if target_type is uuid.UUID:
+            return uuid.UUID(obj)
+        if target_type is ipaddress.IPv4Address:
+            return ipaddress.IPv4Address(obj)
+        if target_type is ipaddress.IPv6Address:
+            return ipaddress.IPv6Address(obj)
+        if target_type is Version:
+            return Version(obj)
     msg = f"toolr runner: don't know how to coerce {type(obj).__name__} → {target_type!r}"
     raise TypeError(msg)
 
@@ -410,56 +405,20 @@ def _print_missing_dep_hint(exc: ImportError, stream: Any) -> None:
     )
 
 
-def _warn_if_paths_relative_to_invocation(
-    invocation_cwd: Path,
-    repo_root: Path,
-    values: list[Any],
-    stream: Any,
-) -> None:
-    """Emit one note iff cwd != repo_root AND a coerced arg is a relative Path.
-
-    Type-driven, never heuristic: only ``pathlib.Path`` instances (which all
-    ``toolr.types`` path-constrained args coerce to) count. ``str`` args are
-    never inspected for path-likeness.
-    """
-    if invocation_cwd.resolve() == repo_root.resolve():
-        return
-
-    def _is_rel_path(value: Any) -> bool:
-        if isinstance(value, Path):
-            return not value.is_absolute()
-        if isinstance(value, (list, tuple)):
-            return any(isinstance(x, Path) and not x.is_absolute() for x in value)
-        return False
-
-    if any(_is_rel_path(value) for value in values):
-        print(
-            f"toolr: note: commands run from the repo root ({repo_root}); "
-            f"relative path arguments resolve from there, not {invocation_cwd}",
-            file=stream,
-        )
-
-
 def _append_repo_root(repo_root: str, path_list: list[str] | None = None) -> None:
     """Append ``repo_root`` to ``sys.path`` so ``import tools.*`` resolves.
 
     Append (not insert) so stdlib and site-packages win — only ``tools.*``,
     which nothing else provides, resolves from the repo. Idempotent.
-    """
-    import sys  # noqa: PLC0415
 
+    This is the one cwd/path concern that must stay in the runner: it needs
+    *append* semantics (repo_root last), which `PYTHONPATH` cannot express
+    (it prepends, ahead of stdlib + site-packages). The chdir and the
+    relative-path warning both live on the Rust side.
+    """
     target = sys.path if path_list is None else path_list
     if repo_root not in target:
         target.append(repo_root)
-
-
-def _chdir_or_raise(repo_root: Path) -> None:
-    """``os.chdir`` into ``repo_root``, surfacing a clear error on failure."""
-    try:
-        os.chdir(repo_root)
-    except OSError as exc:
-        msg = f"failed to enter repo root {repo_root}: {exc}"
-        raise SpecError(msg) from exc
 
 
 def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
@@ -468,16 +427,14 @@ def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
     ``ctx.exit(status, ...)`` raises :class:`SystemExit`; we honor its code.
     Any other uncaught exception is logged to stderr and returns 1.
     """
-    import sys  # noqa: PLC0415
-
-    # Capture the invocation cwd before any chdir; it's a runner-internal
-    # local (not part of Context or the wire format).
-    invocation_cwd = Path.cwd()
     repo_root = Path(spec.context.repo_root)
     try:
         ctx = _build_context(spec)
         # `''` is gone from sys.path (the interpreter ran with `-P`), so make
-        # `import tools.*` resolve regardless of where toolr was invoked.
+        # `import tools.*` resolve regardless of where toolr was invoked. The
+        # working directory is already repo_root (the Rust side spawned the
+        # runner with `current_dir(repo_root)`); the relative-path warning also
+        # lives on the Rust side, which knows the cwd, arg types, and values.
         _append_repo_root(str(repo_root))
         target = _import_target(spec)
         if spec.dispatch is not None:
@@ -487,13 +444,6 @@ def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
             # the parent's hints — `invoke_dispatcher` injects the
             # `DispatchCommand` keyword on top of those.
             _, parent_kwargs = _coerce_args(target, spec.args)
-            # Best-effort: only the parent's coerced kwargs are checked; a
-            # dispatched child's relative path args are coerced inside
-            # `invoke_dispatcher` and are not covered by this warning.
-            _warn_if_paths_relative_to_invocation(
-                invocation_cwd, repo_root, list(parent_kwargs.values()), sys.stderr
-            )
-            _chdir_or_raise(repo_root)
             invoke_dispatcher(
                 ctx=ctx,
                 func=target,
@@ -504,10 +454,6 @@ def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
             )
         else:
             var_args, kw_args = _coerce_args(target, spec.args)
-            _warn_if_paths_relative_to_invocation(
-                invocation_cwd, repo_root, [*var_args, *kw_args.values()], sys.stderr
-            )
-            _chdir_or_raise(repo_root)
             target(ctx, *var_args, **kw_args)
     except SystemExit as exc:
         code = exc.code
@@ -516,13 +462,9 @@ def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
         if isinstance(code, int):
             return code
         # str / other: print and return 1
-        import sys  # noqa: PLC0415
-
         print(code, file=sys.stderr)  # noqa: T201
         return 1
     except SpecError as exc:
-        import sys  # noqa: PLC0415
-
         print(f"toolr runner: {exc}", file=sys.stderr)  # noqa: T201
         # `_import_target` wraps an ImportError thrown while loading the
         # user's command module into a SpecError. Surface the missing-dep
@@ -537,16 +479,10 @@ def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
         # bypasses `_import_target` entirely. Print the traceback and
         # add the same hint so the user gets the same affordance as a
         # top-level import failure.
-        import sys  # noqa: PLC0415
-        import traceback  # noqa: PLC0415
-
         traceback.print_exc(file=sys.stderr)
         _print_missing_dep_hint(exc, sys.stderr)
         return 1
     except Exception:  # noqa: BLE001
-        import sys  # noqa: PLC0415
-        import traceback  # noqa: PLC0415
-
         traceback.print_exc(file=sys.stderr)
         return 1
     return 0
@@ -557,14 +493,10 @@ def main() -> int:
     try:
         spec = load_spec_from_env()
     except SpecError as exc:
-        import sys  # noqa: PLC0415
-
         print(f"toolr runner: {exc}", file=sys.stderr)  # noqa: T201
         return 2
     return run(spec)
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(main())

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -453,14 +453,32 @@ def _append_repo_root(repo_root: str, path_list: list[str] | None = None) -> Non
         target.append(repo_root)
 
 
+def _chdir_or_raise(repo_root: Path) -> None:
+    """``os.chdir`` into ``repo_root``, surfacing a clear error on failure."""
+    try:
+        os.chdir(repo_root)
+    except OSError as exc:
+        msg = f"failed to enter repo root {repo_root}: {exc}"
+        raise SpecError(msg) from exc
+
+
 def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
     """Execute the command described by ``spec``. Returns a process exit code.
 
     ``ctx.exit(status, ...)`` raises :class:`SystemExit`; we honor its code.
     Any other uncaught exception is logged to stderr and returns 1.
     """
+    import sys  # noqa: PLC0415
+
+    # Capture the invocation cwd before any chdir; it's a runner-internal
+    # local (not part of Context or the wire format).
+    invocation_cwd = Path.cwd()
+    repo_root = Path(spec.context.repo_root)
     try:
         ctx = _build_context(spec)
+        # `''` is gone from sys.path (the interpreter ran with `-P`), so make
+        # `import tools.*` resolve regardless of where toolr was invoked.
+        _append_repo_root(str(repo_root))
         target = _import_target(spec)
         if spec.dispatch is not None:
             # Dispatched leaf: `target` is the parent dispatcher, `args`
@@ -469,6 +487,13 @@ def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
             # the parent's hints — `invoke_dispatcher` injects the
             # `DispatchCommand` keyword on top of those.
             _, parent_kwargs = _coerce_args(target, spec.args)
+            # Best-effort: only the parent's coerced kwargs are checked; a
+            # dispatched child's relative path args are coerced inside
+            # `invoke_dispatcher` and are not covered by this warning.
+            _warn_if_paths_relative_to_invocation(
+                invocation_cwd, repo_root, list(parent_kwargs.values()), sys.stderr
+            )
+            _chdir_or_raise(repo_root)
             invoke_dispatcher(
                 ctx=ctx,
                 func=target,
@@ -479,6 +504,10 @@ def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
             )
         else:
             var_args, kw_args = _coerce_args(target, spec.args)
+            _warn_if_paths_relative_to_invocation(
+                invocation_cwd, repo_root, [*var_args, *kw_args.values()], sys.stderr
+            )
+            _chdir_or_raise(repo_root)
             target(ctx, *var_args, **kw_args)
     except SystemExit as exc:
         code = exc.code

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -328,7 +328,7 @@ pub fn dispatch(
         }
     }
 
-    let mut child = spawn_runner(&python, tempfile.path())
+    let mut child = spawn_runner(&python, tempfile.path(), &repo_root)
         .with_context(|| format!("spawning Python runner at {}", python.display()))?;
     let status = wait_with_signals(&mut child)?;
 

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -478,6 +478,24 @@ mod tests {
     }
 
     #[test]
+    fn build_spec_runs_the_relative_path_warning_wrapper() {
+        // Drives `warn_relative_paths` (the `std::env::current_dir()` +
+        // `eprintln!` wrapper, not just the pure `relative_path_warning`):
+        // a relative Path arg plus a repo_root that differs from the test's
+        // cwd makes the note fire. The note only goes to stderr; we just
+        // assert the spec still builds.
+        let cmd = cmd_with(vec![arg_of("file", ArgumentKind::Positional, SupportedType::Path)]);
+        let matches = path_matches(&["t", "rel/x.py"]);
+        let spec = build_spec(
+            &cmd,
+            &matches,
+            Path::new("/nonexistent-repo-xyz"),
+            &OutputOptions::default(),
+        );
+        assert!(spec.args.contains_key("file"));
+    }
+
+    #[test]
     fn build_spec_extracts_optional_arg_value() {
         let cmd = cmd_hello_with_name_arg();
         let matches = parse("Alice");

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -610,7 +610,10 @@ mod tests {
     #[test]
     fn no_warn_for_absolute_path_arg() {
         let cmd = cmd_with(vec![arg_of("file", ArgumentKind::Positional, SupportedType::Path)]);
-        let matches = path_matches(&["t", "/abs/x.py"]);
+        // `/abs/x.py` is NOT absolute on Windows (no drive letter), so use a
+        // platform-appropriate absolute path for the "is_absolute" check.
+        let abs = if cfg!(windows) { "C:\\abs\\x.py" } else { "/abs/x.py" };
+        let matches = path_matches(&["t", abs]);
         assert!(
             relative_path_warning(&cmd, &matches, Path::new("/repo"), Path::new("/repo/sub"))
                 .is_none()

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -28,6 +28,11 @@ pub fn build_spec(
     repo_root: &Path,
     output_opts: &OutputOptions,
 ) -> ExecutionSpec {
+    // SEC-02: the runner chdirs to repo_root, so a relative path typed from a
+    // subdirectory resolves from the repo root, not the user's cwd. Warn here
+    // (the Rust layer knows the cwd, the arg types, and which values the user
+    // actually typed) rather than after coercion in Python.
+    warn_relative_paths(cmd, matches, repo_root);
     let mut args = BTreeMap::new();
     for arg in &cmd.arguments {
         if let Some(value) = extract_value(arg, matches) {
@@ -115,6 +120,9 @@ pub fn build_dispatch_spec(
     repo_root: &Path,
     output_opts: &OutputOptions,
 ) -> ExecutionSpec {
+    // Covers the dispatcher's own (parent) args. A dispatched child's args are
+    // packed separately and not checked here — same scope as before.
+    warn_relative_paths(parent, parent_matches, repo_root);
     let mut parent_args = BTreeMap::new();
     for arg in &parent.arguments {
         if let Some(value) = extract_value(arg, parent_matches) {
@@ -334,6 +342,81 @@ fn extract_many(arg: &Argument, matches: &ArgMatches) -> Vec<Value> {
     }
 }
 
+/// True when `arg` is a path-typed argument whose value the user typed on
+/// the command line (not a default) and that value is a relative path.
+///
+/// Type-driven: only `SupportedType::Path` / `AbsolutePath` / `ResolvedPath`
+/// count — never a `str` arg that merely looks path-like. Source-precise:
+/// `ValueSource::CommandLine` only, so a relative *default* never warns.
+fn arg_has_relative_cli_path(arg: &Argument, matches: &ArgMatches) -> bool {
+    use clap::parser::ValueSource;
+
+    let is_path = matches!(
+        scalar_element_type(arg),
+        Some(SupportedType::Path | SupportedType::AbsolutePath | SupportedType::ResolvedPath)
+    );
+    if !is_path {
+        return false;
+    }
+    let name = arg.name.as_str();
+    if matches.value_source(name) != Some(ValueSource::CommandLine) {
+        return false;
+    }
+    let is_many = matches!(
+        arg.resolved_type.as_ref().map(unwrap_optional),
+        Some(SupportedType::Tuple(_))
+    ) || matches!(arg.kind, ArgumentKind::Repeated | ArgumentKind::VarPositional);
+    if is_many {
+        matches
+            .get_many::<std::path::PathBuf>(name)
+            .map(|it| it.into_iter().any(|p| !p.is_absolute()))
+            .unwrap_or(false)
+    } else {
+        matches
+            .get_one::<std::path::PathBuf>(name)
+            .map(|p| !p.is_absolute())
+            .unwrap_or(false)
+    }
+}
+
+/// The one-line note to print iff the invocation cwd differs from `repo_root`
+/// AND a path-typed argument was given a relative value on the command line.
+/// Pure (no I/O) so it can be unit-tested against constructed matches.
+pub(crate) fn relative_path_warning(
+    cmd: &Command,
+    matches: &ArgMatches,
+    repo_root: &Path,
+    cwd: &Path,
+) -> Option<String> {
+    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    if canon(cwd) == canon(repo_root) {
+        return None;
+    }
+    if !cmd
+        .arguments
+        .iter()
+        .any(|arg| arg_has_relative_cli_path(arg, matches))
+    {
+        return None;
+    }
+    Some(format!(
+        "toolr: note: commands run from the repo root ({}); relative path \
+         arguments resolve from there, not {}",
+        repo_root.display(),
+        cwd.display(),
+    ))
+}
+
+/// Side-effecting wrapper: resolve the invocation cwd and print the note (if
+/// any) to stderr. Called by the spec builders before the runner is spawned.
+fn warn_relative_paths(cmd: &Command, matches: &ArgMatches, repo_root: &Path) {
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Some(msg) = relative_path_warning(cmd, matches, repo_root, &cwd) {
+            eprintln!("{msg}");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -478,6 +561,57 @@ mod tests {
             dispatched_from: None,
             is_dispatcher: false,
         }
+    }
+
+    /// Parse `argv` against a single `file` arg with a `PathBuf` value-parser,
+    /// mirroring how the real CLI builder wires a `SupportedType::Path` arg.
+    fn path_matches(argv: &[&str]) -> ArgMatches {
+        clap::Command::new("t")
+            .arg(Arg::new("file").value_parser(clap::value_parser!(std::path::PathBuf)))
+            .try_get_matches_from(argv)
+            .expect("parse")
+    }
+
+    #[test]
+    fn warns_on_relative_path_arg_from_subdir() {
+        let cmd = cmd_with(vec![arg_of("file", ArgumentKind::Positional, SupportedType::Path)]);
+        let matches = path_matches(&["t", "rel/x.py"]);
+        let msg = relative_path_warning(&cmd, &matches, Path::new("/repo"), Path::new("/repo/sub"));
+        assert!(msg.is_some_and(|m| m.contains("repo root")), "expected a warning");
+    }
+
+    #[test]
+    fn no_warn_when_cwd_equals_repo_root() {
+        let cmd = cmd_with(vec![arg_of("file", ArgumentKind::Positional, SupportedType::Path)]);
+        let matches = path_matches(&["t", "rel/x.py"]);
+        assert!(
+            relative_path_warning(&cmd, &matches, Path::new("/repo"), Path::new("/repo")).is_none()
+        );
+    }
+
+    #[test]
+    fn no_warn_for_absolute_path_arg() {
+        let cmd = cmd_with(vec![arg_of("file", ArgumentKind::Positional, SupportedType::Path)]);
+        let matches = path_matches(&["t", "/abs/x.py"]);
+        assert!(
+            relative_path_warning(&cmd, &matches, Path::new("/repo"), Path::new("/repo/sub"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn no_warn_for_non_path_arg_even_if_value_looks_like_a_path() {
+        // A `str` arg whose value merely looks path-like must NOT warn —
+        // the check is type-driven, not heuristic.
+        let cmd = cmd_with(vec![arg_of("file", ArgumentKind::Positional, SupportedType::Str)]);
+        let matches = clap::Command::new("t")
+            .arg(Arg::new("file"))
+            .try_get_matches_from(["t", "rel/x.py"])
+            .expect("parse");
+        assert!(
+            relative_path_warning(&cmd, &matches, Path::new("/repo"), Path::new("/repo/sub"))
+                .is_none()
+        );
     }
 
     #[test]

--- a/docs/writing-commands/context.md
+++ b/docs/writing-commands/context.md
@@ -36,6 +36,20 @@ subprocess's output to the user's terminal.
 --8<-- "docs/writing-commands/files/example.py:34:45"
 ```
 
+## Working directory
+
+Commands run with the working directory set to the **repo root**, no
+matter where you invoke `toolr` from — the same convention `make` and
+`cargo` follow. `ctx.repo_root` always points there, and `ctx.run(...)`
+subprocesses inherit it as their cwd unless you override it.
+
+Because of this, a **relative path argument resolves from the repo
+root, not from your current directory**. Running `toolr build ./out.txt`
+from a subdirectory writes `<repo-root>/out.txt`. Pass an absolute path
+when you need a file relative to where you ran the command. toolr prints
+a one-line note on stderr if you pass a relative path argument from a
+subdirectory, so the behaviour is never silent.
+
 ## Prompting and exiting
 
 `ctx.prompt(...)` reads a line from stdin (returns the typed string,

--- a/skills/toolr-command-authoring/SKILL.md
+++ b/skills/toolr-command-authoring/SKILL.md
@@ -98,6 +98,23 @@ Add this to `tools/greet.py`, then `toolr greet hello --help` works.
 - **Calling subprocesses.** Use `ctx.run(...)`; it inherits stderr
   for TTY-aware tools and propagates timeouts.
 
+## Runtime working directory
+
+Commands run with the working directory set to the **repo root**,
+regardless of where you invoke `toolr` from (the `make`/`cargo`
+convention). Two consequences:
+
+- **Relative path arguments resolve from the repo root, not your
+  current directory.** `toolr build ./out.txt` run from `tools/`
+  writes `<repo-root>/out.txt`, not `<repo-root>/tools/out.txt`. Pass
+  an absolute path when you need a file relative to where you ran the
+  command. toolr prints a one-line note on stderr if you pass a
+  relative path argument from a subdirectory, so the surprise is
+  visible.
+- **`ctx.run(...)` subprocesses inherit the repo root as their cwd**
+  unless you override it, so paths in the commands you spawn are also
+  repo-root-relative by default.
+
 ## Static-only discovery contract
 
 toolr discovers commands **only by static analysis** of `tools/*.py` —

--- a/specs/2026-06-10-runner-path-hygiene-design.md
+++ b/specs/2026-06-10-runner-path-hygiene-design.md
@@ -1,0 +1,127 @@
+# Runner path hygiene: drop the implicit CWD from the interpreter, run from repo root
+
+**Date:** 2026-06-10
+**Status:** Proposed (brainstorming approved)
+**Depends on:** `specs/2026-06-10-static-only-manifest-design.md` (SEC-01). This branch is stacked on
+`static-only-manifest`; it assumes `_introspect.py` is gone and reuses the `untrusted_repo.rs` test harness.
+**Closes:** audit finding SEC-02.
+
+## Problem
+
+The Python runner is launched as `python -m toolr._runner` (`crates/toolr-core/src/execute/spawn.rs:12-21`).
+The `-m` switch unconditionally prepends the process's current working directory (`''`) to `sys.path`. The
+runner does not set the child's cwd and does not manage `sys.path`, so:
+
+1. **CWD shadowing.** Any `.py` file in the directory the user runs `toolr` from can shadow stdlib or
+   site-packages modules imported by the runner or by the command — including toolr's own startup imports
+   (`msgspec`, `rich`), since `''` is on the path before the runner's code executes.
+2. **Latent correctness bug.** `import tools.*` only resolves because `''` happens to be the repo root when
+   the user runs `toolr` from there. Run from a subdirectory, `''` is the subdirectory and `tools.*` would
+   fail to import.
+
+SEC-02's other reported vector — `_introspect.py` doing `sys.path.insert(0, project_root)` — is removed by
+SEC-01 (the whole introspection layer is deleted), so it is out of scope here.
+
+## Key facts established during design
+
+- `requires-python = ">=3.11"` (`crates/toolr/pyproject.toml:9`, `crates/toolr-py/pyproject.toml:9`), so the
+  `-P` interpreter flag and `PYTHONSAFEPATH` (both added in 3.11) are always available.
+- `repo_root` is already in the spec wire format (`crates/toolr-core/src/execute/spec.rs:52`, read at
+  `crates/toolr-py/python/toolr/_runner.py:211`). No `RUNNER_SCHEMA_VERSION` / Python `SCHEMA_VERSION` bump
+  is needed.
+- `spawn_runner` does not set the child's cwd, so at runner startup `os.getcwd()` is the user's invocation
+  directory — available for free, no new spec field.
+- After SEC-01, `spawn_runner` is the only `python -m toolr.*` entry point (the introspect spawn is gone), so
+  this is a single chokepoint.
+
+## Design
+
+### §1 — Use the `-P` flag, not the env var
+
+Spawn `python -P -m toolr._runner` (`spawn.rs`). `-P` enables safe-path mode for the runner interpreter only;
+unlike `PYTHONSAFEPATH=1`, a command-line flag is **not** inherited by child processes that a command spawns
+via `ctx.run`, so it never silently changes the path semantics of an author's subprocesses. `-P` applies at
+interpreter startup, so it protects the runner's own bootstrap imports (`msgspec`, `rich`) — earlier than any
+in-process `sys.path` fix could.
+
+### §2 — Append `repo_root` to `sys.path`
+
+With `''` gone, `import tools.*` no longer resolves. The runner appends `spec.context.repo_root` to
+`sys.path` (in `run()`, before `_import_target`). Append — not insert(0) — so stdlib and the venv's
+site-packages win; only `tools.*` (which nothing else provides) resolves from the repo. This eliminates
+sibling shadowing entirely rather than relocating it from CWD to repo_root. It also fixes the run-from-
+subdirectory import bug, because resolution no longer depends on where the user invoked toolr.
+
+Tradeoff (accepted): a venv package literally named `tools` would shadow the repo's `tools/`. Exotic, and the
+venv is the repo's own.
+
+### §3 — Run commands from the repo root
+
+Before invoking the command function, the runner `os.chdir(repo_root)`. This gives commands a predictable
+working directory regardless of where the user invoked toolr (the make/cargo convention), and makes
+`ctx.run` subprocesses run from the repo root by default. Because `-P` already removed `''` from `sys.path`,
+the chdir does not reintroduce any import shadowing.
+
+### §4 — Relative path arguments resolve from repo root (documented, not rewritten)
+
+The chdir changes what a relative path **argument** means: `toolr build ./x.py` run from a subdirectory now
+resolves `./x.py` against the repo root. We do **not** silently rewrite path args (no magical path building) —
+the contract is "paths are resolved from the repo root," documented in the command-authoring guide.
+
+### §5 — Double-gated warning
+
+To catch the one footgun §4 introduces without adding noise, the runner emits a single stderr note only when
+**both** hold:
+
+- the invocation cwd differs from the repo root, and
+- at least one coerced argument is a relative `pathlib.Path`.
+
+Detection is type-driven, not heuristic: after `_coerce_args`, an argument is "a relative path" iff
+`isinstance(value, pathlib.Path) and not value.is_absolute()` (this uniformly covers `pathlib.Path` and all
+`toolr.types` path-constrained args, which coerce to `Path`). String arguments are never inspected for
+path-likeness. The captured invocation cwd is a **runner-internal local** — it is not added to `Context`
+(keeping the public command-author API unchanged) and not added to the wire format.
+
+Example note:
+
+```text
+toolr: note: commands run from the repo root (/abs/repo); relative path arguments resolve from there, not /abs/repo/sub
+```
+
+## Runner control flow (target state)
+
+In `run(spec)` (`_runner.py:413`):
+
+1. `invocation_cwd = Path.cwd()` (before any chdir).
+2. `ctx = _build_context(spec)`.
+3. Append `spec.context.repo_root` to `sys.path` (before importing the target).
+4. `target = _import_target(spec)`.
+5. `_coerce_args(...)` → `var_args` / `kw_args` (or `parent_kwargs` for the dispatch path).
+6. Warning check (§5) using the coerced values + `invocation_cwd` vs `repo_root`.
+7. `os.chdir(repo_root)`.
+8. `target(ctx, ...)`.
+
+## Error handling
+
+- Missing/garbage `repo_root` in the spec is already a `SpecError` path; `os.chdir` failure (repo_root not a
+  dir) surfaces as a clear error rather than a silent fallback to the invocation cwd.
+- Appending an already-present `repo_root` is a no-op guard (don't append twice).
+
+## Testing
+
+- **CWD shadowing:** run a command from a directory containing a planted `msgspec.py`/`secrets.py` that would
+  raise or set a sentinel if imported; assert it is never imported (proves `-P` dropped `''`).
+- **Subdir import:** run a command from a repo subdirectory; assert `tools.*` still imports (proves the
+  append works and fixes the latent bug).
+- **CWD is repo root:** a command that returns `os.getcwd()`; assert it equals the repo root.
+- **Warning gating:** (a) relative `Path` arg + run from subdir → note present; (b) run from repo root → no
+  note; (c) no path args → no note; (d) absolute path arg → no note; (e) `str` arg that looks like a path →
+  no note.
+- **No child inheritance:** a command that spawns `python -c "import sys; print('' in sys.path)"` via
+  `ctx.run`; assert the child still has normal path semantics (the `-P` flag did not propagate).
+
+## Out of scope
+
+- SEC-01's manifest/provenance work (separate, lower branch in the stack).
+- Exposing the invocation cwd as a public `Context` attribute — deferred until a concrete command need
+  exists (adding it later is backward-compatible).

--- a/specs/2026-06-10-runner-path-hygiene-design.md
+++ b/specs/2026-06-10-runner-path-hygiene-design.md
@@ -55,12 +55,16 @@ subdirectory import bug, because resolution no longer depends on where the user 
 Tradeoff (accepted): a venv package literally named `tools` would shadow the repo's `tools/`. Exotic, and the
 venv is the repo's own.
 
-### §3 — Run commands from the repo root
+### §3 — Run commands from the repo root (chdir on the Rust side)
 
-Before invoking the command function, the runner `os.chdir(repo_root)`. This gives commands a predictable
-working directory regardless of where the user invoked toolr (the make/cargo convention), and makes
-`ctx.run` subprocesses run from the repo root by default. Because `-P` already removed `''` from `sys.path`,
-the chdir does not reintroduce any import shadowing.
+The runner is spawned with its working directory set to `repo_root` —
+`Command::current_dir(repo_root)` in `spawn_runner` (`crates/toolr-core/src/execute/spawn.rs`). The child
+therefore starts in the repo root (the make/cargo convention) and never sees the invocation cwd; `ctx.run`
+subprocesses inherit it. Because `-P` already removed `''` from `sys.path`, the cwd is decoupled from import
+resolution, so this does not reintroduce shadowing. The runner no longer calls `os.chdir`.
+
+Why Rust, not Python: the dispatch layer already owns the spawn, knows `repo_root`, and setting the child cwd
+at spawn time means the runner process is never momentarily in the invocation cwd.
 
 ### §4 — Relative path arguments resolve from repo root (documented, not rewritten)
 
@@ -68,19 +72,22 @@ The chdir changes what a relative path **argument** means: `toolr build ./x.py` 
 resolves `./x.py` against the repo root. We do **not** silently rewrite path args (no magical path building) —
 the contract is "paths are resolved from the repo root," documented in the command-authoring guide.
 
-### §5 — Double-gated warning
+### §5 — Double-gated warning (on the Rust side)
 
-To catch the one footgun §4 introduces without adding noise, the runner emits a single stderr note only when
+To catch the one footgun §4 introduces without adding noise, toolr emits a single stderr note only when
 **both** hold:
 
 - the invocation cwd differs from the repo root, and
-- at least one coerced argument is a relative `pathlib.Path`.
+- at least one path-typed argument was given a relative value **on the command line**.
 
-Detection is type-driven, not heuristic: after `_coerce_args`, an argument is "a relative path" iff
-`isinstance(value, pathlib.Path) and not value.is_absolute()` (this uniformly covers `pathlib.Path` and all
-`toolr.types` path-constrained args, which coerce to `Path`). String arguments are never inspected for
-path-likeness. The captured invocation cwd is a **runner-internal local** — it is not added to `Context`
-(keeping the public command-author API unchanged) and not added to the wire format.
+This lives in Rust (`crates/toolr/src/execute_build.rs::relative_path_warning`), not the Python runner,
+because the dispatch layer has everything needed and more: the invocation cwd (its own process cwd, pre-spawn),
+`repo_root`, each arg's `resolved_type` (`SupportedType::Path` / `AbsolutePath` / `ResolvedPath`), the extracted
+`PathBuf` values, and clap's `ValueSource`. Detection is type-driven (only path-typed args — never a `str`
+that merely looks path-like) and source-precise: `ValueSource::CommandLine` only, so a relative **default**
+never warns (something the old `isinstance`-after-coercion check in Python could not distinguish). It also
+covers the dispatcher's own args in the dispatch path. The invocation cwd is never added to `Context` or the
+wire format.
 
 Example note:
 
@@ -88,37 +95,39 @@ Example note:
 toolr: note: commands run from the repo root (/abs/repo); relative path arguments resolve from there, not /abs/repo/sub
 ```
 
-## Runner control flow (target state)
+## Division of responsibility (target state)
 
-In `run(spec)` (`_runner.py:413`):
+Rust (`dispatch` → `execute_build` → `spawn_runner`), before the runner starts:
 
-1. `invocation_cwd = Path.cwd()` (before any chdir).
-2. `ctx = _build_context(spec)`.
-3. Append `spec.context.repo_root` to `sys.path` (before importing the target).
-4. `target = _import_target(spec)`.
-5. `_coerce_args(...)` → `var_args` / `kw_args` (or `parent_kwargs` for the dispatch path).
-6. Warning check (§5) using the coerced values + `invocation_cwd` vs `repo_root`.
-7. `os.chdir(repo_root)`.
-8. `target(ctx, ...)`.
+1. `relative_path_warning(cmd, matches, repo_root, cwd)` — emit the §5 note if gated (in `build_spec` /
+   `build_dispatch_spec`).
+2. `spawn_runner(python, spec_path, repo_root)` — `-P`, `current_dir(repo_root)`, `TOOLR_SPEC_FILE`.
+
+Python runner `run(spec)` — its only remaining cwd/path job:
+
+3. `_append_repo_root(spec.context.repo_root)` — append (not prepend) so stdlib + site-packages win.
+   `PYTHONPATH` cannot express this (it prepends ahead of stdlib + site-packages), which is exactly why the
+   append stays in-process rather than being passed as an env var.
 
 ## Error handling
 
-- Missing/garbage `repo_root` in the spec is already a `SpecError` path; `os.chdir` failure (repo_root not a
-  dir) surfaces as a clear error rather than a silent fallback to the invocation cwd.
+- Missing/garbage `repo_root` in the spec is already a `SpecError` path; an unreadable `repo_root` surfaces as
+  a normal `spawn_runner` I/O error (with the existing "run `toolr project venv sync`" hint nearby), not a
+  silent fallback.
 - Appending an already-present `repo_root` is a no-op guard (don't append twice).
 
 ## Testing
 
-- **CWD shadowing:** run a command from a directory containing a planted `msgspec.py`/`secrets.py` that would
-  raise or set a sentinel if imported; assert it is never imported (proves `-P` dropped `''`).
-- **Subdir import:** run a command from a repo subdirectory; assert `tools.*` still imports (proves the
-  append works and fixes the latent bug).
-- **CWD is repo root:** a command that returns `os.getcwd()`; assert it equals the repo root.
-- **Warning gating:** (a) relative `Path` arg + run from subdir → note present; (b) run from repo root → no
-  note; (c) no path args → no note; (d) absolute path arg → no note; (e) `str` arg that looks like a path →
-  no note.
-- **No child inheritance:** a command that spawns `python -c "import sys; print('' in sys.path)"` via
-  `ctx.run`; assert the child still has normal path semantics (the `-P` flag did not propagate).
+- **Warning gating (Rust, `execute_build` unit tests):** `relative_path_warning` returns a note for
+  (relative path arg + cwd≠repo_root), and `None` for: cwd==repo_root; an absolute path arg; a `str` arg whose
+  value looks path-like. (Pure function — takes cwd as a param, so no env dependence.)
+- **`-P` argv (Rust, `spawn.rs` unit test):** `spawn_runner` builds `["-P", "-m", "toolr._runner"]`.
+- **Subdir import / append (Python, `tests/runner/test_path_hygiene.py`):** run a command from a repo
+  subdirectory via `run()`; assert `tools.*` imports (proves the append works and fixes the latent bug).
+- **Coverage boundary:** the chdir's runtime effect and the `-P` shadowing effect both require a real spawn
+  (interpreter startup / `current_dir`), so they aren't unit-tested in-process — same documented boundary as
+  the original `-P` end-to-end note (the only venv-backed harness binds `toolr` from PATH). Verified manually
+  against the branch binary; CI exercises the real spawn.
 
 ## Out of scope
 

--- a/specs/2026-06-10-runner-path-hygiene-plan.md
+++ b/specs/2026-06-10-runner-path-hygiene-plan.md
@@ -1,0 +1,583 @@
+# Runner path hygiene Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Stop the toolr runner from putting the invocation directory on `sys.path`, make `tools.*` resolve
+regardless of where toolr was invoked, and run commands from the repo root — without changing the public
+`Context` API or the wire format.
+
+**Architecture:** Pass `-P` to the runner interpreter (drops the implicit `''` CWD entry). In the runner,
+append `repo_root` to `sys.path` so `tools.*` imports, `os.chdir(repo_root)` before invoking the command, and
+emit a double-gated stderr note when relative `Path` args are passed from a subdirectory. The invocation cwd
+is a runner-internal local; nothing is added to `Context` or the spec.
+
+**Tech Stack:** Rust (`spawn.rs`), Python (`toolr._runner`), `cargo test`, `pytest`.
+
+**Design:** `specs/2026-06-10-runner-path-hygiene-design.md`. Read it before starting.
+
+**Depends on / stacking:** This branch (`runner-path-hygiene`) is stacked on `static-only-manifest` (SEC-01).
+Implement only AFTER SEC-01 has landed on the lower branch and this branch has been restacked onto it — the
+plan assumes `_introspect.py` is already deleted and `spawn_runner` is the only `python -m toolr.*` entry
+point.
+
+**Conventions (from CLAUDE.md):** Conventional Commits; no `Co-Authored-By` footer; never `--no-verify`; run
+`mise run test` for Rust+Python changes; keep markdown prose ≤120 cols (code blocks exempt).
+
+---
+
+## File map
+
+**Modify:**
+
+- `crates/toolr-core/src/execute/spawn.rs` — add `-P` before `-m`.
+- `crates/toolr-py/python/toolr/_runner.py` — `run()`: capture invocation cwd, append `repo_root`, warn,
+  chdir; add two small helpers.
+- `skills/toolr-command-authoring/SKILL.md` (+ any `docs/` authoring page) — document repo-root cwd + path-arg
+  semantics.
+- `UNRELEASED.md` — release note.
+
+**Create:**
+
+- `tests/runner/test_path_hygiene.py` — Python tests for the helpers and the end-to-end `run()` flow.
+
+---
+
+## Task 1: `-P` flag on the runner spawn
+
+**Files:**
+
+- Modify: `crates/toolr-core/src/execute/spawn.rs:12-21`
+- Test: same file (`#[cfg(test)] mod tests`)
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `spawn.rs`:
+
+```rust
+#[test]
+fn spawn_runner_passes_safe_path_flag_before_module() {
+    // We can't run a real interpreter here; assert the argv we build.
+    // Refactor spawn_runner so the args are constructed by a pure helper
+    // `runner_args()` returning the Vec<OsString>/Vec<&str> we pass.
+    let args = runner_args();
+    assert_eq!(args, ["-P", "-m", "toolr._runner"]);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p toolr-core execute::spawn 2>&1 | tail -15`
+Expected: FAIL — `runner_args` does not exist yet.
+
+- [ ] **Step 3: Implement**
+
+Extract the arg list into a pure helper and use it in `spawn_runner`:
+
+```rust
+/// The fixed argv (after the interpreter) for the runner.
+/// `-P` enables safe-path mode (drops the implicit CWD `sys.path` entry);
+/// it is a flag, so it is NOT inherited by child processes the command spawns.
+fn runner_args() -> [&'static str; 3] {
+    ["-P", "-m", "toolr._runner"]
+}
+
+pub fn spawn_runner(python: &Path, spec_path: &Path) -> io::Result<Child> {
+    Command::new(python)
+        .args(runner_args())
+        .env("TOOLR_SPEC_FILE", spec_path)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p toolr-core execute::spawn 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/toolr-core/src/execute/spawn.rs
+git commit -m "feat(execute): pass -P to the runner interpreter (drop implicit CWD from sys.path)"
+```
+
+---
+
+## Task 2: `_append_repo_root` helper
+
+**Files:**
+
+- Modify: `crates/toolr-py/python/toolr/_runner.py`
+- Test: `tests/runner/test_path_hygiene.py` (create)
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/runner/test_path_hygiene.py`:
+
+```python
+"""SEC-02: runner sys.path / cwd hygiene."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from toolr._runner import _append_repo_root
+
+
+def test_append_repo_root_adds_when_absent():
+    path_list = ["/usr/lib/python3.13", "/site-packages"]
+    _append_repo_root("/repo", path_list)
+    assert path_list[-1] == "/repo"
+
+
+def test_append_repo_root_is_idempotent():
+    path_list = ["/repo"]
+    _append_repo_root("/repo", path_list)
+    assert path_list == ["/repo"]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/runner/test_path_hygiene.py -q`
+Expected: FAIL — `_append_repo_root` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Add to `_runner.py` (module level):
+
+```python
+def _append_repo_root(repo_root: str, path_list: list[str] | None = None) -> None:
+    """Append ``repo_root`` to ``sys.path`` so ``import tools.*`` resolves.
+
+    Append (not insert) so stdlib and site-packages win — only ``tools.*``,
+    which nothing else provides, resolves from the repo. Idempotent.
+    """
+    import sys  # noqa: PLC0415
+
+    target = sys.path if path_list is None else path_list
+    if repo_root not in target:
+        target.append(repo_root)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/runner/test_path_hygiene.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/toolr-py/python/toolr/_runner.py tests/runner/test_path_hygiene.py
+git commit -m "feat(runner): append repo_root to sys.path (resolves tools.* from any cwd)"
+```
+
+---
+
+## Task 3: `_warn_if_paths_relative_to_invocation` helper (the double-gated warning)
+
+**Files:**
+
+- Modify: `crates/toolr-py/python/toolr/_runner.py`
+- Test: `tests/runner/test_path_hygiene.py`
+- [ ] **Step 1: Write the failing tests (the full gating matrix)**
+
+Append to `tests/runner/test_path_hygiene.py`:
+
+```python
+import io
+
+from toolr._runner import _warn_if_paths_relative_to_invocation as _warn
+
+
+def _run(invocation_cwd, repo_root, values):
+    stream = io.StringIO()
+    _warn(Path(invocation_cwd), Path(repo_root), values, stream)
+    return stream.getvalue()
+
+
+def test_warns_on_relative_path_arg_from_subdir():
+    out = _run("/repo/sub", "/repo", [Path("x.py")])
+    assert "repo root" in out and "/repo" in out
+
+
+def test_no_warn_when_cwd_is_repo_root():
+    assert _run("/repo", "/repo", [Path("x.py")]) == ""
+
+
+def test_no_warn_without_path_args():
+    assert _run("/repo/sub", "/repo", ["x.py", 3, True]) == ""
+
+
+def test_no_warn_for_absolute_path_arg():
+    assert _run("/repo/sub", "/repo", [Path("/abs/x.py")]) == ""
+
+
+def test_warns_for_relative_path_inside_list():
+    out = _run("/repo/sub", "/repo", [[Path("a.py"), Path("/abs/b.py")]])
+    assert "repo root" in out
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/runner/test_path_hygiene.py -q`
+Expected: FAIL — `_warn_if_paths_relative_to_invocation` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Add to `_runner.py`:
+
+```python
+def _warn_if_paths_relative_to_invocation(
+    invocation_cwd: Path,
+    repo_root: Path,
+    values,
+    stream,
+) -> None:
+    """Emit one note iff cwd != repo_root AND a coerced arg is a relative Path.
+
+    Type-driven, never heuristic: only ``pathlib.Path`` instances (which all
+    ``toolr.types`` path-constrained args coerce to) count. ``str`` args are
+    never inspected for path-likeness.
+    """
+    if invocation_cwd.resolve() == repo_root.resolve():
+        return
+
+    def _is_rel_path(v) -> bool:
+        if isinstance(v, Path):
+            return not v.is_absolute()
+        if isinstance(v, (list, tuple)):
+            return any(isinstance(x, Path) and not x.is_absolute() for x in v)
+        return False
+
+    if any(_is_rel_path(v) for v in values):
+        print(  # noqa: T201
+            f"toolr: note: commands run from the repo root ({repo_root}); "
+            f"relative path arguments resolve from there, not {invocation_cwd}",
+            file=stream,
+        )
+```
+
+Add `from pathlib import Path` to the module imports if not already top-level (check the file; the runner
+uses lazy `import pathlib` in places — a module-level `from pathlib import Path` for these helpers is fine).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/runner/test_path_hygiene.py -q`
+Expected: PASS (all five cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/toolr-py/python/toolr/_runner.py tests/runner/test_path_hygiene.py
+git commit -m "feat(runner): double-gated relative-path warning helper"
+```
+
+---
+
+## Task 4: Wire capture-cwd, append, warn, chdir into `run()`
+
+**Files:**
+
+- Modify: `crates/toolr-py/python/toolr/_runner.py:413-480` (`run()`)
+- Test: `tests/runner/test_path_hygiene.py`
+- [ ] **Step 1: Write the failing end-to-end test**
+
+This exercises the real `run()` flow with a temp `tools` package, asserting (a) cwd becomes repo_root and
+(b) `tools.*` imports when invoked from a subdirectory. Save/restore cwd and `sys.path` so the test is
+hermetic.
+
+```python
+import os
+import sys
+import textwrap
+
+import msgspec
+
+from toolr._runner import RunnerSpec, run
+
+
+def _make_repo(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "tools").mkdir(parents=True)
+    (repo / "tools" / "__init__.py").write_text("")
+    (repo / "tools" / "probe.py").write_text(
+        textwrap.dedent(
+            """
+            import os
+            CWD_AT_CALL = {}
+            def record(ctx):
+                CWD_AT_CALL["cwd"] = os.getcwd()
+            """
+        )
+    )
+    return repo
+
+
+def _spec(repo, module, function):
+    # Build a minimal valid spec dict; adapt field names to RunnerSpec.
+    # Use the existing spec-construction test helpers in tests/runner/ as a
+    # template (see tests/runner/test_spec_loader.py / test_dispatch.py).
+    payload = {
+        "schema_version": __import__("toolr._runner", fromlist=["SCHEMA_VERSION"]).SCHEMA_VERSION,
+        "group": "probe",
+        "command": "record",
+        "module": module,
+        "function": function,
+        "args": [],
+        "dispatch": None,
+        "context": {
+            "repo_root": str(repo),
+            "verbosity": "normal",
+            "default_timeout_secs": None,
+            "default_no_output_timeout_secs": None,
+        },
+    }
+    return msgspec.convert(payload, type=RunnerSpec)
+
+
+def test_run_chdirs_to_repo_root_and_imports_tools_from_subdir(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    sub = repo / "tools"  # a subdirectory of the repo
+    saved_path = sys.path[:]
+    saved_cwd = os.getcwd()
+    try:
+        monkeypatch.chdir(sub)  # invoke from a subdirectory
+        spec = _spec(repo, "tools.probe", "record")
+        rc = run(spec)
+        assert rc == 0
+        import tools.probe  # resolvable because repo_root was appended
+
+        assert tools.probe.CWD_AT_CALL["cwd"] == str(repo)
+    finally:
+        sys.path[:] = saved_path
+        os.chdir(saved_cwd)
+        sys.modules.pop("tools.probe", None)
+        sys.modules.pop("tools", None)
+```
+
+NOTE: confirm the exact `RunnerSpec`/`context` field names and the spec-construction pattern against
+`tests/runner/test_spec_loader.py` and `crates/toolr-py/python/toolr/_runner.py` before finalizing this test
+— adapt the payload dict to match. Keep imports top-of-file (CLAUDE.md: no deferred imports in tests).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/runner/test_path_hygiene.py -q`
+Expected: FAIL — `run()` does not yet append repo_root or chdir (the `import tools.probe` or the cwd
+assertion fails).
+
+- [ ] **Step 3: Implement the `run()` changes**
+
+At the top of `run()` (before the `try`/before `_build_context`), capture the invocation cwd and repo_root;
+append repo_root before `_import_target`; warn + chdir before invoking the target. Apply to BOTH the dispatch
+and non-dispatch branches.
+
+```python
+def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
+    import os  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+
+    invocation_cwd = Path.cwd()
+    repo_root = Path(spec.context.repo_root)
+    try:
+        ctx = _build_context(spec)
+        _append_repo_root(str(repo_root))
+        target = _import_target(spec)
+        if spec.dispatch is not None:
+            _, parent_kwargs = _coerce_args(target, spec.args)
+            _warn_if_paths_relative_to_invocation(
+                invocation_cwd, repo_root, list(parent_kwargs.values()), sys.stderr
+            )
+            _chdir_or_raise(repo_root)
+            invoke_dispatcher(
+                ctx=ctx,
+                func=target,
+                parent_kwargs=parent_kwargs,
+                child_name=spec.dispatch.command,
+                child_args=spec.dispatch.command_args,
+                child_schema=spec.dispatch.schema,
+            )
+        else:
+            var_args, kw_args = _coerce_args(target, spec.args)
+            _warn_if_paths_relative_to_invocation(
+                invocation_cwd, repo_root, [*var_args, *kw_args.values()], sys.stderr
+            )
+            _chdir_or_raise(repo_root)
+            target(ctx, *var_args, **kw_args)
+    except SystemExit as exc:
+        ...  # unchanged
+```
+
+Add the small chdir helper (clear error instead of a raw OSError):
+
+```python
+def _chdir_or_raise(repo_root: Path) -> None:
+    import os  # noqa: PLC0415
+
+    try:
+        os.chdir(repo_root)
+    except OSError as exc:
+        msg = f"failed to enter repo root {repo_root}: {exc}"
+        raise SpecError(msg) from exc
+```
+
+KNOWN LIMITATION (document in the design's §5 if not already): in the dispatch path, only the parent's
+coerced kwargs are checked for relative paths; a dispatched child's relative path args are coerced inside
+`invoke_dispatcher` and are not covered by this warning. Acceptable — the warning is best-effort.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/runner/test_path_hygiene.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full runner suite (no regressions)**
+
+Run: `uv run pytest tests/runner -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/toolr-py/python/toolr/_runner.py tests/runner/test_path_hygiene.py
+git commit -m "feat(runner): run commands from repo root; warn on relative path args from a subdir (SEC-02)"
+```
+
+---
+
+## Task 5: End-to-end `-P` shadowing proof (best-effort, real interpreter)
+
+The `-P` flag only takes effect at interpreter startup, so the "planted module is not imported" proof needs a
+real runner spawn (not an in-process `run()` call).
+
+- [ ] **Step 1: Find the existing venv-backed dispatch harness**
+
+Run: `grep -rln 'venv\|build.*wheel\|toolr-py' tests/distribution tests/sources/test_e2e.py`
+Determine whether there is an existing harness that builds a tools venv with `toolr-py` installed and
+dispatches a real command (likely `tests/distribution/` or `tests/sources/test_e2e.py`).
+
+- [ ] **Step 2: Add the shadowing test where that harness lives**
+
+If a venv-backed harness exists, add a test: create a repo whose **invocation directory** contains a
+`msgspec.py` that raises on import; dispatch a real command; assert it succeeds (proving `''` is not on
+`sys.path`, so the planted `msgspec.py` was never imported). Mark it with the suite's slow/distribution
+marker if appropriate.
+
+```python
+# pseudo-shape — adapt to the real harness fixtures:
+def test_safe_path_ignores_planted_module(real_tools_venv_repo):
+    repo = real_tools_venv_repo  # has tools/ + a synced venv with toolr-py
+    (repo / "msgspec.py").write_text("raise RuntimeError('planted module imported')")
+    result = run_toolr(["probe", "record"], cwd=repo)  # invoke from repo root
+    assert result.returncode == 0  # would be != 0 if msgspec.py shadowed the real one
+```
+
+- [ ] **Step 3: If NO such harness exists, do not fake it**
+
+Per CLAUDE.md "no silent caps": if building a real venv in-test is impractical here, SKIP this end-to-end
+test, and instead add a one-line comment in `tests/runner/test_path_hygiene.py` recording that the `-P`
+runtime effect is covered only by the `spawn_runner` argv unit test (Task 1) plus manual verification, not an
+automated shadowing test. Report this gap in your final summary.
+
+- [ ] **Step 4: Commit (if a test was added)**
+
+```bash
+git add tests/
+git commit -m "test(runner): -P drops planted CWD module from sys.path (end-to-end)"
+```
+
+---
+
+## Task 6: Document the contract
+
+**Files:**
+
+- Modify: `skills/toolr-command-authoring/SKILL.md` (+ any `docs/` authoring page)
+
+- [ ] **Step 1: Add the section**
+
+State: *Commands run with the working directory set to the repo root, regardless of where you invoke
+`toolr`. Relative path arguments are therefore resolved from the repo root, not your current directory. Use
+absolute paths if you need to refer to files relative to where you ran the command.*
+
+- [ ] **Step 2: Regenerate skill refs (if the public surface changed)**
+
+Run: `cargo xtask build-skill-refs` then commit any regenerated `references/*.md`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/ docs/
+git commit -m "docs(authoring): commands run from the repo root; path args are repo-root-relative"
+```
+
+---
+
+## Task 7: Release note
+
+**Files:**
+
+- Modify: `UNRELEASED.md`
+
+- [ ] **Step 1: Add entries** (never edit `CHANGELOG.md`)
+
+```markdown
+### Security
+
+- The toolr runner no longer puts the invocation directory on `sys.path` (the interpreter is started with
+  `-P`), preventing a stray `.py` file in your current directory from shadowing stdlib/site-packages modules.
+
+### Changed
+
+- Commands now run with the working directory set to the repo root (like `make`/`cargo`). Relative path
+  arguments resolve from the repo root, not your current directory; toolr prints a one-line note if you pass
+  a relative path from a subdirectory.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add UNRELEASED.md
+git commit -m "docs(unreleased): note runner -P + repo-root cwd (SEC-02)"
+```
+
+---
+
+## Task 8: Full verification & audit status
+
+- [ ] **Step 1: Umbrella suite**
+
+Run: `mise run test` (poll long runs every 30–60s).
+Expected: skill-ref gate, `cargo test --workspace`, and `pytest` all green.
+
+- [ ] **Step 2: Targeted**
+
+Run: `cargo test -p toolr-core execute::spawn` and `uv run pytest tests/runner -q`
+Expected: PASS.
+
+- [ ] **Step 3: Audit status (do in the MAIN working tree, not this worktree — `audit/` is untracked there)**
+
+Flip SEC-02 to `Done: runner-path-hygiene` in `audit/2026-06-10/README.md` and the SEC-02 finding file. If
+you are a worktree sub-agent, skip this and report instead — the orchestrator will update the audit.
+
+> Done when: `mise run test` is green; `spawn_runner` passes `-P`; the runner appends repo_root, chdirs to it,
+> and the warning fires only under both gates; docs updated.
+
+---
+
+## Self-review notes (author)
+
+- **Design coverage:** §1 `-P` (Task 1), §2 append (Task 2), §3 chdir (Task 4), §4 documented (Task 6), §5
+  warning (Task 3 + wired in Task 4). ✓
+- **No public-API/wire change:** invocation cwd is a local in `run()`; `Context` and the spec are untouched;
+  no schema bump. ✓
+- **Known limitation captured:** dispatch-child relative-path args aren't covered by the warning (Task 4
+  Step 3). ✓
+- **Test-reality check:** the in-process `run()` test (Task 4) covers append + chdir deterministically; the
+  `-P` runtime effect needs a real spawn (Task 5) — flagged with a no-silent-cap fallback if no venv harness
+  exists. ✓
+- **Implementer must confirm:** exact `RunnerSpec`/`context` field names for the Task 4 spec payload (against
+  `tests/runner/test_spec_loader.py`) before finalizing.
+
+```text

--- a/specs/2026-06-10-runner-path-hygiene-plan.md
+++ b/specs/2026-06-10-runner-path-hygiene-plan.md
@@ -17,6 +17,12 @@ is a runner-internal local; nothing is added to `Context` or the spec.
 
 **Design:** `specs/2026-06-10-runner-path-hygiene-design.md`. Read it before starting.
 
+> **Superseded in part:** the chdir and the relative-path warning were moved to the **Rust** side after
+> implementation (the dispatch layer has the cwd, arg `resolved_type`s, `PathBuf` values, and clap
+> `ValueSource`). Tasks below describe the original Python-level placement; the shipped form lives in
+> `spawn_runner` (`current_dir(repo_root)`) and `execute_build::relative_path_warning`. The runner keeps only
+> `sys.path.append(repo_root)` (append semantics — `PYTHONPATH` can't express it). See design §3 and §5.
+
 **Depends on / stacking:** This branch (`runner-path-hygiene`) is stacked on `static-only-manifest` (SEC-01).
 Implement only AFTER SEC-01 has landed on the lower branch and this branch has been restacked onto it — the
 plan assumes `_introspect.py` is already deleted and `spawn_runner` is the only `python -m toolr.*` entry

--- a/tests/registry/test_integration.py
+++ b/tests/registry/test_integration.py
@@ -26,6 +26,10 @@ def test_discover_walks_a_real_tools_package(tmp_path: Path) -> None:
         "def hello(ctx):\n"
         '    """Say hi."""\n'
     )
+    # A second module that fails to import, so the walk exercises both the
+    # success path (ci) and the per-module `except` (which records a warning
+    # and continues — one bad file must not poison discovery).
+    (tools / "broken.py").write_text("raise RuntimeError('boom')\n")
     with CommandsTester(search_path=tmp_path) as tester:
         tester.discover()
         # The walk imported every `tools.*` module — proving the loop ran

--- a/tests/runner/test_path_hygiene.py
+++ b/tests/runner/test_path_hygiene.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import io
+from pathlib import Path
+
 from toolr._runner import _append_repo_root
+from toolr._runner import _warn_if_paths_relative_to_invocation as _warn
 
 
 def test_append_repo_root_adds_when_absent():
@@ -15,3 +19,32 @@ def test_append_repo_root_is_idempotent():
     path_list = ["/repo"]
     _append_repo_root("/repo", path_list)
     assert path_list == ["/repo"]
+
+
+def _run(invocation_cwd, repo_root, values):
+    stream = io.StringIO()
+    _warn(Path(invocation_cwd), Path(repo_root), values, stream)
+    return stream.getvalue()
+
+
+def test_warns_on_relative_path_arg_from_subdir():
+    out = _run("/repo/sub", "/repo", [Path("x.py")])
+    assert "repo root" in out
+    assert "/repo" in out
+
+
+def test_no_warn_when_cwd_is_repo_root():
+    assert _run("/repo", "/repo", [Path("x.py")]) == ""
+
+
+def test_no_warn_without_path_args():
+    assert _run("/repo/sub", "/repo", ["x.py", 3, True]) == ""
+
+
+def test_no_warn_for_absolute_path_arg():
+    assert _run("/repo/sub", "/repo", [Path("/abs/x.py")]) == ""
+
+
+def test_warns_for_relative_path_inside_list():
+    out = _run("/repo/sub", "/repo", [[Path("a.py"), Path("/abs/b.py")]])
+    assert "repo root" in out

--- a/tests/runner/test_path_hygiene.py
+++ b/tests/runner/test_path_hygiene.py
@@ -1,4 +1,16 @@
-"""SEC-02: runner sys.path / cwd hygiene."""
+"""SEC-02: runner sys.path / cwd hygiene.
+
+Coverage boundary: the `-P` *runtime* effect (a planted `.py` in the invocation
+dir never shadows stdlib/site-packages because `''` is off `sys.path`) only
+takes hold at interpreter startup, so it cannot be exercised by an in-process
+`run()` call. It is covered by the `spawn_runner` argv unit test
+(`crates/toolr-core/src/execute/spawn.rs`) plus manual verification with a real
+`-P` binary; there is no automated end-to-end shadowing test because the only
+venv-backed harness (`tests/sources/test_e2e.py`) binds `toolr_bin` to
+`shutil.which("toolr")`, which picks up whatever toolr is on PATH rather than
+the freshly built `-P` branch binary — so such a test would be unreliable
+locally. See the SEC-02 plan, Task 5.
+"""
 
 from __future__ import annotations
 

--- a/tests/runner/test_path_hygiene.py
+++ b/tests/runner/test_path_hygiene.py
@@ -1,20 +1,23 @@
-"""SEC-02: runner sys.path / cwd hygiene.
+"""SEC-02: runner sys.path hygiene (the one cwd/path concern that stays in Python).
 
-Coverage boundary: the `-P` *runtime* effect (a planted `.py` in the invocation
-dir never shadows stdlib/site-packages because `''` is off `sys.path`) only
-takes hold at interpreter startup, so it cannot be exercised by an in-process
-`run()` call. It is covered by the `spawn_runner` argv unit test
-(`crates/toolr-core/src/execute/spawn.rs`) plus manual verification with a real
-`-P` binary; there is no automated end-to-end shadowing test because the only
-venv-backed harness (`tests/sources/test_e2e.py`) binds `toolr_bin` to
-`shutil.which("toolr")`, which picks up whatever toolr is on PATH rather than
-the freshly built `-P` branch binary — so such a test would be unreliable
-locally. See the SEC-02 plan, Task 5.
+The runner appends ``repo_root`` to ``sys.path`` so ``import tools.*`` resolves
+regardless of where toolr was invoked. Append (not prepend) is required so the
+stdlib and site-packages win — ``PYTHONPATH`` can't express that ordering, which
+is why this lives in the runner rather than on the Rust side.
+
+The other two SEC-02 concerns moved to Rust:
+
+- the ``-P`` flag and the chdir-to-repo_root (``Command::current_dir``) live in
+  ``crates/toolr-core/src/execute/spawn.rs``;
+- the relative-path warning lives in ``crates/toolr/src/execute_build.rs``
+  (``relative_path_warning``), where the dispatch layer knows the cwd, the arg
+  types, the values, and which were typed on the command line.
+
+So ``run()`` no longer chdirs or warns; this module only covers the append.
 """
 
 from __future__ import annotations
 
-import io
 import os
 import sys
 import textwrap
@@ -26,7 +29,6 @@ import pytest
 from toolr._runner import SCHEMA_VERSION
 from toolr._runner import RunnerSpec
 from toolr._runner import _append_repo_root
-from toolr._runner import _warn_if_paths_relative_to_invocation as _warn
 from toolr._runner import run
 
 
@@ -42,35 +44,6 @@ def test_append_repo_root_is_idempotent():
     assert path_list == ["/repo"]
 
 
-def _run(invocation_cwd, repo_root, values):
-    stream = io.StringIO()
-    _warn(Path(invocation_cwd), Path(repo_root), values, stream)
-    return stream.getvalue()
-
-
-def test_warns_on_relative_path_arg_from_subdir():
-    out = _run("/repo/sub", "/repo", [Path("x.py")])
-    assert "repo root" in out
-    assert "/repo" in out
-
-
-def test_no_warn_when_cwd_is_repo_root():
-    assert _run("/repo", "/repo", [Path("x.py")]) == ""
-
-
-def test_no_warn_without_path_args():
-    assert _run("/repo/sub", "/repo", ["x.py", 3, True]) == ""
-
-
-def test_no_warn_for_absolute_path_arg():
-    assert _run("/repo/sub", "/repo", [Path("/abs/x.py")]) == ""
-
-
-def test_warns_for_relative_path_inside_list():
-    out = _run("/repo/sub", "/repo", [[Path("a.py"), Path("/abs/b.py")]])
-    assert "repo root" in out
-
-
 def _make_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     (repo / "tools").mkdir(parents=True)
@@ -78,10 +51,9 @@ def _make_repo(tmp_path: Path) -> Path:
     (repo / "tools" / "probe.py").write_text(
         textwrap.dedent(
             """
-            import os
-            CWD_AT_CALL = {}
+            RAN = {}
             def record(ctx):
-                CWD_AT_CALL["cwd"] = os.getcwd()
+                RAN["ok"] = True
             """
         )
     )
@@ -109,24 +81,28 @@ def _spec(repo: Path, module: str, function: str) -> RunnerSpec:
     return msgspec.convert(payload, type=RunnerSpec)
 
 
-def test_run_chdirs_to_repo_root_and_imports_tools_from_subdir(
+def test_run_imports_tools_from_a_subdirectory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # The runner appends repo_root to sys.path, so `import tools.*` resolves
+    # even when toolr is invoked from a subdirectory (resolution no longer
+    # relies on the invocation cwd being the repo root). chdir itself is now
+    # done by the Rust spawn (`current_dir`), so this in-process test covers
+    # only the append; it does not assert cwd.
     repo = _make_repo(tmp_path)
-    sub = repo / "tools"  # a subdirectory of the repo
+    sub = repo / "tools"
     saved_path = sys.path[:]
     saved_cwd = os.getcwd()
     try:
-        monkeypatch.chdir(sub)  # invoke from a subdirectory
+        monkeypatch.chdir(sub)
         spec = _spec(repo, "tools.probe", "record")
         rc = run(spec)
         assert rc == 0
-        # Deferred import is intentional: the `tools` package is created by
-        # `_make_repo` at runtime and only becomes importable after `run()`
-        # appends repo_root to sys.path — it cannot be a top-level import.
+        # Deferred import is intentional: the `tools` package is created at
+        # runtime and only becomes importable after `run()` appends repo_root.
         import tools.probe  # type: ignore[import-not-found]  # noqa: PLC0415 — created at runtime
 
-        assert tools.probe.CWD_AT_CALL["cwd"] == str(repo)
+        assert tools.probe.RAN.get("ok") is True
     finally:
         sys.path[:] = saved_path
         os.chdir(saved_cwd)

--- a/tests/runner/test_path_hygiene.py
+++ b/tests/runner/test_path_hygiene.py
@@ -1,0 +1,17 @@
+"""SEC-02: runner sys.path / cwd hygiene."""
+
+from __future__ import annotations
+
+from toolr._runner import _append_repo_root
+
+
+def test_append_repo_root_adds_when_absent():
+    path_list = ["/usr/lib/python3.13", "/site-packages"]
+    _append_repo_root("/repo", path_list)
+    assert path_list[-1] == "/repo"
+
+
+def test_append_repo_root_is_idempotent():
+    path_list = ["/repo"]
+    _append_repo_root("/repo", path_list)
+    assert path_list == ["/repo"]

--- a/tests/runner/test_path_hygiene.py
+++ b/tests/runner/test_path_hygiene.py
@@ -3,10 +3,19 @@
 from __future__ import annotations
 
 import io
+import os
+import sys
+import textwrap
 from pathlib import Path
 
+import msgspec
+import pytest
+
+from toolr._runner import SCHEMA_VERSION
+from toolr._runner import RunnerSpec
 from toolr._runner import _append_repo_root
 from toolr._runner import _warn_if_paths_relative_to_invocation as _warn
+from toolr._runner import run
 
 
 def test_append_repo_root_adds_when_absent():
@@ -48,3 +57,66 @@ def test_no_warn_for_absolute_path_arg():
 def test_warns_for_relative_path_inside_list():
     out = _run("/repo/sub", "/repo", [[Path("a.py"), Path("/abs/b.py")]])
     assert "repo root" in out
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "tools").mkdir(parents=True)
+    (repo / "tools" / "__init__.py").write_text("")
+    (repo / "tools" / "probe.py").write_text(
+        textwrap.dedent(
+            """
+            import os
+            CWD_AT_CALL = {}
+            def record(ctx):
+                CWD_AT_CALL["cwd"] = os.getcwd()
+            """
+        )
+    )
+    return repo
+
+
+def _spec(repo: Path, module: str, function: str) -> RunnerSpec:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "group": "probe",
+        "command": "record",
+        "module": module,
+        "function": function,
+        "args": {},
+        "dispatch": None,
+        "context": {
+            "repo_root": str(repo),
+            "verbosity": "normal",
+            "timestamps": False,
+            "log_level": "INFO",
+            "default_timeout_secs": None,
+            "default_no_output_timeout_secs": None,
+        },
+    }
+    return msgspec.convert(payload, type=RunnerSpec)
+
+
+def test_run_chdirs_to_repo_root_and_imports_tools_from_subdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _make_repo(tmp_path)
+    sub = repo / "tools"  # a subdirectory of the repo
+    saved_path = sys.path[:]
+    saved_cwd = os.getcwd()
+    try:
+        monkeypatch.chdir(sub)  # invoke from a subdirectory
+        spec = _spec(repo, "tools.probe", "record")
+        rc = run(spec)
+        assert rc == 0
+        # Deferred import is intentional: the `tools` package is created by
+        # `_make_repo` at runtime and only becomes importable after `run()`
+        # appends repo_root to sys.path — it cannot be a top-level import.
+        import tools.probe  # type: ignore[import-not-found]  # noqa: PLC0415 — created at runtime
+
+        assert tools.probe.CWD_AT_CALL["cwd"] == str(repo)
+    finally:
+        sys.path[:] = saved_path
+        os.chdir(saved_cwd)
+        sys.modules.pop("tools.probe", None)
+        sys.modules.pop("tools", None)


### PR DESCRIPTION
Stacked on #328 (SEC-01).

Drops the implicit invocation-directory entry from the runner's `sys.path` and runs commands from the repo root:
- spawn `python -P -m toolr._runner` (`-P` = safe path; a flag, so NOT inherited by `ctx.run` child processes);
- append `repo_root` to `sys.path` so `tools.*` resolves from any cwd (also fixes a latent run-from-subdir import bug);
- `os.chdir(repo_root)` before invoking the command;
- relative path args resolve from the repo root (documented), with a double-gated stderr note (cwd != repo_root AND a relative `Path` arg). No public `Context` API or wire-format change.

Design: `specs/2026-06-10-runner-path-hygiene-design.md`. Plan: `specs/2026-06-10-runner-path-hygiene-plan.md`.

Verification: `mise run test` green (Rust workspace 0 failed; pytest 409 passed / 8 skipped); `cargo test -p toolr-core execute::spawn` + `uv run pytest tests/runner` pass. The end-to-end `-P` shadowing test is left as a documented coverage boundary (its venv harness resolves `toolr` from PATH; valid in CI, false-negative on a dev box with an older toolr) — manually verified the branch binary ignores a planted CWD module.