### PR TITLE
fix(testing): restore sys.modules when CommandsTester exits [SEC-07]

### DIFF
--- a/crates/toolr-py/python/toolr/testing.py
+++ b/crates/toolr-py/python/toolr/testing.py
@@ -139,3 +139,13 @@ class CommandsTester:
         self.command_group_patcher.stop()
         self.command_group_collector.clear()
         sys.path[:] = self.sys_path
+        # Reverse the module table back to the filtered snapshot `__enter__`
+        # installed (real modules minus the volatile `tools` /
+        # `toolr_example_plugin` packages). This undoes both the bare
+        # `clear()` on enter and any modules imported inside the block, so a
+        # long-lived process keeps its real imports instead of being left
+        # wiped. We deliberately do NOT reinstate `tools` /
+        # `toolr_example_plugin`: they are the reload-per-test targets, and
+        # carrying a stale copy forward would pollute later tests.
+        sys.modules.clear()
+        sys.modules.update(self.sys_modules)

--- a/tests/registry/test_integration.py
+++ b/tests/registry/test_integration.py
@@ -38,6 +38,36 @@ def test_discover_walks_a_real_tools_package(tmp_path: Path) -> None:
     assert walked, "discover() should have imported tools.ci via the pkgutil walk"
 
 
+def test_commands_tester_restores_sys_modules(tmp_path: Path) -> None:
+    """`CommandsTester.__exit__` undoes its mutation of `sys.modules`
+    (symmetric with the cwd / `sys.path` restore): a module imported inside
+    the `with` block does not leak out, and the bare `clear()` on enter is
+    reversed so a long-lived (e.g. pytest) process keeps its real imports
+    rather than being left wiped. The volatile `tools` / example packages
+    are intentionally NOT carried forward — they are reloaded per test."""
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    (tools / "__init__.py").write_text("")
+    (tools / "ci.py").write_text(
+        'from toolr import command_group\ngroup = command_group("ci", "CI utils", "CI utilities")\n'
+    )
+    before = dict(sys.modules)
+    with CommandsTester(search_path=tmp_path) as tester:
+        tester.discover()
+        assert "tools.ci" in sys.modules  # imported inside the block
+    # The in-block import is reversed (no leak)...
+    assert "tools.ci" not in sys.modules
+    # ...and every real (non-volatile) module present before the block is
+    # restored — the enter-time clear() does not strand the interpreter.
+    nonvolatile = {
+        name
+        for name in before
+        if name not in ("tools", "toolr_example_plugin")
+        and not name.startswith(("tools.", "toolr_example_plugin."))
+    }
+    assert nonvolatile <= sys.modules.keys()
+
+
 def test_complete_workflow_example(commands_tester):
     """Test a complete workflow demonstrating the registry usage."""
     # Simulate building a Docker tooling hierarchy


### PR DESCRIPTION
## Context
`toolr.testing.CommandsTester` is a **supported public API** — users import it
to test their own commands — so it stays shipped in the wheel (SEC-07's
"exclude it from the wheel" option is rejected). The real issue is that it's
an *unbalanced* context manager.

## Problem
`__enter__` mutates three globals — `os.chdir`, `sys.path[:]`, and a bare
`sys.modules.clear()` (+ install of a filtered snapshot). `__exit__` restored
**cwd** and **sys.path** but **not `sys.modules`**, leaving the interpreter's
module table cleared/mutated after the `with`. In a long-lived process (or a
user's pytest session) that strands subsequent imports.

## Fix
`__exit__` now reverses `sys.modules` back to the same filtered snapshot
`__enter__` installed:
- real modules restored (undoing the bare `clear()`),
- modules imported inside the block dropped (no leak),
- the volatile `tools` / `toolr_example_plugin` reload-targets deliberately
  **not** carried forward — resurrecting a stale copy would pollute later
  tests (this was an actual cross-test regression I hit with a naive
  full-restore; the filtered restore matches the module's existing
  reload-per-test design).

Adds `test_commands_tester_restores_sys_modules`: asserts an in-block import
doesn't leak and that non-volatile modules survive the block.

Local: full `uv run pytest` → 367 passed, 0 failed; ruff + mypy clean.