### PR TITLE
ci: route workflow inputs through env vars (CWE-78 hardening) [SEC-12]

### DIFF
--- a/.github/actions/apply-release-patch/action.yml
+++ b/.github/actions/apply-release-patch/action.yml
@@ -19,5 +19,7 @@ runs:
 
     - name: Apply The Release Patch
       shell: bash
+      env:
+        RELEASE_PATCH_NAME: ${{ inputs.release-patch-name }}
       run: |
-        git am --committer-date-is-author-date ${{ inputs.release-patch-name }}
+        git am --committer-date-is-author-date "$RELEASE_PATCH_NAME"

--- a/.github/actions/throttle/action.yml
+++ b/.github/actions/throttle/action.yml
@@ -13,5 +13,7 @@ runs:
   steps:
     - name: Configure Git
       shell: bash
+      env:
+        MAX_SLEEP: ${{ inputs.max-sleep-seconds }}
       run: |
-        t=$(python3 -c 'import random, sys; sys.stdout.write(str(random.randint(1, ${{ inputs.max-sleep-seconds }})))'); echo "Sleeping $t seconds"; sleep "$t"
+        t=$(python3 -c 'import os, random, sys; sys.stdout.write(str(random.randint(1, int(os.environ["MAX_SLEEP"]))))'); echo "Sleeping $t seconds"; sleep "$t"

--- a/.github/workflows/_prepare-release.yml
+++ b/.github/workflows/_prepare-release.yml
@@ -141,8 +141,14 @@ jobs:
       - name: Bump Version
         id: bump-version
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
-          toolr version bump --write --check-existing-tag --include-action ${{ inputs.release-version != '' && format('--new-version={0}', inputs.release-version) || '' }}
+          new_version_arg=()
+          if [ -n "$RELEASE_VERSION" ]; then
+            new_version_arg=(--new-version="$RELEASE_VERSION")
+          fi
+          toolr version bump --write --check-existing-tag --include-action "${new_version_arg[@]}"
 
       - name: Load UNRELEASED.md into TOOLR_RELEASE_NOTES env var
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,12 +400,16 @@ jobs:
           release-patch-name: ${{ needs.prepare-release.outputs.release-patch-name }}
 
       - name: Tag the v${{ needs.prepare-release.outputs.release-version }} Release
+        env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.release-version }}
         run: |
-          git tag -m "chore(release): Release v${{ needs.prepare-release.outputs.release-version }}" -a v${{ needs.prepare-release.outputs.release-version }}
+          git tag -m "chore(release): Release v${RELEASE_VERSION}" -a "v${RELEASE_VERSION}"
 
       - name: Push tag
+        env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.release-version }}
         run: |
-          git push origin v${{ needs.prepare-release.outputs.release-version }}
+          git push origin "v${RELEASE_VERSION}"
           git push
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Several `run:` / `python -c` blocks spliced non-literal `${{ … }}` values
directly into the script body — GitHub-Actions template injection by
construction. None is a live vuln today (inputs are admin-gated, semver-shaped),
but it's defense-in-depth + consistency with the env-routing pattern `ci.yml`
already uses. SEC-12.

Routed every flagged site through a step `env:` var:

| File | env var | site |
|---|---|---|
| `.github/actions/throttle/action.yml` | `MAX_SLEEP` | `random.randint(1, int(os.environ["MAX_SLEEP"]))` — non-numeric now fails via `int()` instead of injecting |
| `.github/actions/apply-release-patch/action.yml` | `RELEASE_PATCH_NAME` | `git am … "$RELEASE_PATCH_NAME"` |
| `.github/workflows/release.yml` | `RELEASE_VERSION` | `git tag` / `git push` |
| `.github/workflows/_prepare-release.yml` | `RELEASE_VERSION` | `toolr version bump` argv (preserves empty-means-omit semantics) |

(`install-smoke.yml`'s sites were already fixed in #337.) Verified by grep that
no `${{ inputs.* }}` / `${{ needs.* }}` / `${{ github.event.* }}` remains in any
`run:` body in the touched files; actionlint clean.

Follow-up (out of scope, noted): a `steps.mise-…outputs.python` path is spliced
into a `run:` in `_prepare-release.yml` — a resolved tool path, not external
input; lower risk, left for a separate pass.