### PR TITLE
refactor(cli): derive built-in completions from clap instead of hand-mirroring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ prek run --all-files              # run every pre-commit hook
   `specs/`. See `specs/README.md`.
 - **Specs (archive):** `specs/archive/<year>/`. Move with `git mv` in the implementing PR (see
   *Archive specs as the last implementation step* below).
-- Built-in completion entries: `crates/toolr/src/builtin_completions.rs` (mirror `cli::build_command`).
+- Built-in completion entries: `crates/toolr/src/builtin_completions.rs` (derived from `cli::build_command`).
 - Static manifest parser: `crates/toolr-core/src/parser/`.
 - Tab-completion freshness: `crates/toolr-core/src/complete/freshness.rs`.
 - Reference plugin / example: `examples/plugin-package/`.

--- a/crates/toolr/src/builtin_completions.rs
+++ b/crates/toolr/src/builtin_completions.rs
@@ -2,196 +2,159 @@
 //!
 //! The completion engine in [`toolr_core::complete`] is purely
 //! manifest-driven — it knows nothing about the binary's own subcommands
-//! (`self`, `project`). This module supplies the entries that mirror
-//! [`crate::cli::build_command`] so the engine can offer them as
-//! candidates. The synthetic [`Command`] entries are never invoked; only
-//! their `name`, `group`, `arguments[].name`, `arguments[].kind`, and
-//! `arguments[].allowed_values` matter for completion classification.
+//! (`self`, `project`). This module *derives* the entries directly from
+//! [`crate::cli::build_command`] by walking the clap tree, so the engine
+//! can offer them as candidates. The synthetic [`Command`] entries are
+//! never invoked; only their `name`, `group`, `arguments[].name`,
+//! `arguments[].kind`, and `arguments[].allowed_values` matter for
+//! completion classification.
 //!
-//! When [`crate::cli::build_command`] grows or changes a built-in
-//! subcommand, mirror the change here. Tests in this module assert the
-//! structure matches at least at the names-and-shape level.
-//!
-//! Hidden internal helpers (`__complete`, `__build-static-manifest`,
-//! `__install-uv-now`) are intentionally omitted — they don't appear in
-//! `--help` and shouldn't be tab-completed either.
+//! Because the entries are derived, there is nothing to hand-maintain
+//! here: adding or changing a `self`/`project` subcommand in
+//! [`crate::cli::build_command`] flows through automatically. Hidden
+//! internal helpers (`__complete`, `__build-static-manifest`,
+//! `__install-uv-now`, the `project deps` migration shim) carry
+//! `.hide(true)` in the CLI builder and are skipped — they don't appear
+//! in `--help` and shouldn't be tab-completed either.
 
+use clap::{Arg, ArgAction, Command as ClapCommand};
 use toolr_core::manifest::{
-    ArgMetadata, Argument, ArgumentKind, Command, Group, Origin,
+    ArgMetadata, Argument, ArgumentKind, Command, Group, Manifest, Origin, SCHEMA_VERSION,
 };
 
-/// Synthetic [`Group`] + [`Command`] entries that mirror the built-in
+/// The two top-level builtin subtrees, walked out of the clap command.
+const BUILTIN_ROOTS: &[&str] = &["project", "self"];
+
+/// A manifest with no user/third-party entries, so
+/// [`crate::cli::build_command`] yields *only* the hardcoded `self` /
+/// `project` builtin subtrees plus the root flags.
+fn empty_manifest() -> Manifest {
+    Manifest {
+        schema_version: SCHEMA_VERSION,
+        static_hash: String::new(),
+        third_party_hash: String::new(),
+        groups: Vec::new(),
+        commands: Vec::new(),
+    }
+}
+
+/// Synthetic [`Group`] + [`Command`] entries derived from the built-in
 /// subcommand tree wired up in [`crate::cli::build_command`]. Callers
 /// (currently only [`crate::dispatch::run_complete`]) merge these into a
 /// loaded manifest before delegating to
 /// [`toolr_core::complete::serve_completions`].
 pub fn built_in_completion_entries() -> (Vec<Group>, Vec<Command>) {
-    let groups = vec![
-        top_group("project", "Operations on the current repo's tools/ directory"),
-        child_group("venv", "project", "Inspect, sync, and operate on the tools venv"),
-        child_group("manifest", "project", "Manage the project's toolr manifest"),
-        top_group("self", "Operations on toolr itself"),
-        child_group("cache", "self", "Manage the cache of per-repo virtualenvs"),
-        child_group("completion", "self", "Manage shell completion scripts"),
-    ];
+    let root = crate::cli::build_command(&empty_manifest());
+    let mut groups = Vec::new();
+    let mut commands = Vec::new();
 
-    let commands = vec![
-        // project ...
-        leaf(
-            "init",
-            "project",
-            "Scaffold tools/ in the current directory",
-            vec![
-                flag("force"),
-                flag("no-sync"),
-                opt_enum("venv-location", &["cache", "in-tree"]),
-                flag("no-example"),
-                opt("python"),
-                flag("quiet"),
-            ],
-        ),
-        leaf("path", "project.venv", "Print the absolute path to the tools venv", vec![]),
-        leaf(
-            "shell",
-            "project.venv",
-            "Spawn a subshell with the tools venv activated",
-            vec![],
-        ),
-        leaf(
-            "sync",
-            "project.venv",
-            "Sync the tools venv (no-op when fresh)",
-            vec![flag("force"), flag("quiet"), flag("upgrade"), repeated("upgrade-package")],
-        ),
-        leaf(
-            "lock",
-            "project.venv",
-            "Refresh tools/uv.lock without applying (wraps `uv lock`)",
-            vec![flag("quiet"), flag("upgrade"), repeated("upgrade-package")],
-        ),
-        leaf(
-            "add",
-            "project.venv",
-            "Add one or more packages to tools/pyproject.toml (wraps `uv add`)",
-            vec![positional("packages"), flag("quiet")],
-        ),
-        leaf(
-            "remove",
-            "project.venv",
-            "Remove one or more packages from tools/pyproject.toml (wraps `uv remove`)",
-            vec![positional("packages"), flag("quiet")],
-        ),
-        leaf(
-            "rebuild",
-            "project.manifest",
-            "Regenerate the static + dynamic manifest in place",
-            vec![],
-        ),
-        // self ...
-        leaf(
-            "build-manifest",
-            "self",
-            "Generate a third-party manifest fragment for a package",
-            vec![
-                positional("package"),
-                opt("output"),
-                opt("python"),
-                opt("schema-version"),
-                flag("check"),
-            ],
-        ),
-        leaf(
-            "list",
-            "self.cache",
-            "List every cached virtualenv with size and last-use timestamp",
-            vec![],
-        ),
-        leaf(
-            "prune",
-            "self.cache",
-            "Remove orphan and stale cache entries",
-            vec![
-                flag("all"),
-                opt("stale-after-days"),
-                flag("dry-run"),
-                flag("yes"),
-            ],
-        ),
-        leaf(
-            "print",
-            "self.completion",
-            "Print the completion script for a shell to stdout",
-            vec![positional_enum("shell", &["bash", "zsh", "fish"])],
-        ),
-        leaf(
-            "install",
-            "self.completion",
-            "Install the completion script for a shell into its standard location",
-            vec![
-                positional_enum("shell", &["bash", "zsh", "fish"]),
-                flag("force"),
-            ],
-        ),
-    ];
+    for name in BUILTIN_ROOTS {
+        let Some(sub) = root
+            .get_subcommands()
+            .find(|c| c.get_name() == *name && !c.is_hide_set())
+        else {
+            continue;
+        };
+        // Each builtin root (`self`, `project`) is itself a group node.
+        walk_group(sub, None, &mut groups, &mut commands);
+    }
 
     (groups, commands)
 }
 
-/// Root-level flags carried by the `toolr` binary itself (the long-form
-/// names; short aliases are intentionally omitted to match how the
-/// engine renders leaf flags). Mirror [`crate::cli::build_command`]'s
-/// root [`Arg`]s. Engine-level `--help` is offered separately by
-/// [`toolr_core::complete::serve_completions`] at every group node.
-pub const ROOT_LONG_FLAGS: &[&str] = &[
-    "--debug",
-    "--no-output-timeout-secs",
-    "--no-timestamps",
-    "--quiet",
-    "--timeout-secs",
-    "--timestamps",
-];
-
-fn top_group(name: &str, title: &str) -> Group {
-    Group {
-        name: name.into(),
-        title: title.into(),
+/// Recursively walk a clap subcommand that represents a *group* node,
+/// emitting a [`Group`] for it and classifying each visible child as
+/// either a nested group (has its own subcommands) or a leaf
+/// [`Command`].
+fn walk_group(
+    cmd: &ClapCommand,
+    parent: Option<&str>,
+    groups: &mut Vec<Group>,
+    commands: &mut Vec<Command>,
+) {
+    let name = cmd.get_name().to_string();
+    let full_path = match parent {
+        Some(p) => format!("{p}.{name}"),
+        None => name.clone(),
+    };
+    groups.push(Group {
+        name: name.clone(),
+        title: about_text(cmd),
         description: String::new(),
-        parent: None,
+        parent: parent.map(str::to_string),
         origin: Origin::Static,
+    });
+
+    for child in cmd.get_subcommands() {
+        if child.is_hide_set() {
+            continue;
+        }
+        if child.get_subcommands().next().is_some() {
+            // A child that itself owns subcommands is a nested group.
+            walk_group(child, Some(&full_path), groups, commands);
+        } else {
+            commands.push(leaf_command(child, &full_path));
+        }
     }
 }
 
-fn child_group(name: &str, parent: &str, title: &str) -> Group {
-    Group {
-        name: name.into(),
-        title: title.into(),
-        description: String::new(),
-        parent: Some(parent.into()),
-        origin: Origin::Static,
-    }
-}
-
-fn leaf(name: &str, group: &str, summary: &str, arguments: Vec<Argument>) -> Command {
+/// Build a synthetic leaf [`Command`] from a clap subcommand. The
+/// synthetic entry is never invoked — the binary intercepts
+/// `self`/`project` before any manifest lookup — so `module`/`function`
+/// are empty; only the shape the completion classifier reads is filled.
+fn leaf_command(cmd: &ClapCommand, group: &str) -> Command {
     Command {
-        name: name.into(),
-        group: group.into(),
-        // Synthetic entries are never invoked — the binary intercepts
-        // `self`/`project` before any manifest lookup happens. These
-        // fields just need to round-trip through the engine's classifier.
+        name: cmd.get_name().to_string(),
+        group: group.to_string(),
         module: String::new(),
         function: String::new(),
-        summary: summary.into(),
+        summary: about_text(cmd),
         description: String::new(),
-        arguments,
+        arguments: cmd.get_arguments().filter_map(derive_argument).collect(),
         origin: Origin::Static,
         dispatched_from: None,
         is_dispatcher: false,
     }
 }
 
-fn arg(name: &str, kind: ArgumentKind, allowed_values: Vec<String>) -> Argument {
-    Argument {
-        name: name.into(),
+/// Map a clap [`Arg`] onto a synthetic [`Argument`], or `None` when the
+/// arg shouldn't surface as a completion candidate.
+///
+/// `--help` is filtered out: the engine offers it for free at every
+/// group node, so listing it here would duplicate it. Hidden args are
+/// skipped for the same reason hidden subcommands are.
+///
+/// Arg → [`ArgumentKind`] mapping:
+/// - positional                     → `Positional`
+/// - `ArgAction::SetTrue`/`SetFalse` → `Flag`
+/// - `ArgAction::Count`             → `Count`
+/// - `ArgAction::Append`            → `Repeated`
+/// - value-taking option (`Set`, …) → `Optional`
+fn derive_argument(arg: &Arg) -> Option<Argument> {
+    if arg.get_id() == "help" || arg.is_hide_set() {
+        return None;
+    }
+    let kind = if arg.is_positional() {
+        ArgumentKind::Positional
+    } else {
+        match arg.get_action() {
+            ArgAction::SetTrue | ArgAction::SetFalse => ArgumentKind::Flag,
+            ArgAction::Count => ArgumentKind::Count,
+            ArgAction::Append => ArgumentKind::Repeated,
+            _ => ArgumentKind::Optional,
+        }
+    };
+    let allowed_values = arg
+        .get_possible_values()
+        .iter()
+        .map(|v| v.get_name().to_string())
+        .collect();
+    Some(Argument {
+        // The engine matches a committed `--flag` against `a.name` after
+        // stripping `--`, and renders flag candidates as
+        // `--{name.replace('_', "-")}`. clap's id is already the
+        // hyphenated long-flag stem, so it round-trips.
+        name: arg.get_id().to_string(),
         kind,
         help: String::new(),
         default: None,
@@ -201,46 +164,35 @@ fn arg(name: &str, kind: ArgumentKind, allowed_values: Vec<String>) -> Argument 
         path_constraints: None,
         metadata: ArgMetadata::default(),
         long_flag: None,
-    }
+    })
 }
 
-fn flag(name: &str) -> Argument {
-    arg(name, ArgumentKind::Flag, Vec::new())
+/// clap's `about` rendered to a plain string (empty when unset).
+fn about_text(cmd: &ClapCommand) -> String {
+    cmd.get_about().map(ToString::to_string).unwrap_or_default()
 }
 
-fn opt(name: &str) -> Argument {
-    arg(name, ArgumentKind::Optional, Vec::new())
-}
-
-fn opt_enum(name: &str, values: &[&str]) -> Argument {
-    arg(
-        name,
-        ArgumentKind::Optional,
-        values.iter().map(|v| (*v).to_string()).collect(),
-    )
-}
-
-fn positional(name: &str) -> Argument {
-    arg(name, ArgumentKind::Positional, Vec::new())
-}
-
-fn repeated(name: &str) -> Argument {
-    arg(name, ArgumentKind::Repeated, Vec::new())
-}
-
-fn positional_enum(name: &str, values: &[&str]) -> Argument {
-    arg(
-        name,
-        ArgumentKind::Positional,
-        values.iter().map(|v| (*v).to_string()).collect(),
-    )
+/// Root-level long flags carried by the `toolr` binary itself, derived
+/// from [`crate::cli::build_command`]'s root [`Arg`]s. Short aliases are
+/// intentionally omitted (the engine renders leaf flags long-form only),
+/// as is `--help` (offered separately by
+/// [`toolr_core::complete::serve_completions`] at every group node). The
+/// list is sorted so the engine's downstream `sort()` is a no-op.
+pub fn root_long_flags() -> Vec<String> {
+    let root = crate::cli::build_command(&empty_manifest());
+    let mut flags: Vec<String> = root
+        .get_arguments()
+        .filter(|a| a.get_id() != "help" && !a.is_hide_set())
+        .filter_map(|a| a.get_long().map(|l| format!("--{l}")))
+        .collect();
+    flags.sort();
+    flags
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use toolr_core::complete::serve_completions;
-    use toolr_core::manifest::{Manifest, SCHEMA_VERSION};
 
     fn merged_empty_manifest() -> Manifest {
         let (groups, commands) = built_in_completion_entries();
@@ -257,6 +209,38 @@ mod tests {
         strs.iter().map(|s| (*s).to_string()).collect()
     }
 
+    // --- Unit: the clap Arg -> ArgumentKind classifier ---
+
+    #[test]
+    fn derive_argument_maps_each_clap_action() {
+        // `Count` and `Append` aren't used by any built-in `self`/`project`
+        // arg today, so exercise `derive_argument` directly to pin the full
+        // mapping table (and the help/hidden drop) regardless of which
+        // actions the live CLI happens to use.
+        let count = Arg::new("verbose").long("verbose").action(ArgAction::Count);
+        assert_eq!(derive_argument(&count).unwrap().kind, ArgumentKind::Count);
+
+        let append = Arg::new("define").long("define").action(ArgAction::Append);
+        assert_eq!(derive_argument(&append).unwrap().kind, ArgumentKind::Repeated);
+
+        let set_true = Arg::new("force").long("force").action(ArgAction::SetTrue);
+        assert_eq!(derive_argument(&set_true).unwrap().kind, ArgumentKind::Flag);
+
+        let optional = Arg::new("prefix").long("prefix").action(ArgAction::Set);
+        assert_eq!(derive_argument(&optional).unwrap().kind, ArgumentKind::Optional);
+
+        // `help` and hidden args are dropped from completion output.
+        let help = Arg::new("help").long("help").action(ArgAction::SetTrue);
+        assert!(derive_argument(&help).is_none());
+        let hidden = Arg::new("secret")
+            .long("secret")
+            .action(ArgAction::SetTrue)
+            .hide(true);
+        assert!(derive_argument(&hidden).is_none());
+    }
+
+    // --- Behavioural: the derived tree drives real completion output ---
+
     #[test]
     fn top_level_offers_self_and_project() {
         let m = merged_empty_manifest();
@@ -267,6 +251,8 @@ mod tests {
 
     #[test]
     fn self_offers_known_subcommands() {
+        // Proves a `self` subcommand defined only in `cli.rs` surfaces
+        // here without editing this file.
         let m = merged_empty_manifest();
         let out = serve_completions(&m, &tokens(&["self", ""]));
         for expected in ["build-manifest", "cache", "completion"] {
@@ -287,11 +273,11 @@ mod tests {
                 "missing {expected} in {out:?}"
             );
         }
-        // `deps` was removed in 0.22 and must NOT appear as a completion
-        // candidate (it would mislead users into trying the old path).
+        // `deps` is `.hide(true)` in cli.rs (a removed-command migration
+        // shim) and must NOT leak into completion candidates.
         assert!(
             !out.contains(&"deps".to_string()),
-            "`deps` should not be a completion candidate, got: {out:?}"
+            "`deps` is hidden and should not be a completion candidate, got: {out:?}"
         );
     }
 
@@ -305,10 +291,6 @@ mod tests {
                 "missing {expected} under project venv, got: {out:?}"
             );
         }
-        assert!(
-            !out.contains(&"upgrade".to_string()),
-            "`upgrade` should no longer be a completion candidate, got: {out:?}"
-        );
     }
 
     #[test]
@@ -332,6 +314,8 @@ mod tests {
 
     #[test]
     fn self_completion_install_offers_shells() {
+        // A leaf with an enum positional offers its possible values,
+        // proving `allowed_values` is derived from clap's value_parser.
         let m = merged_empty_manifest();
         let out = serve_completions(&m, &tokens(&["self", "completion", "install", ""]));
         assert_eq!(
@@ -353,38 +337,46 @@ mod tests {
     }
 
     #[test]
-    fn root_long_flags_cover_every_root_arg_in_build_command() {
-        // Guardrail: if someone adds a root-level `Arg::new(...).long(...)`
-        // to `cli::build_command`, this constant must grow to match.
-        // `--help` lives in the engine (every group node gets it for
-        // free), so it's deliberately not listed here.
-        let expected: std::collections::BTreeSet<&str> = [
-            "--debug",
-            "--no-output-timeout-secs",
-            "--no-timestamps",
-            "--quiet",
-            "--timeout-secs",
-            "--timestamps",
-        ]
-        .into_iter()
-        .collect();
-        let actual: std::collections::BTreeSet<&str> =
-            ROOT_LONG_FLAGS.iter().copied().collect();
-        assert_eq!(actual, expected);
-        // Sorted asc so the engine's downstream `sort()` is a no-op
-        // and tests asserting alphabetical output stay deterministic.
-        let mut sorted = ROOT_LONG_FLAGS.to_vec();
-        sorted.sort();
-        assert_eq!(sorted.as_slice(), ROOT_LONG_FLAGS);
+    fn project_init_offers_venv_location_values() {
+        let m = merged_empty_manifest();
+        let out =
+            serve_completions(&m, &tokens(&["project", "init", "--venv-location", ""]));
+        assert_eq!(out, vec!["cache".to_string(), "in-tree".to_string()]);
+    }
+
+    // --- Derivation invariants ---
+
+    #[test]
+    fn hidden_internal_helpers_are_absent() {
+        // The `__*` helpers are `.hide(true)` top-level subcommands and
+        // must never appear as completion candidates.
+        let m = merged_empty_manifest();
+        let out = serve_completions(&m, &tokens(&[""]));
+        for hidden in ["__complete", "__build-static-manifest", "__install-uv-now"] {
+            assert!(
+                !out.contains(&hidden.to_string()),
+                "hidden helper {hidden} leaked into candidates: {out:?}"
+            );
+        }
     }
 
     #[test]
-    fn project_init_offers_venv_location_values() {
-        let m = merged_empty_manifest();
-        let out = serve_completions(
-            &m,
-            &tokens(&["project", "init", "--venv-location", ""]),
+    fn root_long_flags_are_sorted_and_exclude_help() {
+        let flags = root_long_flags();
+        assert!(!flags.is_empty(), "expected some root flags");
+        assert!(
+            !flags.contains(&"--help".to_string()),
+            "--help is engine-provided and should be excluded: {flags:?}"
         );
-        assert_eq!(out, vec!["cache".to_string(), "in-tree".to_string()]);
+        let mut sorted = flags.clone();
+        sorted.sort();
+        assert_eq!(flags, sorted, "root flags must be pre-sorted");
+        // Spot-check a couple known root flags carry through.
+        for expected in ["--debug", "--quiet"] {
+            assert!(
+                flags.contains(&expected.to_string()),
+                "missing {expected} in {flags:?}"
+            );
+        }
     }
 }

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -592,9 +592,9 @@ fn merge_root_flags_at_top_level(tokens: &[String], candidates: &mut Vec<String>
     if !is_flag_prefix {
         return;
     }
-    for flag in crate::builtin_completions::ROOT_LONG_FLAGS {
+    for flag in crate::builtin_completions::root_long_flags() {
         if flag.starts_with(prefix.as_str()) {
-            candidates.push((*flag).to_string());
+            candidates.push(flag);
         }
     }
     candidates.sort();


### PR DESCRIPTION
`builtin_completions.rs` hand-maintained a synthetic copy of the `self`/
`project` subcommand tree, with a `CLAUDE.md` rule mandating "mirror
`cli::build_command`" and tests that just asserted the copy matched. This
replaces the copy with an ~80-line **walker over `cli::build_command`**.

## How
- `build_command(&empty_manifest())` yields only the hardcoded `self` /
  `project` builtin subtrees + root flags (no user/third-party commands).
- Recurse the two `BUILTIN_ROOTS`, skipping any `is_hide_set()` subcommand;
  nested subcommands → `Group`s (dotted parent path), leaves → synthetic
  `Command`s. Arg→`ArgumentKind`: positional→Positional, `SetTrue`/`SetFalse`
  →Flag, `Count`→Count, `Append`→Repeated, else→Optional; `allowed_values`
  from `get_possible_values()`. `ROOT_LONG_FLAGS` likewise derived.
- 390 → 352 lines; `CLAUDE.md` + module doc no longer mandate mirroring.

## It also fixed a stale mirror
Because the entries are now derived from the real CLI, completions pick up
flags the hand-copy had drifted from:
- `self build-manifest` gains `--source-dir` / `--package`, drops a phantom
  `--python` (verified against `--help`).
- `project init` gains `--yes`.

## Tests
Dropped the mirror-equality guardrail
(`root_long_flags_cover_every_root_arg_in_build_command`); the kept tests now
exercise the *derived* tree behaviourally, plus new
`hidden_internal_helpers_are_absent` (the `__*` helpers never surface) and a
sorted-root-flags check. `self_offers_known_subcommands` doubles as proof a
new `cli.rs` subcommand appears without editing this file.

Local: `cargo test -p toolr --test complete_smoke` 12 passed; builtin tests
11 passed; clippy/cargo-check clean. Stacked on #333 (now merged), rebased
onto `main`.