### PR TITLE
feat(ci): pin & verify action SHAs in one pre-commit pass [SEC-10]

### DIFF
--- a/.github/actions/setup-virtualenv/action.yml
+++ b/.github/actions/setup-virtualenv/action.yml
@@ -62,18 +62,23 @@ runs:
     # installs via rustup and symlinks it; see `mise.toml`). `~/.rustup`
     # is outside mise's cached scope, so on a mise cache *hit* mise reports
     # "all tools are installed" and skips `rustup component add` — leaving
-    # `~/.rustup` as whatever the bare runner image shipped (a `minimal`
-    # profile with no clippy). The pre-commit `clippy` hook then fails with
-    # `'cargo-clippy' is not installed for the toolchain '1.96.0-...'`, and
-    # maturin's `cargo metadata` fails the same way for the `cargo`
-    # component. Cache `~/.rustup` so the cached "installed" state is
-    # truthful and the components persist across hits.
+    # `~/.rustup` as whatever was restored, which need not contain clippy.
+    # The pre-commit `clippy` hook then fails with `'cargo-clippy' is not
+    # installed for the toolchain '1.96.0-...'`, and maturin's
+    # `cargo metadata` fails the same way for the `cargo` component.
     #
-    # Exact-match key only (no `restore-keys`): it is keyed on the same
-    # `mise.toml`/`mise.lock` hash that drives the mise cache below, so the
-    # two co-invalidate on any toolchain change and never restore mismatched
-    # states. Shared across job types (no `cache-prefix`) — the toolchain is
-    # identical regardless of which job installs it.
+    # Caching `~/.rustup` (below) keeps a warm toolchain around, but is a
+    # *speed optimisation only* — it cannot guarantee correctness on its own:
+    # this cache and mise's data-dir cache have independent keys and are saved
+    # by different jobs at different times, so a job with a mise-cache hit but
+    # a `~/.rustup`-cache miss skips the install and then saves a
+    # clippy-less `~/.rustup` under the shared key, poisoning it for everyone.
+    # The "Ensure rust components" step after mise is what actually guarantees
+    # the components exist, regardless of what either cache restored.
+    #
+    # Exact-match key only (no `restore-keys`): keyed on the `mise.toml`/
+    # `mise.lock` hash so it invalidates on any toolchain change. Shared across
+    # job types (no `cache-prefix`) — the toolchain is identical everywhere.
     - name: Cache rust toolchain (~/.rustup)
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
@@ -91,6 +96,18 @@ runs:
         version: ${{ inputs.mise-version }}
         cache: true
         cache_key_prefix: mise|${{ inputs.cache-seed }}|${{ inputs.mise-version }}|${{ runner.os }}|${{ runner.arch }}|${{ inputs.cache-prefix }}
+
+    # Deterministic guarantee that `clippy`/`rustfmt` are present on the
+    # mise-pinned toolchain. mise declares these `components` in `mise.toml`,
+    # but only installs them when it actually installs the toolchain — on a
+    # mise-cache hit it short-circuits ("all tools are installed") and a
+    # restored/poisoned `~/.rustup` may lack them. `rustup component add` is
+    # idempotent: a no-op (~instant) when present, a quick fetch when not. It
+    # targets the active toolchain (mise exports `RUSTUP_TOOLCHAIN`), so it
+    # follows the `mise.toml` pin automatically with no version hardcoded here.
+    - name: Ensure rust components (clippy, rustfmt)
+      shell: bash
+      run: rustup component add clippy rustfmt
 
     - name: Get Python version checksum
       id: python-version-checksum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,11 @@ jobs:
           mise-version: ${{ env.MISE_VERSION }}
 
       - name: Run Prek
+        env:
+          # The `verify-action-pins` hook resolves each pinned action's tag
+          # via `gh api`; a token raises the rate limit from 60/hr
+          # (unauthenticated) to 5000/hr so the run can't be throttled.
+          GH_TOKEN: ${{ github.token }}
         run: |
           prek run --all-files --show-diff-on-failure
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
   FORCE_COLOR: "1"
   # Bump to invalidate every cache (mise install dirs, .venv, prek hooks,
   # mypy/ruff caches, ...) used by this workflow.
-  CACHE_SEED: "4"
+  CACHE_SEED: "5"
   # `MISE_VERSION` lives in `.github/env` — loaded per-job by a
   # "Load shared env vars" step (immediately after `actions/checkout`)
   # so the value is available via `$MISE_VERSION` / `env.MISE_VERSION`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,18 @@ repos:
 
   - repo: local
     hooks:
+      # One pass: pin any unpinned `uses:` ref to a SHA AND verify that
+      # every already-pinned ref still matches the SHA its `# <tag>` comment
+      # resolves to (catching hand-edited / typosquatted / upstream-repointed
+      # pins). Fires on everything that carries pins — workflows, composite
+      # actions, and the root action.yml. Resolutions are memoised per run.
+      # Requires `gh`; a missing gh is a hard error here (pass `--exit-zero`
+      # for a non-blocking, gh-optional advisory run).
       - id: pin-github-actions
-        name: Pin GitHub Actions to commit SHAs
-        language: python
-        entry: python .pre-commit-hooks/pin-github-actions.py
-        files: ^\.github/workflows/.*\.ya?ml$
+        name: Pin & verify GitHub Action SHAs
+        language: system
+        entry: .pre-commit-hooks/pin-github-actions.py
+        files: ^(\.github/(workflows|actions/[^/]+)/.*\.ya?ml|action\.yml)$
 
       - id: regen-doc-snippets
         name: Verify doc snippets are in sync

--- a/.pre-commit-hooks/pin-github-actions.py
+++ b/.pre-commit-hooks/pin-github-actions.py
@@ -14,6 +14,18 @@ from functools import lru_cache
 from pathlib import Path
 
 
+class TransientResolutionError(Exception):
+    """A ref could not be resolved for a *transient* reason — rate limiting,
+    a network/connection failure, a timeout, an auth/5xx response, or a
+    malformed reply — rather than the ref genuinely not existing.
+
+    Callers should treat this as "unknown, try again later" (warn and skip),
+    **not** as a verification failure. A definitive "this tag/repo does not
+    exist" (HTTP 404) is reported as ``None`` instead, which *is* a real
+    problem with the pin.
+    """
+
+
 def check_gh_cli() -> bool:
     """Check if gh CLI is available."""
     return shutil.which("gh") is not None
@@ -23,12 +35,19 @@ def check_gh_cli() -> bool:
 def get_commit_sha(owner: str, repo: str, ref: str) -> str | None:
     """Get the commit SHA for a given ref (tag or branch) using gh CLI.
 
+    Returns the resolved SHA on success, or ``None`` when GitHub reports the
+    ref genuinely does not exist (HTTP 404) — a real, actionable pin problem.
+    Raises :class:`TransientResolutionError` for everything else (rate limit,
+    auth, 5xx, network, timeout, malformed response): the ref's existence is
+    *unknown*, so the caller must not treat it as a verification failure.
+
     In-process memoised on ``(owner, repo, ref)``: a workflow/action set
     typically pins the same action+version many times over, so this
     resolves each unique ``owner/repo@ref`` once per run instead of
     re-querying `gh api` for every occurrence. The cache lives for the
     process (one hook invocation), so it never serves stale data across
-    runs.
+    runs. (``lru_cache`` does not memoise raised exceptions, so a transient
+    failure is retried on the next occurrence rather than poisoning the run.)
     """
     try:
         # Use gh api to get commit info
@@ -38,13 +57,27 @@ def get_commit_sha(owner: str, repo: str, ref: str) -> str | None:
             text=True,
             timeout=10,
         )
-        if result.returncode == 0:
-            data = json.loads(result.stdout)
-            return data["sha"]
-        return None
     except Exception as e:
-        print(f"Warning: Failed to fetch SHA for {owner}/{repo}@{ref}: {e}", file=sys.stderr)
+        # Timeout, gh vanished mid-run, OSError, ... — all transient.
+        raise TransientResolutionError(f"failed to invoke gh for {owner}/{repo}@{ref}: {e}") from e
+
+    if result.returncode == 0:
+        try:
+            return json.loads(result.stdout)["sha"]
+        except (json.JSONDecodeError, KeyError) as e:
+            raise TransientResolutionError(
+                f"malformed gh response for {owner}/{repo}@{ref}: {e}"
+            ) from e
+
+    stderr = (result.stderr or "").strip()
+    # Definitive "does not exist" — the only case that is a real pin problem.
+    if "HTTP 404" in stderr or "Not Found" in stderr:
         return None
+    # Rate limit, auth, 5xx, connection reset, ... — existence still unknown.
+    raise TransientResolutionError(
+        f"could not reach GitHub to resolve {owner}/{repo}@{ref}: "
+        f"{stderr or f'gh exited {result.returncode}'}"
+    )
 
 
 def get_latest_release(owner: str, repo: str) -> str | None:
@@ -133,9 +166,23 @@ def verify_action_line(
         return f"{action_path} could not be parsed into owner/repo"
     owner, repo = parts[0], parts[1]
 
-    expected_sha = resolve(owner, repo, tag)
+    try:
+        expected_sha = resolve(owner, repo, tag)
+    except TransientResolutionError as e:
+        # Existence unknown (rate limit / network / timeout). Don't fail the
+        # run over a problem that isn't the pin's fault — warn and skip.
+        print(
+            f"Warning: skipping pin check for {action_path}@{pinned_sha} # {tag}: {e}",
+            file=sys.stderr,
+        )
+        return None
+
     if expected_sha is None:
-        return f"{action_path}@{pinned_sha} # {tag}: could not resolve tag '{tag}' to a SHA"
+        # Definitive 404: the tag genuinely does not exist — a real problem.
+        return (
+            f"{action_path}@{pinned_sha} # {tag}: "
+            f"tag '{tag}' does not exist — could not resolve tag '{tag}' to a SHA"
+        )
 
     if expected_sha != pinned_sha:
         return (
@@ -167,8 +214,14 @@ def pin_action(action_info: dict[str, str], use_latest: bool = False) -> str | N
         else:
             print(f"Warning: Could not fetch latest release for {action_path}, using current ref")
 
-    # Get the commit SHA
-    sha = get_commit_sha(owner, repo, ref)
+    # Get the commit SHA. A transient resolution failure (rate limit /
+    # network / timeout) leaves the ref unpinned for this run rather than
+    # crashing the whole pass — warn and move on.
+    try:
+        sha = get_commit_sha(owner, repo, ref)
+    except TransientResolutionError as e:
+        print(f"Warning: leaving {action_path}@{ref} unpinned this run: {e}", file=sys.stderr)
+        return None
     if not sha:
         return None
 

--- a/.pre-commit-hooks/pin-github-actions.py
+++ b/.pre-commit-hooks/pin-github-actions.py
@@ -9,6 +9,8 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
+from functools import lru_cache
 from pathlib import Path
 
 
@@ -17,8 +19,17 @@ def check_gh_cli() -> bool:
     return shutil.which("gh") is not None
 
 
+@lru_cache(maxsize=None)
 def get_commit_sha(owner: str, repo: str, ref: str) -> str | None:
-    """Get the commit SHA for a given ref (tag or branch) using gh CLI."""
+    """Get the commit SHA for a given ref (tag or branch) using gh CLI.
+
+    In-process memoised on ``(owner, repo, ref)``: a workflow/action set
+    typically pins the same action+version many times over, so this
+    resolves each unique ``owner/repo@ref`` once per run instead of
+    re-querying `gh api` for every occurrence. The cache lives for the
+    process (one hook invocation), so it never serves stale data across
+    runs.
+    """
     try:
         # Use gh api to get commit info
         result = subprocess.run(
@@ -83,6 +94,58 @@ def parse_action_line(line: str, include_pinned: bool = False) -> dict[str, str]
     }
 
 
+def verify_action_line(
+    line: str,
+    resolve: "Callable[[str, str, str], str | None]" = get_commit_sha,
+) -> str | None:
+    """Verify a single `uses:` line's pin against its `# <tag>` comment.
+
+    Returns an error message string when the line is a SHA pin that
+    cannot be verified or whose pinned SHA does not match the SHA the
+    comment's tag currently resolves to. Returns ``None`` when the line
+    is fine (or is not a verifiable pin — e.g. a not-yet-pinned tag ref,
+    a local action, or a non-`uses:` line; those are out of scope here).
+
+    `resolve(owner, repo, ref) -> sha | None` is injected so tests can
+    supply a fake resolver and avoid any network / `gh` dependency.
+    """
+    info = parse_action_line(line, include_pinned=True)
+    if info is None:
+        return None
+
+    action_path = info["action_path"]
+
+    # Not-yet-pinned tag refs are the autofix hook's job, not verify's.
+    if not info["is_pinned"]:
+        return None
+
+    pinned_sha = info["ref"]
+
+    # Extract the tag from the trailing comment, e.g. "# v6.0.3" -> "v6.0.3".
+    comment_match = re.match(r"\s*#\s*(\S+)", info["comment"])
+    if not comment_match:
+        return f"{action_path} is pinned to {pinned_sha} but has no '# <tag>' comment to verify against"
+
+    tag = comment_match.group(1)
+
+    parts = action_path.split("/", 2)
+    if len(parts) < 2:
+        return f"{action_path} could not be parsed into owner/repo"
+    owner, repo = parts[0], parts[1]
+
+    expected_sha = resolve(owner, repo, tag)
+    if expected_sha is None:
+        return f"{action_path}@{pinned_sha} # {tag}: could not resolve tag '{tag}' to a SHA"
+
+    if expected_sha != pinned_sha:
+        return (
+            f"{action_path} pin mismatch for tag '{tag}': "
+            f"expected {expected_sha} but file has {pinned_sha}"
+        )
+
+    return None
+
+
 def pin_action(action_info: dict[str, str], use_latest: bool = False) -> str | None:
     """Pin an action to its commit SHA."""
     action_path = action_info["action_path"]
@@ -121,30 +184,46 @@ def pin_action(action_info: dict[str, str], use_latest: bool = False) -> str | N
     return new_line
 
 
-def process_file(filepath: Path, use_latest: bool = False) -> bool:
-    """Process a workflow file and pin actions. Returns True if changes were made."""
+def process_file(filepath: Path, use_latest: bool = False) -> tuple[bool, list[str]]:
+    """Pin unpinned `uses:` refs and verify already-pinned ones in one pass.
+
+    Returns ``(modified, errors)``:
+    - ``modified`` — an unpinned ref was rewritten to a SHA (or, under
+      ``--latest``, every ref was re-pinned to its newest release).
+    - ``errors`` — already-pinned refs whose SHA no longer matches their
+      ``# <tag>`` comment. Verification is skipped under ``--latest`` (which
+      re-pins everything from scratch anyway).
+    """
     try:
         content = filepath.read_text()
     except Exception as e:
-        print(f"Error reading {filepath}: {e}", file=sys.stderr)
-        return False
+        return False, [f"{filepath}: could not read file: {e}"]
 
-    lines = content.splitlines(keepends=True)
     modified = False
-    new_lines = []
+    errors: list[str] = []
+    new_lines: list[str] = []
 
-    for line in lines:
-        action_info = parse_action_line(line, include_pinned=use_latest)
+    for lineno, line in enumerate(content.splitlines(keepends=True), start=1):
+        info = parse_action_line(line, include_pinned=True)
+        if info is None:
+            new_lines.append(line)
+            continue
 
-        if action_info:
-            new_line = pin_action(action_info, use_latest=use_latest)
-            if new_line:
-                if not use_latest:
-                    print(f"Pinning {action_info['action_path']}@{action_info['ref']} -> SHA")
-                new_lines.append(new_line + "\n" if not new_line.endswith("\n") else new_line)
-                modified = True
-            else:
-                new_lines.append(line)
+        if not use_latest and info["is_pinned"]:
+            # Already pinned: verify it matches its tag comment; never rewrite.
+            error = verify_action_line(line)
+            if error:
+                errors.append(f"{filepath}:{lineno}: {error}")
+            new_lines.append(line)
+            continue
+
+        # Unpinned ref (or a `--latest` re-pin): rewrite to a SHA.
+        new_line = pin_action(info, use_latest=use_latest)
+        if new_line:
+            if not use_latest:
+                print(f"Pinning {info['action_path']}@{info['ref']} -> SHA")
+            new_lines.append(new_line if new_line.endswith("\n") else new_line + "\n")
+            modified = True
         else:
             new_lines.append(line)
 
@@ -152,48 +231,80 @@ def process_file(filepath: Path, use_latest: bool = False) -> bool:
         filepath.write_text("".join(new_lines))
         print(f"Updated: {filepath}")
 
-    return modified
+    return modified, errors
 
 
 def main() -> int:
     """Main entry point."""
-    parser = argparse.ArgumentParser(description="Pin GitHub Actions to commit SHAs for security.")
-    parser.add_argument("files", nargs="+", help="Workflow files to process")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Lock GitHub Action `uses:` refs to commit SHAs and verify existing "
+            "pins against their tag comments. Default: pin unpinned refs and "
+            "verify already-pinned ones in a single pass."
+        )
+    )
+    parser.add_argument("files", nargs="+", help="Workflow / action files to process")
     parser.add_argument(
         "--latest",
         action="store_true",
-        help="Update all actions to their latest release versions",
+        help="Re-pin every action to its latest release SHA (instead of verifying).",
+    )
+    parser.add_argument(
+        "--exit-zero",
+        action="store_true",
+        help=(
+            "Report pin problems but exit 0 (advisory); also exit 0 — rather than "
+            "hard-erroring — when the gh CLI is unavailable."
+        ),
     )
 
     args = parser.parse_args()
 
-    # Check if gh CLI is available
+    # gh is required to resolve refs. By default a missing gh is a HARD error
+    # (exit 2) — never a silent skip, so "cannot verify" can't masquerade as
+    # "verified, all good". `--exit-zero` is the explicit opt-out: it
+    # downgrades the missing-gh case to a warning + exit 0 (for advisory /
+    # best-effort runs and gh-less contributors).
     if not check_gh_cli():
-        print("Warning: gh CLI not found. Skipping GitHub Actions pinning.", file=sys.stderr)
+        if args.exit_zero:
+            print(
+                "Warning: gh CLI not found; skipping action-pin checks (--exit-zero).",
+                file=sys.stderr,
+            )
+            return 0
+        print("Error: gh CLI not found; cannot resolve or verify action pins.", file=sys.stderr)
         print("Install gh CLI from: https://cli.github.com/", file=sys.stderr)
-        return 0  # Skip gracefully
+        return 2
 
-    modified_files = []
+    errors: list[str] = []
+    modified_any = False
 
     for filepath_str in args.files:
         filepath = Path(filepath_str)
-
         if not filepath.exists():
             print(f"Error: {filepath} does not exist", file=sys.stderr)
             continue
-
         if filepath.suffix not in {".yml", ".yaml"}:
             continue
 
-        if process_file(filepath, use_latest=args.latest):
-            modified_files.append(filepath)
+        modified, file_errors = process_file(filepath, use_latest=args.latest)
+        modified_any = modified_any or modified
+        errors.extend(file_errors)
 
-    if modified_files:
-        action = "Updated" if args.latest else "Pinned"
-        print(f"\n{action} actions in {len(modified_files)} file(s)")
-        return 1  # Return 1 to indicate files were modified (pre-commit should fail)
+    if errors:
+        print("Action pin verification problems:", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        print(f"\n{len(errors)} problem(s) found.", file=sys.stderr)
 
-    return 0
+    if args.exit_zero:
+        # Advisory: report the findings above, but never fail on them. (A
+        # missing gh already hard-errored before we got here.)
+        return 0
+
+    # Non-zero when we rewrote files (pre-commit should re-stage) or found a
+    # pin that no longer matches its tag comment.
+    return 1 if (errors or modified_any) else 0
 
 
 if __name__ == "__main__":

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -37,6 +37,17 @@ runs. Refresh the lockfile with `mise upgrade && mise lock` (bare
 `mise lock` already targets every platform CI runs on) and commit
 `mise.lock` with the change.
 
+The `pin-github-actions` pre-commit hook now verifies as well as pins, in a
+single pass. By default it locks any unpinned `uses:` ref to a SHA *and*
+re-resolves every already-pinned `uses: …@<sha> # <tag>` line against the SHA
+its `# <tag>` comment currently points to, failing on any mismatch or
+unverifiable pin — catching hand-edited or upstream-repointed pins that the
+old pin-only behaviour (which skipped already-pinned lines) would never flag.
+Resolutions are memoised per run. A missing `gh` CLI is now a hard error rather
+than a silent skip; pass `--exit-zero` for a non-blocking, gh-optional advisory
+run. The hook runs in CI too (`prek run --all-files` already covers `.github/**`),
+so no separate verification workflow is needed.
+
 ### Security
 
 - toolr no longer executes repository Python to build its command manifest.

--- a/tests/hooks/test_pin_github_actions.py
+++ b/tests/hooks/test_pin_github_actions.py
@@ -100,11 +100,29 @@ def test_sha_pin_without_comment_fails(
 def test_unresolvable_tag_comment_fails(
     hook: ModuleType, resolver: Callable[[str, str, str], str | None]
 ) -> None:
-    """A tag comment the resolver can't map to a SHA is an error, not a pass."""
+    """A tag that genuinely does not exist (resolver returns None / HTTP 404)
+    is an error, not a pass."""
     line = f"      - uses: actions/checkout@{GOOD_SHA} # v9.9.9"
     error = hook.verify_action_line(line, resolve=resolver)
     assert error is not None
     assert "could not resolve tag" in error
+    assert "does not exist" in error
+
+
+def test_transient_resolution_is_skipped_not_failed(
+    hook: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A transient resolution failure (rate limit / network / timeout) must NOT
+    fail verification — the pin is correct, GitHub was merely unreachable. The
+    line is skipped with a warning instead of reported as an error."""
+
+    def transient(owner: str, repo: str, ref: str) -> str | None:
+        msg = "API rate limit exceeded (HTTP 403)"
+        raise hook.TransientResolutionError(msg)
+
+    line = f"      - uses: actions/checkout@{GOOD_SHA} # {TAG}"
+    assert hook.verify_action_line(line, resolve=transient) is None
+    assert "skipping pin check" in capsys.readouterr().err
 
 
 def test_unpinned_tag_ref_is_out_of_scope(
@@ -192,6 +210,60 @@ def test_process_file_verifies_existing_pins(
     assert len(errors) == 1
     assert errors[0].startswith(f"{bad}:5:")
     assert "mismatch" in errors[0]
+
+
+@pytest.fixture
+def gh_fail_stub(hook: ModuleType, monkeypatch: pytest.MonkeyPatch) -> Callable[[int, str], None]:
+    """Factory: stub ``gh`` to fail with a given returncode + stderr, so the
+    real ``get_commit_sha`` exercises its error-classification path."""
+
+    def install(returncode: int, stderr: str) -> None:
+        rc, err = returncode, stderr
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            class _Result:
+                returncode = rc
+                stdout = ""
+                stderr = err
+
+            return _Result()
+
+        hook.get_commit_sha.cache_clear()
+        monkeypatch.setattr(hook.subprocess, "run", fake_run)
+
+    return install
+
+
+def test_get_commit_sha_404_is_real_not_found(
+    hook: ModuleType, gh_fail_stub: Callable[[int, str], None]
+) -> None:
+    """A genuine HTTP 404 means the ref does not exist — returned as None (a
+    real, reportable problem), not a transient error."""
+    gh_fail_stub(1, "gh: Not Found (HTTP 404)")
+    assert hook.get_commit_sha("orhun", "git-cliff-action", "v9.9.9") is None
+
+
+def test_get_commit_sha_rate_limit_is_transient(
+    hook: ModuleType, gh_fail_stub: Callable[[int, str], None]
+) -> None:
+    """A 403 rate-limit (or any non-404 failure) is transient: the ref's
+    existence is unknown, so it raises rather than reporting a bad pin."""
+    gh_fail_stub(1, "gh: API rate limit exceeded for installation. (HTTP 403)")
+    with pytest.raises(hook.TransientResolutionError):
+        hook.get_commit_sha("orhun", "git-cliff-action", "v4.8.0")
+
+
+def test_process_file_does_not_fail_on_transient(
+    hook: ModuleType,
+    gh_fail_stub: Callable[[int, str], None],
+    workflow_factory: Callable[[str], Path],
+) -> None:
+    """Regression for the prepare-release flake: a correct pin must not be
+    reported as an error just because GitHub was rate-limited/unreachable when
+    the hook ran. A transient failure yields no errors and no rewrite."""
+    gh_fail_stub(1, "gh: API rate limit exceeded. (HTTP 403)")
+    wf = workflow_factory(f"      - uses: actions/checkout@{GOOD_SHA} # {TAG}\n")
+    assert hook.process_file(wf) == (False, [])
 
 
 def test_get_commit_sha_is_memoised(

--- a/tests/hooks/test_pin_github_actions.py
+++ b/tests/hooks/test_pin_github_actions.py
@@ -1,0 +1,220 @@
+"""Tests for the ``pin-github-actions`` pre-commit hook.
+
+The hook locks `uses:` refs to SHAs and verifies already-pinned ones against
+their tag comment in a single default pass. It is a standalone script under
+``.pre-commit-hooks/`` (not an importable package), loaded via
+``importlib.util.spec_from_file_location``. No test touches the network: the
+per-line verify tests inject a fake resolver into ``verify_action_line``, and
+the ``process_file`` / cache tests stub the ``gh`` subprocess via ``gh_stub``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOK_PATH = _REPO_ROOT / ".pre-commit-hooks" / "pin-github-actions.py"
+
+# A pretend "good" pin: this SHA is what tag v6.0.3 resolves to.
+GOOD_SHA = "df4cb1c069e1874edd31b4311f1884172cec0e10"
+TAG = "v6.0.3"
+
+
+def _load_hook() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("pin_github_actions", _HOOK_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def hook() -> ModuleType:
+    """The loaded ``pin-github-actions`` hook module."""
+    return _load_hook()
+
+
+@pytest.fixture
+def resolver() -> Callable[[str, str, str], str | None]:
+    """Fake resolver: only ``actions/checkout@v6.0.3`` resolves, to GOOD_SHA."""
+
+    def resolve(owner: str, repo: str, ref: str) -> str | None:
+        if (owner, repo, ref) == ("actions", "checkout", TAG):
+            return GOOD_SHA
+        return None
+
+    return resolve
+
+
+@pytest.fixture
+def workflow_factory(tmp_path: Path) -> Callable[[str], Path]:
+    """Factory writing a workflow file with the given body, returning its path."""
+    created: list[Path] = []
+
+    def make(body: str) -> Path:
+        path = tmp_path / f"workflow_{len(created)}.yml"
+        path.write_text(body)
+        created.append(path)
+        return path
+
+    return make
+
+
+def test_doctored_sha_fails_verify(
+    hook: ModuleType, resolver: Callable[[str, str, str], str | None]
+) -> None:
+    """A line whose pinned SHA disagrees with its tag comment is rejected."""
+    line = "      - uses: actions/checkout@0000000000000000000000000000000000000000 # v6.0.3"
+    error = hook.verify_action_line(line, resolve=resolver)
+    assert error is not None
+    assert "mismatch" in error
+    assert GOOD_SHA in error  # expected SHA surfaced
+    assert "0000000000000000000000000000000000000000" in error  # actual SHA surfaced
+
+
+def test_correctly_pinned_line_passes(
+    hook: ModuleType, resolver: Callable[[str, str, str], str | None]
+) -> None:
+    """A line whose pinned SHA matches the resolved tag comment passes."""
+    line = f"      - uses: actions/checkout@{GOOD_SHA} # {TAG}"
+    assert hook.verify_action_line(line, resolve=resolver) is None
+
+
+def test_sha_pin_without_comment_fails(
+    hook: ModuleType, resolver: Callable[[str, str, str], str | None]
+) -> None:
+    """A SHA pin with no ``# <tag>`` comment cannot be verified -> error."""
+    line = f"      - uses: actions/checkout@{GOOD_SHA}"
+    error = hook.verify_action_line(line, resolve=resolver)
+    assert error is not None
+    assert "no '# <tag>' comment" in error
+
+
+def test_unresolvable_tag_comment_fails(
+    hook: ModuleType, resolver: Callable[[str, str, str], str | None]
+) -> None:
+    """A tag comment the resolver can't map to a SHA is an error, not a pass."""
+    line = f"      - uses: actions/checkout@{GOOD_SHA} # v9.9.9"
+    error = hook.verify_action_line(line, resolve=resolver)
+    assert error is not None
+    assert "could not resolve tag" in error
+
+
+def test_unpinned_tag_ref_is_out_of_scope(
+    hook: ModuleType, resolver: Callable[[str, str, str], str | None]
+) -> None:
+    """A not-yet-pinned tag ref is the autofix hook's job; verify ignores it."""
+    line = "      - uses: actions/checkout@v6.0.3"
+    assert hook.verify_action_line(line, resolve=resolver) is None
+
+
+def test_non_uses_line_ignored(
+    hook: ModuleType, resolver: Callable[[str, str, str], str | None]
+) -> None:
+    """Lines that aren't ``uses:`` declarations return None."""
+    assert hook.verify_action_line("      - run: echo hello", resolve=resolver) is None
+
+
+def test_repointed_tag_is_caught(
+    hook: ModuleType, resolver: Callable[[str, str, str], str | None]
+) -> None:
+    """A tag that upstream now resolves to a new SHA is caught — verification
+    compares against the comment's tag, not the SHA already in the file."""
+
+    def repointed(owner: str, repo: str, ref: str) -> str | None:
+        # v6.0.3 now points at a different SHA than what the file pins.
+        return "ffffffffffffffffffffffffffffffffffffffff"
+
+    line = f"      - uses: actions/checkout@{GOOD_SHA} # {TAG}"
+    error = hook.verify_action_line(line, resolve=repointed)
+    assert error is not None
+    assert "mismatch" in error
+
+
+@pytest.fixture
+def gh_stub(hook: ModuleType, monkeypatch: pytest.MonkeyPatch) -> Callable[[str], list[list[str]]]:
+    """Factory: stub the ``gh`` subprocess so the real (cached)
+    ``get_commit_sha`` resolves every ref to the given SHA.
+
+    Clears the per-process resolution cache on each install (so one test's
+    stub never leaks into the next) and returns the list of recorded ``gh``
+    invocations, letting a test assert how many times ``gh`` was called.
+    """
+
+    def install(sha: str) -> list[list[str]]:
+        calls: list[list[str]] = []
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            calls.append(argv)
+
+            class _Result:
+                returncode = 0
+                stdout = json.dumps({"sha": sha})
+
+            return _Result()
+
+        hook.get_commit_sha.cache_clear()
+        monkeypatch.setattr(hook.subprocess, "run", fake_run)
+        return calls
+
+    return install
+
+
+def test_process_file_verifies_existing_pins(
+    hook: ModuleType,
+    gh_stub: Callable[[str], list[list[str]]],
+    workflow_factory: Callable[[str], Path],
+) -> None:
+    """Default ``process_file`` verifies an already-pinned ref without
+    rewriting it: a matching pin is clean, a mismatch is reported with a
+    ``file:line`` prefix and leaves the file untouched."""
+    gh_stub(GOOD_SHA)
+
+    ok = workflow_factory(f"      - uses: actions/checkout@{GOOD_SHA} # {TAG}\n")
+    assert hook.process_file(ok) == (False, [])
+
+    bad = workflow_factory(
+        "name: demo\n"
+        "jobs:\n"
+        "  build:\n"
+        "    steps:\n"
+        f"      - uses: actions/checkout@{'0' * 40} # {TAG}\n"
+    )
+    modified, errors = hook.process_file(bad)
+    assert modified is False  # already pinned -> verified, never rewritten
+    assert len(errors) == 1
+    assert errors[0].startswith(f"{bad}:5:")
+    assert "mismatch" in errors[0]
+
+
+def test_get_commit_sha_is_memoised(
+    hook: ModuleType, gh_stub: Callable[[str], list[list[str]]]
+) -> None:
+    """The same owner/repo@ref resolves once per run — a repeated lookup reuses
+    the in-process cache instead of re-querying ``gh``."""
+    calls = gh_stub(GOOD_SHA)
+    assert hook.get_commit_sha("actions", "checkout", TAG) == GOOD_SHA
+    assert hook.get_commit_sha("actions", "checkout", TAG) == GOOD_SHA
+    assert len(calls) == 1
+
+
+def test_missing_gh_is_a_hard_error(hook: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without ``gh`` and without ``--exit-zero``, the hook hard-errors (exit
+    2) rather than silently passing as if everything verified."""
+    monkeypatch.setattr(hook, "check_gh_cli", lambda: False)
+    monkeypatch.setattr(hook.sys, "argv", ["pin-github-actions", "x.yml"])
+    assert hook.main() == 2
+
+
+def test_exit_zero_softens_missing_gh(hook: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--exit-zero`` downgrades a missing ``gh`` to a warning + exit 0."""
+    monkeypatch.setattr(hook, "check_gh_cli", lambda: False)
+    monkeypatch.setattr(hook.sys, "argv", ["pin-github-actions", "--exit-zero", "x.yml"])
+    assert hook.main() == 0


### PR DESCRIPTION
## Problem
`.pre-commit-hooks/pin-github-actions.py` was an autofixer only — it skipped any
line already pinned to a 40-hex SHA and **never checked** that an existing
`uses: owner/repo@<sha> # vX.Y.Z` actually had a `<sha>` matching tag `vX.Y.Z`.
The trailing `# vX.Y.Z` was unverified free text, so a hand-edited or
maliciously-altered SHA with a legit-looking comment passed unchanged. SEC-10.

## Fix
One hook, one pass — **pin and verify by default**:
- For each `uses:` line the hook now *pins* unpinned refs to a SHA **and**
  *verifies* already-pinned ones: it resolves the **comment's tag** to a SHA
  (via `gh api`) and asserts it equals the pinned SHA — catching both
  hand-edited mismatches and **upstream-repointed tags** (it compares against
  the comment, not just re-resolving the SHA). Fails on mismatch or any SHA pin
  lacking a resolvable `# tag`.
- Verification is factored into a pure `verify_action_line(line, resolve=…)` so
  it's testable with an injected fake resolver — **no network in tests**.
- Resolutions are **memoised per run** (`lru_cache`): the same `owner/repo@ref`
  is resolved once, not re-queried per occurrence.
- `--latest` re-pins every action to its newest release (unchanged).
- A missing `gh` CLI is a **hard error (exit 2)** rather than a silent skip, so
  "can't verify" can't masquerade as "verified". `--exit-zero` opts into a
  non-blocking, gh-optional advisory run (exit 0 on findings *and* on missing
  `gh`).
- The hook is `files:`-scoped to `.github/` action files (workflows, composite
  actions, root `action.yml`) and runs as an executable `language: system`
  script — matching the repo's existing `regen-doc-snippets.py` pattern.

No separate CI workflow: the hook runs in CI via the existing
`prek run --all-files` step, which is now given `GH_TOKEN`. The standalone
`verify-action-pins.yml` workflow is removed.

## Tests
`tests/hooks/test_pin_github_actions.py` — 11 hermetic tests (collected by
`testpaths = ["tests/"]`, so they run in the CI matrix):
- Per-line verify via injected resolver: doctored SHA → fail (expected+actual
  surfaced); correct pin → pass; SHA pin with no `# tag` → fail; unresolvable
  tag → fail; upstream-repointed tag → caught; unpinned ref / non-`uses:`
  ignored.
- `process_file` pin+verify in one pass (mismatch reported with `file:line`
  prefix, already-pinned line never rewritten), `lru_cache` memoisation
  (one `gh` call for repeated lookups), missing-`gh` hard error → exit 2,
  `--exit-zero` → exit 0. The `gh`-touching tests stub `subprocess.run`; none
  hit the network.

Note: this PR's `prek` CI job resolves every pin in the repo for real — if it
flags a genuine pre-existing mismatch, that's the gate working.