### PR TITLE
fix(install): verify SLSA attestation by default (fail closed) [SEC-08]

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -55,12 +55,15 @@ jobs:
           # `gh attestation verify` reads $GH_TOKEN to authenticate
           # against the GitHub API for attestation lookup.
           GH_TOKEN: ${{ github.token }}
+          # Route the workflow_dispatch input through an env var rather than
+          # interpolating it into the script body (CWE-78 shell injection).
+          VERSION: ${{ inputs.version }}
         run: |
           # The runner image ships the `gh` CLI; --verify-attestation=require
           # fails the job if the SLSA attestation does not validate.
-          if [ -n "${{ inputs.version }}" ]; then
+          if [ -n "$VERSION" ]; then
             sh ./installation/install.sh \
-              --version "${{ inputs.version }}" \
+              --version "$VERSION" \
               --prefix "$RUNNER_TEMP/toolr-bin" \
               --verify-attestation=require
           else
@@ -72,6 +75,43 @@ jobs:
         run: |
           "$RUNNER_TEMP/toolr-bin/toolr" --version
           "$RUNNER_TEMP/toolr-bin/toolr" --help
+
+      # SEC-08 regression: with `gh` absent and the default mode
+      # (`require`), the installer must FAIL CLOSED rather than silently
+      # downgrade to checksum-only. Hide `gh`, run with NO
+      # `--verify-attestation` flag (exercising the default), and assert a
+      # non-zero exit whose message points at `gh` / the `skip` escape hatch.
+      - name: install.sh fails closed when 'gh' is absent (SEC-08)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh_bin="$(command -v gh)"
+          sudo mv "$gh_bin" "${gh_bin}.hidden"
+          set +e
+          if [ -n "$VERSION" ]; then
+            out=$(sh ./installation/install.sh --version "$VERSION" --prefix "$RUNNER_TEMP/nogh-bin" 2>&1)
+          else
+            out=$(sh ./installation/install.sh --prefix "$RUNNER_TEMP/nogh-bin" 2>&1)
+          fi
+          rc=$?
+          set -e
+          sudo mv "${gh_bin}.hidden" "$gh_bin"
+          printf '%s\n' "$out"
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::install.sh installed WITHOUT attestation verification when gh was absent (must fail closed)" >&2
+            exit 1
+          fi
+          printf '%s\n' "$out" | grep -qi "gh" || {
+            echo "::error::install.sh failed but without actionable gh/skip guidance" >&2
+            exit 1
+          }
+          test ! -e "$RUNNER_TEMP/nogh-bin/toolr" || {
+            echo "::error::install.sh placed the binary despite failing verification" >&2
+            exit 1
+          }
+          echo "OK: install.sh failed closed (no gh, default=require)"
 
   smoke-install-ps1:
     name: install.ps1 (windows)
@@ -86,10 +126,11 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
         run: |
           $prefix = Join-Path $env:RUNNER_TEMP "toolr-bin"
-          if ("${{ inputs.version }}" -ne "") {
-            ./installation/install.ps1 -Version "${{ inputs.version }}" -Prefix $prefix -VerifyAttestation require
+          if ("$env:VERSION" -ne "") {
+            ./installation/install.ps1 -Version "$env:VERSION" -Prefix $prefix -VerifyAttestation require
           } else {
             ./installation/install.ps1 -Prefix $prefix -VerifyAttestation require
           }
@@ -120,35 +161,41 @@ jobs:
           python-version: '3.14'
       - name: Smoke `pip install toolr` (binary wheel)
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           # `toolr` on PyPI is now the binary-only wheel produced from
           # crates/toolr/pyproject.toml — it ships the `toolr` executable
           # entry point but has no importable Python module.
+          spec="toolr"; [ -n "$VERSION" ] && spec="toolr==$VERSION"
           python -m venv .venv-bin
           if [ "$RUNNER_OS" = "Windows" ]; then
             .venv-bin/Scripts/python.exe -m pip install --upgrade pip
-            .venv-bin/Scripts/pip install toolr${{ inputs.version && format('=={0}', inputs.version) || '' }}
+            .venv-bin/Scripts/pip install "$spec"
             .venv-bin/Scripts/toolr.exe --version
           else
             .venv-bin/bin/python -m pip install --upgrade pip
-            .venv-bin/bin/pip install toolr${{ inputs.version && format('=={0}', inputs.version) || '' }}
+            .venv-bin/bin/pip install "$spec"
             .venv-bin/bin/toolr --version
           fi
 
       - name: Smoke `pip install toolr-py` (pyo3 wheel)
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           # `toolr-py` on PyPI is the pyo3 bindings wheel produced from
           # crates/toolr-py/pyproject.toml — installs as `import toolr`
           # with the Rust extension at `toolr.utils._rust_utils`.
+          spec="toolr-py"; [ -n "$VERSION" ] && spec="toolr-py==$VERSION"
           python -m venv .venv-py
           if [ "$RUNNER_OS" = "Windows" ]; then
             .venv-py/Scripts/python.exe -m pip install --upgrade pip
-            .venv-py/Scripts/pip install toolr-py${{ inputs.version && format('=={0}', inputs.version) || '' }}
+            .venv-py/Scripts/pip install "$spec"
             .venv-py/Scripts/python.exe -c "import toolr; import toolr.utils._rust_utils; print(toolr.__version__)"
           else
             .venv-py/bin/python -m pip install --upgrade pip
-            .venv-py/bin/pip install toolr-py${{ inputs.version && format('=={0}', inputs.version) || '' }}
+            .venv-py/bin/pip install "$spec"
             .venv-py/bin/python -c "import toolr; import toolr.utils._rust_utils; print(toolr.__version__)"
           fi
 
@@ -197,10 +244,12 @@ jobs:
           version: ${{ env.MISE_VERSION }}
           install: false
       - name: Install toolr via the aqua backend
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            mise install "aqua:s0undt3ch/ToolR@${{ inputs.version }}"
-            mise exec "aqua:s0undt3ch/ToolR@${{ inputs.version }}" -- toolr --version
+          if [ -n "$VERSION" ]; then
+            mise install "aqua:s0undt3ch/ToolR@$VERSION"
+            mise exec "aqua:s0undt3ch/ToolR@$VERSION" -- toolr --version
           else
             mise install aqua:s0undt3ch/ToolR@latest
             mise exec aqua:s0undt3ch/ToolR@latest -- toolr --version

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Reproduce locally with `python3 scripts/bench.py` (stdlib-only; emits the table 
 - **First-class third-party command packages.** Plugins ship a static `toolr-manifest.json` inside
   the wheel. Discovery is a glob + JSON parse; no Python import to find them.
 - **Signed releases.** Every release archive ships with a SLSA build-provenance attestation. The
-  install scripts verify it automatically when `gh` is on PATH.
+  install scripts verify it by default (requires the `gh` CLI); pass `--verify-attestation=skip`
+  to bypass, accepting the supply-chain risk.
 
 ## Two wheels, two roles
 
@@ -81,7 +82,8 @@ See "Two wheels, two roles" above for the split.
 curl -fsSL https://raw.githubusercontent.com/s0undt3ch/ToolR/main/installation/install.sh | sh
 ```
 
-Verifies the SLSA attestation when `gh` is on PATH. Pin a version with `sh -s -- --version X.Y.Z`.
+Verifies the SLSA attestation by default (requires the `gh` CLI; pass `--verify-attestation=skip`
+to bypass). Pin a version with `sh -s -- --version X.Y.Z`.
 Custom prefix: `sh -s -- --prefix /opt/toolr/bin`.
 
 ### PowerShell (Windows)

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -34,6 +34,13 @@ comment.
 - The toolr runner no longer puts the invocation directory on `sys.path` (the
   interpreter is started with `-P`), preventing a stray `.py` file in your
   current directory from shadowing stdlib/site-packages modules.
+- The install scripts (`install.sh`, `install.ps1`) now **verify the release's
+  SLSA build provenance by default** (`--verify-attestation=require`). Previously
+  the default silently skipped verification when the `gh` CLI was absent, leaving
+  only a same-release `.sha256` check that can't detect a tampered release asset.
+  If `gh` is missing the install now fails with guidance rather than installing
+  unverified; pass `--verify-attestation=skip` (`-VerifyAttestation skip` on
+  Windows) to explicitly opt out. Matches the already-fail-closed GitHub Action.
 
 ### Changed
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -57,7 +57,8 @@ front-end rewrite; use the `toolr` executable instead.
 curl -fsSL https://raw.githubusercontent.com/s0undt3ch/ToolR/main/installation/install.sh | sh
 ```
 
-Verifies the SLSA attestation when `gh` is on PATH. Pin a version
+Verifies the SLSA attestation by default (requires the `gh` CLI; pass
+`--verify-attestation=skip` to bypass). Pin a version
 with `sh -s -- --version X.Y.Z`. Custom prefix:
 `sh -s -- --prefix /opt/toolr/bin`. Default prefix is
 `$XDG_BIN_HOME` (or `~/.local/bin`).
@@ -132,12 +133,18 @@ your tools venv when it executes commands.
 
 Every release archive is signed with a SLSA build-provenance
 attestation produced by the GitHub-hosted release workflow. The
-`install.sh` and `install.ps1` scripts verify the attestation
-automatically when the `gh` CLI is on PATH. To require verification:
+`install.sh` and `install.ps1` scripts verify the attestation **by
+default** (`--verify-attestation=require`), which needs the `gh` CLI: if
+`gh` is missing the install **fails** rather than silently downgrading to
+a checksum-only install (the `.sha256` ships from the same release, so it
+catches transport corruption, not a tampered release asset).
+
+To install without supply-chain verification (accepting the risk — e.g.
+on a host where you can't install `gh`):
 
 ```sh
-sh installation/install.sh --verify-attestation=require   # POSIX
-./installation/install.ps1 -VerifyAttestation require     # Windows
+sh installation/install.sh --verify-attestation=skip   # POSIX
+./installation/install.ps1 -VerifyAttestation skip     # Windows
 ```
 
 Or verify a downloaded archive manually:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,7 +47,8 @@ scaffolds for you.
 curl -fsSL https://raw.githubusercontent.com/s0undt3ch/ToolR/main/installation/install.sh | sh
 ```
 
-Verifies the SLSA attestation when `gh` is on PATH. Pin a version with
+Verifies the SLSA attestation by default (requires the `gh` CLI; pass
+`--verify-attestation=skip` to bypass). Pin a version with
 `sh -s -- --version X.Y.Z`. Custom prefix: `sh -s -- --prefix /opt/toolr/bin`.
 
 ### PowerShell (Windows)

--- a/installation/install.ps1
+++ b/installation/install.ps1
@@ -14,7 +14,7 @@ param(
   [switch]$DryRun,
   [switch]$NoVerify,
   [ValidateSet("auto", "require", "skip")]
-  [string]$VerifyAttestation = "auto"
+  [string]$VerifyAttestation = "require"
 )
 
 $ErrorActionPreference = "Stop"
@@ -49,9 +49,15 @@ function Test-AttestationVerified {
   $gh = Get-Command gh -ErrorAction SilentlyContinue
   if (-not $gh) {
     if ($VerifyAttestation -eq "require") {
-      throw "gh CLI required for -VerifyAttestation require but not on PATH"
+      throw @"
+cannot verify the release's SLSA build provenance: the 'gh' CLI is not on PATH.
+  toolr archives are signed; verification needs GitHub CLI -> https://cli.github.com
+  Choose one:
+    * install 'gh' and re-run this installer (recommended), or
+    * re-run with -VerifyAttestation skip to install WITHOUT supply-chain verification.
+"@
     }
-    Write-Host "skipping attestation verification ('gh' CLI not installed)"
+    Write-Warning "skipping attestation verification ('gh' CLI not installed) -- the archive is NOT supply-chain verified"
     return
   }
   Write-Host "verifying SLSA build provenance via 'gh attestation verify'"

--- a/installation/install.sh
+++ b/installation/install.sh
@@ -13,7 +13,7 @@ TRIPLE=""
 PREFIX=""
 DRY_RUN=0
 NO_VERIFY=0
-VERIFY_ATTESTATION="auto"
+VERIFY_ATTESTATION="require"
 
 print_help() {
   cat <<EOF
@@ -26,7 +26,8 @@ Options:
   --dry-run                 Print actions without making changes
   --no-verify               Skip SHA-256 verification (not recommended)
   --verify-attestation MODE Attestation verification mode: auto|require|skip
-                            (default: auto - verify when 'gh' is available)
+                            (default: require - needs the 'gh' CLI; pass
+                            'skip' to bypass, accepting the supply-chain risk)
   -h, --help                Show this help
 EOF
 }
@@ -50,6 +51,7 @@ done
 
 err() { printf "install.sh: %s\n" "$*" >&2; exit 1; }
 info() { printf "install.sh: %s\n" "$*" >&2; }
+warn() { printf "install.sh: WARNING: %s\n" "$*" >&2; }
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || err "missing required command: $1"
@@ -108,9 +110,12 @@ verify_sha256() {
 
 # Verify the SLSA build-provenance attestation attached to a release
 # archive via the GitHub CLI. Modes:
-#   auto    - verify if `gh` is on PATH; skip silently otherwise
-#   require - fail hard if `gh` is missing or verification fails
+#   require - (default) fail hard if `gh` is missing or verification fails
+#   auto    - verify if `gh` is on PATH; skip with a warning otherwise
 #   skip    - never verify (e.g. when running offline)
+# `require` is the default so a missing verifier can't silently downgrade
+# the install to checksum-only (the `.sha256` ships from the same release,
+# so it catches transport corruption, not a tampered release asset).
 verify_attestation() {
   file="$1"
   case "$VERIFY_ATTESTATION" in
@@ -123,9 +128,16 @@ verify_attestation() {
   esac
   if ! command -v gh >/dev/null 2>&1; then
     if [ "$VERIFY_ATTESTATION" = "require" ]; then
-      err "gh CLI required for --verify-attestation=require but not on PATH"
+      printf '%s\n' \
+        "install.sh: cannot verify the release's SLSA build provenance: the 'gh' CLI is not on PATH." \
+        "  toolr archives are signed; verification needs GitHub CLI -> https://cli.github.com" \
+        "  Choose one:" \
+        "    * install 'gh' and re-run this installer (recommended), or" \
+        "    * re-run with --verify-attestation=skip to install WITHOUT supply-chain verification." \
+        >&2
+      exit 1
     fi
-    info "skipping attestation verification ('gh' CLI not installed)"
+    warn "skipping attestation verification ('gh' CLI not installed) -- the archive is NOT supply-chain verified"
     return 0
   fi
   info "verifying SLSA build provenance via 'gh attestation verify'"


### PR DESCRIPTION
## Problem
`install.sh` and `install.ps1` defaulted to `--verify-attestation=auto`,
which **silently skipped** SLSA attestation verification whenever the `gh`
CLI wasn't on PATH — the common case for the documented `curl … | sh`
one-liner. The only control left running was a `.sha256` fetched from the
**same** GitHub release as the archive, so it detects transport corruption,
not a tampered release asset. Anyone able to replace the release assets
(compromised release job, leaked publish token, CDN compromise) swaps both
the archive and its checksum and the install succeeds. The GitHub Action
already fails closed; the shell installers didn't.

## Fix
- **Default `require`** in both installers. Missing `gh` now **fails** with
  actionable guidance (install `gh`, or pass `--verify-attestation=skip` /
  `-VerifyAttestation skip` to explicitly opt out) instead of silently
  downgrading to checksum-only.
- `auto` stays as an explicit opt-in but now prints a loud **WARNING**
  (not a silent info line) when it skips for a missing `gh`.
- **`install-smoke.yml`:** new fail-closed regression — hide `gh`, run with
  the default mode, assert a non-zero exit, an actionable message, and that
  **no binary was placed**. (The require-success path was already covered.)
- **CWE-78 hardening (bonus, same file):** the `gh`-absent semgrep pass
  flagged that every run step interpolated the `workflow_dispatch`
  `version` input via `${{ … }}`. Routed it through `env:` vars in all
  steps (`install.sh`, `install.ps1`, both `pip` smokes, mise-aqua).
- **Docs:** README / installation / quickstart now state verification is
  on by default and document the `skip` opt-out.

## Acceptance criteria
- [x] No `gh` + default ⇒ install fails (not silent checksum-only).
- [x] With `gh`, attestation verified against `--repo s0undt3ch/ToolR`.
- [x] `install-smoke.yml` exercises require-success **and** missing-`gh`.