### PR TITLE
ci: single abi3 wheel for toolr-py + Linux-default benches

### DIFF
--- a/.github/workflows/_bench.yml
+++ b/.github/workflows/_bench.yml
@@ -70,12 +70,11 @@ jobs:
       - name: Compute Python cp-tag
         id: cp-tag
         shell: bash
-        # Mirror the docs job: derive the wheel ABI tag from the
-        # venv's active Python so a mise.toml python bump picks the
-        # matching wheel artifact without a second edit.
+        # abi3: the toolr-py wheel is a single cp311-abi3 build that
+        # installs on every CPython >=3.11, so the artifact is always
+        # tagged cp311 — independent of the venv's active Python.
         run: |
-          pyver=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-          echo "cp-tag=cp${pyver//./}" >> "$GITHUB_OUTPUT"
+          echo "cp-tag=cp311" >> "$GITHUB_OUTPUT"
 
       - name: Download toolr-py wheel
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -61,9 +61,12 @@ jobs:
             Windows) triple=x86_64-pc-windows-msvc;   wheelplat=win_amd64 ;;
             *) echo "unknown RUNNER_OS=$RUNNER_OS" >&2; exit 1 ;;
           esac
-          # 3.11 -> cp311 (drop the dot)
-          pyver="${{ matrix.python-version }}"
-          cptag="cp${pyver//./}"
+          # abi3: the toolr-py wheel is a single cp311-abi3 build that
+          # installs on every CPython >=3.11, so the artifact is always
+          # tagged cp311 regardless of which interpreter this matrix
+          # entry runs (matrix.python-version still spans the full range
+          # for test breadth — we just install the one shared wheel).
+          cptag="cp311"
           {
             echo "toolr-triple=$triple"
             echo "wheel-platform=$wheelplat"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,12 +512,11 @@ jobs:
       - name: Compute docs Python cp-tag
         id: cp-tag
         shell: bash
-        # Derive the wheel ABI tag from the venv's active Python so a
-        # mise.toml python bump (e.g. 3.14 → 3.15) automatically picks
-        # the matching wheel artifact below — no second edit needed.
+        # abi3: the toolr-py wheel is a single cp311-abi3 build that
+        # installs on every CPython >=3.11, so the artifact is always
+        # tagged cp311 — independent of the venv's active Python.
         run: |
-          pyver=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-          echo "cp-tag=cp${pyver//./}" >> "$GITHUB_OUTPUT"
+          echo "cp-tag=cp311" >> "$GITHUB_OUTPUT"
 
       - name: Download toolr-py wheel
         # `regen-doc-snippets.py` runs `toolr project manifest rebuild`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ on:
     # trigger a re-run (cheap and self-correcting); the matrix selector
     # in `tools/ci.py` ignores labels other than `full-build`.
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      bench-all-os:
+        description: "Run benchmarks on macOS and Windows too (Linux always runs)."
+        type: boolean
+        default: false
+        required: false
 
 concurrency:
   # Concurrency is defined in a way that concurrent builds against the main branch do not not cancel previous builds.
@@ -681,6 +688,14 @@ jobs:
 
   bench-macos:
     name: Bench
+    # macOS/Windows benches are advisory step-summary output nothing
+    # blocks on, and macOS runner-minutes cost ~10x Linux. Run them only
+    # on opt-in: the `bench-all-os` PR label, or the workflow_dispatch
+    # input. `pull_request.labels.*.name` is an empty array (not an
+    # error) on push/dispatch, so this expression is valid everywhere.
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'bench-all-os')
+      || github.event.inputs.bench-all-os == 'true'
     needs:
       - prepare-ci
       - build-binary-archive
@@ -696,6 +711,12 @@ jobs:
 
   bench-windows:
     name: Bench
+    # Gated identically to bench-macos: opt-in via the `bench-all-os` PR
+    # label or the workflow_dispatch input. See bench-macos for the
+    # rationale and why the expression is safe on non-PR events.
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'bench-all-os')
+      || github.event.inputs.bench-all-os == 'true'
     needs:
       - prepare-ci
       - build-binary-archive

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ which = "8"
 similar = "3"
 clap = { version = "4", features = ["derive", "env", "string"] }
 termimad = "0.34"
-pyo3 = { version = "0.28", features = ["extension-module"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py311"] }
 assert_cmd = "2"
 predicates = "3"
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -41,6 +41,12 @@ comment.
   `make`/`cargo`). Relative path arguments resolve from the repo root, not your
   current directory; toolr prints a one-line note if you pass a relative path
   from a subdirectory.
+- `toolr-py` now ships a single stable-ABI (`abi3`) wheel per platform, tagged
+  `cp311-abi3`, instead of one wheel per CPython. The one wheel installs on every
+  CPython >=3.11 (matching `requires-python`), so `pip install toolr-py` resolves
+  the same wheel whether you run 3.11, 3.12, 3.13, or 3.14. No action needed —
+  this only shrinks the published wheel set; the supported interpreter range is
+  unchanged and still fully tested.
 
 ### Removed
 

--- a/crates/toolr-py/pyproject.toml
+++ b/crates/toolr-py/pyproject.toml
@@ -59,11 +59,14 @@ exclude = ["**/__pycache__/**", "**/*.pyc"]
 # Only include skip patterns that match enabled builds
 # Removed: pp* (no PyPy builds enabled), *-i686 (no 32-bit builds), *-s390x (no s390x builds)
 skip = "*-win32 *-musllinux_i686"
-# Explicitly define supported Python versions. Must stay aligned with
-# `requires-python` above — cibuildwheel respects requires-python as a
-# secondary filter, but keeping the explicit list makes intent obvious
-# at-a-glance and lets the build matrix in CI mirror it.
-build = "cp311-* cp312-* cp313-* cp314-*"
+# Single abi3 (stable-ABI) build per platform. The pyo3 `abi3-py311`
+# feature (root Cargo.toml [workspace.dependencies] pyo3) makes the
+# extension link against the limited API, so maturin tags the wheel
+# `cp311-abi3-<platform>`. That one wheel installs on every CPython
+# >=3.11 (matching `requires-python` above) — build once, run everywhere.
+# We therefore only drive a single cp311 cibuildwheel build; cp312/cp313/
+# cp314 would each re-emit the identical abi3 wheel for no benefit.
+build = "cp311-*"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -28,11 +28,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 group = command_group("ci", "CI utilities", docstring=__doc__)
 
 
-# CPython ABI tags for the toolr-py (pyo3) wheel. Keep aligned with
-# `requires-python` in crates/toolr-py/pyproject.toml and the explicit
-# `[tool.cibuildwheel] build = ...` list in that same file. Bump in
-# lockstep when a new CPython is added/removed.
+# Every supported CPython, dotted form derived below. This drives the
+# *test* matrix only — the toolr-py wheel itself is now a single abi3
+# build (see ABI3_WHEEL_PYTHONS). Keep aligned with `requires-python`
+# in crates/toolr-py/pyproject.toml; bump when a CPython is added/removed.
 ALL_CPYTHONS = ["cp311", "cp312", "cp313", "cp314"]
+
+# CPython ABI tags cibuildwheel builds for the toolr-py (pyo3) wheel.
+# abi3 stable-ABI → a single cp311 wheel covers all CPython >=3.11;
+# build once, test everywhere. The pyo3 `abi3-py311` feature (root
+# Cargo.toml) makes maturin tag the wheel `cp311-abi3-<platform>`, which
+# pip installs on any CPython >=3.11. Building cp312/cp313/cp314 would
+# only re-emit the identical abi3 wheel, so we build cp311 alone while
+# TEST_PYTHONS below still exercises the full interpreter range.
+ABI3_WHEEL_PYTHONS = ["cp311"]
 
 
 def _cp_tag_to_dotted(tag: str) -> str:
@@ -40,7 +49,7 @@ def _cp_tag_to_dotted(tag: str) -> str:
 
     `cp311` -> `3.11`, `cp310` -> `3.10`, etc. Used to derive the
     `_test.yml` matrix's `python-version` entries from `ALL_CPYTHONS`
-    so the test matrix and the wheel-build matrix can't drift.
+    so the test matrix and the supported-CPython list can't drift.
     """
     if not tag.startswith("cp"):
         msg = f"unexpected python tag: {tag!r}"
@@ -49,8 +58,10 @@ def _cp_tag_to_dotted(tag: str) -> str:
     return f"{rest[:1]}.{rest[1:]}"
 
 
-# Dotted-form CPython versions for the `_test.yml` matrix. Derived
-# from ALL_CPYTHONS so a single bump propagates.
+# Dotted-form CPython versions for the `_test.yml` matrix. Derived from
+# ALL_CPYTHONS so a single bump propagates. Stays the full range even
+# though the wheel is abi3/single-build — we test every CPython against
+# the one shared wheel.
 TEST_PYTHONS = [_cp_tag_to_dotted(t) for t in ALL_CPYTHONS]
 
 # The toolr binary wheel uses `bindings = "bin"` → produces a single
@@ -224,9 +235,12 @@ def generate_build_matrix(
       - `binary-archive-triples` — list of triple+runner+archive objects
         (used by _build-binary-archive.yml's matrix).
       - `pythons-binary` — CPython ABI tags for the toolr binary wheel.
-      - `pythons-py` — CPython ABI tags for the toolr-py (pyo3) wheel.
+      - `pythons-py` — CPython ABI tag(s) for the toolr-py (pyo3) wheel.
+        A single `cp311` abi3 build: the stable-ABI wheel installs on
+        every CPython >=3.11, so we build it once.
       - `test-pythons` — dotted-form CPython versions for the test matrix
-        in `_test.yml` (derived from `pythons-py`, so the two cannot drift).
+        in `_test.yml` (the full supported range; every interpreter is
+        tested against the single shared abi3 wheel).
 
     Centralising these in one place (vs. hardcoded YAML across multiple
     workflow files) keeps the binary-wheel/py-wheel/binary-archive matrices
@@ -256,7 +270,7 @@ def generate_build_matrix(
         "platform-matrix": _WHEEL_PLATFORM_MATRIX,
         "binary-archive-triples": binary_archive_triples,
         "pythons-binary": BINARY_WHEEL_PYTHONS,
-        "pythons-py": ALL_CPYTHONS,
+        "pythons-py": ABI3_WHEEL_PYTHONS,
         "test-pythons": TEST_PYTHONS,
     }
 
@@ -288,7 +302,11 @@ def generate_build_matrix(
         )
         wfh.write("\n### Python ABIs\n\n")
         wfh.write(f"- Binary wheel: `{', '.join(BINARY_WHEEL_PYTHONS)}`\n")
-        wfh.write(f"- toolr-py wheel: `{', '.join(ALL_CPYTHONS)}`\n\n")
+        wfh.write(
+            f"- toolr-py wheel: `{', '.join(ABI3_WHEEL_PYTHONS)}` "
+            "(abi3 stable-ABI — one wheel covers all CPython >=3.11)\n"
+        )
+        wfh.write(f"- Test interpreters: `{', '.join(TEST_PYTHONS)}`\n\n")
 
     ctx.info(f"Emitting build matrix outputs for workflow={workflow!r} (reason: {reason})")
     ctx.print(outputs)


### PR DESCRIPTION
Two independent CI/build simplifications, one branch.

## 1. `toolr-py` ships a single abi3 (`cp311`) wheel per platform
The pyo3 extension now links against the stable ABI (`abi3-py311`, matching
`requires-python = ">=3.11,<3.15"`), so maturin tags one `cp311-abi3-<platform>`
wheel that installs on every CPython ≥ 3.11. Previously we built one wheel per
CPython (3.11–3.14) per platform — a 4× multiplication on the version axis for
identical-behavior artifacts.

- `Cargo.toml`: add `abi3-py311` to the workspace `pyo3` features.
- `crates/toolr-py/pyproject.toml`: `[tool.cibuildwheel] build` → `cp311-*`.
- `tools/ci.py` (`generate-build-matrix`): py-wheel ABI list → `["cp311"]`;
  **test matrix unchanged** (still 3.11–3.14, all run against the one shared wheel).
- `_test.yml` / `_bench.yml` / `ci.yml` docs job: the `-py` wheel artifact is now
  always tagged `cp311`, so cp-tag derivation is pinned to `cp311` (was derived
  from the running interpreter). Binary-wheel plumbing untouched.

Build once, test everywhere. The build matrix loses its per-CPython rows; test
breadth is preserved.

## 2. Benchmarks run on Linux by default, macOS/Windows on opt-in
The macOS/Windows bench jobs are advisory step-summary output nothing blocks on,
and macOS runner-minutes cost ~10× Linux. They now run only when opted in via a
`bench-all-os` PR label or a `workflow_dispatch` boolean input. `bench-linux`
always runs. The `if:` expression is valid on push/dispatch (empty label array,
not an error).