### PR TITLE
ci: full-bench label + verify example-plugin manifest with the shipped binary

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -194,19 +194,20 @@ jobs:
         # would regenerate from its current Python source. Drift here means
         # the plugin-packaging contract advertised in `docs/third-party.md`
         # would mislead authors who follow it. Lives here (rather than in
-        # pre-commit) because the check requires the workspace toolr binary
-        # to be built, which CI does anyway -- pre-commit would burn a
-        # full Rust compile on every dev's first commit.
+        # pre-commit) because it needs the `toolr` binary -- which this job
+        # already has on PATH from the downloaded release archive (the
+        # "Extract toolr binary onto PATH" step above), so we exercise the
+        # SHIPPED binary instead of a separate debug rebuild. pre-commit
+        # would instead burn a full Rust compile on every dev's first commit.
         #
         # Regen-and-diff pattern (same as the skills/*/references step
-        # below): build the binary, regenerate the manifest in place,
+        # below): regenerate the manifest in place with the on-PATH binary,
         # then `git diff --exit-code` to surface the exact bytes that
         # changed in the CI log. The previous `--check` variant just
         # exited non-zero with no visible diff.
         shell: bash
         run: |
-          cargo build --quiet -p toolr
-          ./target/debug/toolr self build-manifest \
+          toolr self build-manifest \
             --source-dir examples/plugin-package/src/toolr_example_plugin \
             --package toolr_example_plugin
           if ! git diff --exit-code -- examples/plugin-package/src/toolr_example_plugin/toolr-manifest.json; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,12 @@ run-name: "CI (${{ github.event_name == 'pull_request' && format('pr: #{0}', git
 on:
   push:
   pull_request:
-    # Default PR triggers PLUS labeled/unlabeled: applying or removing
-    # the `full-build` label re-runs CI so the new matrix shape takes
-    # effect without needing a dummy commit. Other label changes also
-    # trigger a re-run (cheap and self-correcting); the matrix selector
-    # in `tools/ci.py` ignores labels other than `full-build`.
+    # Default PR triggers PLUS labeled/unlabeled: applying or removing the
+    # `full-build` or `full-bench` label re-runs CI so the new matrix /
+    # bench shape takes effect without needing a dummy commit. Other label
+    # changes also trigger a re-run (cheap and self-correcting);
+    # `tools/ci.py` ignores labels other than `full-build`/`full-bench`.
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  workflow_dispatch:
-    inputs:
-      bench-all-os:
-        description: "Run benchmarks on macOS and Windows too (Linux always runs)."
-        type: boolean
-        default: false
-        required: false
 
 concurrency:
   # Concurrency is defined in a way that concurrent builds against the main branch do not not cancel previous builds.
@@ -52,6 +45,7 @@ jobs:
       pythons-binary: ${{ steps.generate-build-matrix.outputs.pythons-binary }}
       pythons-py: ${{ steps.generate-build-matrix.outputs.pythons-py }}
       test-pythons: ${{ steps.generate-build-matrix.outputs.test-pythons }}
+      run-full-bench: ${{ steps.generate-build-matrix.outputs.run-full-bench }}
       # Mirrors env.CACHE_SEED / env.MISE_VERSION. Exposed as outputs so
       # reusable workflows can read them via `needs.prepare-ci.outputs.*`
       # (the `env` context is not allowed in workflow-call `with:` blocks).
@@ -689,13 +683,11 @@ jobs:
   bench-macos:
     name: Bench
     # macOS/Windows benches are advisory step-summary output nothing
-    # blocks on, and macOS runner-minutes cost ~10x Linux. Run them only
-    # on opt-in: the `bench-all-os` PR label, or the workflow_dispatch
-    # input. `pull_request.labels.*.name` is an empty array (not an
-    # error) on push/dispatch, so this expression is valid everywhere.
-    if: >-
-      contains(github.event.pull_request.labels.*.name, 'bench-all-os')
-      || github.event.inputs.bench-all-os == 'true'
+    # blocks on, and macOS runner-minutes cost ~10x Linux. Gated on
+    # `run-full-bench` (computed in tools/ci.py): true on push to `main`
+    # or a PR carrying the `full-bench` label. The Linux bench (below)
+    # always runs.
+    if: needs.prepare-ci.outputs.run-full-bench == 'true'
     needs:
       - prepare-ci
       - build-binary-archive
@@ -711,12 +703,9 @@ jobs:
 
   bench-windows:
     name: Bench
-    # Gated identically to bench-macos: opt-in via the `bench-all-os` PR
-    # label or the workflow_dispatch input. See bench-macos for the
-    # rationale and why the expression is safe on non-PR events.
-    if: >-
-      contains(github.event.pull_request.labels.*.name, 'bench-all-os')
-      || github.event.inputs.bench-all-os == 'true'
+    # Gated identically to bench-macos on `run-full-bench` (push to
+    # `main` or the `full-bench` PR label). See bench-macos for rationale.
+    if: needs.prepare-ci.outputs.run-full-bench == 'true'
     needs:
       - prepare-ci
       - build-binary-archive

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -22,6 +22,13 @@ from toolr import command_group
 # only) to keep iteration fast.
 FULL_BUILD_LABEL = "full-build"
 
+# Label name a PR can carry to opt into the full benchmark suite (macOS +
+# Windows in addition to Linux). Without it, PRs bench Linux only; pushes
+# to `main` always run the full suite. Mirrors FULL_BUILD_LABEL above and
+# lives here so the label name sits next to the logic that reads it
+# (`_run_full_bench`), rather than being hardcoded in workflow YAML.
+FULL_BENCH_LABEL = "full-bench"
+
 # tools/ci.py → repo root (two parents up resolves the `tools/` directory).
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -214,6 +221,43 @@ def _select_workflow_mode() -> tuple[Literal["ci", "release"], str]:
     )
 
 
+def _run_full_bench() -> tuple[bool, str]:
+    """Decide whether the full bench suite (macOS + Windows) should run.
+
+    Reads the GitHub event context. Returns ``(run, reason)``; the reason
+    is rendered into the job step
+    summary so reviewers see *why* the bench shape was chosen.
+
+    Rules (first match wins):
+
+    1. ``push`` to ``refs/heads/main`` → run. Main mirrors the release
+       surface, so cross-OS bench regressions get caught at merge time.
+    2. ``pull_request`` carrying the ``full-bench`` label → run. Opt-in
+       for PRs touching perf-sensitive, platform-divergent code (e.g. the
+       subprocess tee/timeout loop).
+    3. Everything else → Linux bench only.
+
+    The Linux bench always runs regardless; this only gates the macOS and
+    Windows bench jobs (advisory step-summary output nothing blocks on,
+    and macOS runner-minutes cost ~10x Linux).
+    """
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    ref = os.environ.get("GITHUB_REF", "")
+
+    if event_name == "push" and ref == "refs/heads/main":
+        return True, "push to `main` — full bench suite (macOS + Windows)."
+
+    if event_name == "pull_request":
+        if FULL_BENCH_LABEL in _pr_labels():
+            return True, f"PR carries the `{FULL_BENCH_LABEL}` label — full bench on opt-in."
+        return False, (
+            f"PR (no `{FULL_BENCH_LABEL}` label) — Linux bench only. "
+            f"Apply the `{FULL_BENCH_LABEL}` label and re-run for the macOS + Windows suite."
+        )
+
+    return False, f"event=`{event_name or '(unset)'}` — Linux bench only."
+
+
 class Workflow(StrEnum):
     """The workflow to run, either `ci` or `release`."""
 
@@ -229,7 +273,7 @@ def generate_build_matrix(
     """
     Emit the CI matrix configuration consumed by `prepare-ci` jobs.
 
-    Writes five GITHUB_OUTPUT keys:
+    Writes six GITHUB_OUTPUT keys:
 
       - `platform-matrix` — wheel platform map per OS (used by _build.yml).
       - `binary-archive-triples` — list of triple+runner+archive objects
@@ -241,6 +285,9 @@ def generate_build_matrix(
       - `test-pythons` — dotted-form CPython versions for the test matrix
         in `_test.yml` (the full supported range; every interpreter is
         tested against the single shared abi3 wheel).
+      - `run-full-bench` — `true`/`false`: whether ci.yml's macOS + Windows
+        bench jobs run (push to `main` or a `full-bench`-labelled PR). The
+        Linux bench always runs; this only gates the other two.
 
     Centralising these in one place (vs. hardcoded YAML across multiple
     workflow files) keeps the binary-wheel/py-wheel/binary-archive matrices
@@ -259,6 +306,8 @@ def generate_build_matrix(
     else:
         reason = f"caller forced `--workflow {workflow}`."
 
+    run_full_bench, bench_reason = _run_full_bench()
+
     if workflow == Workflow.RELEASE:
         binary_archive_triples: list[dict[str, object]] = list(_BINARY_ARCHIVE_TRIPLES)
     else:
@@ -272,6 +321,7 @@ def generate_build_matrix(
         "pythons-binary": BINARY_WHEEL_PYTHONS,
         "pythons-py": ABI3_WHEEL_PYTHONS,
         "test-pythons": TEST_PYTHONS,
+        "run-full-bench": run_full_bench,
     }
 
     github_output = os.environ.get("GITHUB_OUTPUT")
@@ -307,6 +357,10 @@ def generate_build_matrix(
             "(abi3 stable-ABI — one wheel covers all CPython >=3.11)\n"
         )
         wfh.write(f"- Test interpreters: `{', '.join(TEST_PYTHONS)}`\n\n")
+        wfh.write("### Benchmarks\n\n")
+        wfh.write(
+            f"- Full suite (macOS + Windows): `{json.dumps(run_full_bench)}` — {bench_reason}\n\n"
+        )
 
     ctx.info(f"Emitting build matrix outputs for workflow={workflow!r} (reason: {reason})")
     ctx.print(outputs)


### PR DESCRIPTION
Two small CI follow-ups (split into two commits).

## 1. Verify the example-plugin manifest with the **shipped** toolr binary
The Test job already downloads the release `toolr` archive onto PATH, then
separately ran `cargo build -p toolr` to produce a debug binary just for the
manifest-sync check. That rebuild is redundant now that the job downloads the
binary — so call the on-PATH binary directly. Faster (no second `toolr`
compile) and more faithful: it verifies the **shipped** binary regenerates an
in-sync manifest, not a debug build. (The skill-refs step still uses
`cargo xtask`, so this doesn't remove Rust from the job — it only drops the
`toolr` binary-crate build.)

## 2. `full-bench` label to opt PRs into the macOS + Windows benches
macOS/Windows benches are advisory step-summary output nothing blocks on, and
macOS runner-minutes cost ~10× Linux. They now run only when warranted:

- **push to `main`** → full suite (cross-OS regressions caught at merge);
- **PR with the `full-bench` label** → full suite (opt-in);
- otherwise → **Linux bench only** (which always runs).

The decision is computed in `tools/ci.py` (`FULL_BENCH_LABEL = "full-bench"` +
`_run_full_bench()`), emitted as a `run-full-bench` matrix output, and consumed
by the bench jobs — mirroring how `full-build` works, so label logic lives in
one place instead of hardcoded YAML strings. Replaces (and removes) the
short-lived `workflow_dispatch` `bench-all-os` input added in #331.

Validated on this PR by applying the `full-bench` label (so the macOS + Windows
bench jobs actually run).