### PR TITLE
ci: attest wheels on release + main pushes, not just PRs [SEC-11]

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -117,8 +117,15 @@ jobs:
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        # Only run attestations on the main repository, not on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        # Attest everywhere except fork PRs (which lack `id-token`). The
+        # bare `head.repo.full_name == github.repository` check was FALSE
+        # on release (`workflow_dispatch`) and push-to-main — there's no
+        # pull_request context, so `'' == 's0undt3ch/ToolR'` silently
+        # skipped the per-wheel attestation (Test PyPI wheels from main
+        # got none). `|| event_name != 'pull_request'` attests on release
+        # + main pushes while still skipping only fork PRs. Matches
+        # `_prepare-release.yml`. SEC-11.
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
         with:
           subject-path: wheelhouse/*.whl
 


### PR DESCRIPTION
The wheel `Attest build provenance` step in `_build.yml` was gated on
`github.event.pull_request.head.repo.full_name == github.repository`. On the
release workflow (`workflow_dispatch`) and push-to-main there's **no
pull_request context**, so the expression is `'' == 's0undt3ch/ToolR'` = false
and the per-wheel attestation was **silently skipped** — Test PyPI wheels from
main pushes got none, and the gating is fragile (a future refactor relying on
the redundant final `dist/*` attest would ship unattested artifacts unnoticed).
SEC-11.

Fix: `|| github.event_name != 'pull_request'` — attest on release + main pushes,
still skip only fork PRs (which lack `id-token`). Matches the condition
`_prepare-release.yml` already uses; `_build-binary-archive.yml` attests
unconditionally.

## Acceptance criteria
- [x] Main-push / release builds now run the attestation step (the `||
      event_name != 'pull_request'` arm is true).
- [x] Fork PRs still skip it (both arms false).
- [x] `release.yml`'s final `dist/*` attestation is unchanged (no regression).