### PR TITLE
fix(context): echo ctx.run cmdline literally, not as rich markup [SEC-06]

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -74,6 +74,14 @@ runs. Refresh the lockfile with `mise upgrade && mise lock` (bare
   this only shrinks the published wheel set; the supported interpreter range is
   unchanged and still fully tested.
 
+### Fixed
+
+- The `Running '…'` line that `ctx.run` logs now prints the command line
+  literally instead of interpreting it as rich markup. A command argument that
+  looks like a rich tag (e.g. `jq '[.foo]'`, `[link=…]`) is no longer consumed
+  or rendered, so the echo always reflects exactly what ran — matching how the
+  command would appear in your shell.
+
 ### Removed
 
 - The dynamic introspection layer (`toolr._introspect`) is gone. Commands

--- a/crates/toolr-py/python/toolr/_context.py
+++ b/crates/toolr-py/python/toolr/_context.py
@@ -217,7 +217,11 @@ class Context(Struct, frozen=True):
         Returns:
             CommandResult instance.
         """
-        self.info(f"""Running '{" ".join(cmdline)}'""")
+        # markup=False: the cmdline is data, not rich markup. Without it, an
+        # argument like `[.foo]` or `[link=…]` would be parsed as a rich tag,
+        # so the echoed command would lie about what actually ran. Printing it
+        # literally keeps this line faithful to the shell.
+        self.info(f"""Running '{" ".join(cmdline)}'""", markup=False)
         # Per-call values win over the Context defaults set by
         # `toolr --timeout-secs` / `--no-output-timeout-secs`. The
         # defaults only fill in when the caller passes nothing.

--- a/tests/context/test_run.py
+++ b/tests/context/test_run.py
@@ -21,6 +21,23 @@ def test_run_command_basic(verbose_ctx, capfd):
     assert "echo hello" in captured.err
 
 
+def test_run_command_echo_is_literal_not_markup(verbose_ctx, capfd):
+    """The 'Running ...' echo prints the cmdline literally, never as rich markup.
+
+    A command argument that looks like a rich tag (``[red]``, ``[link=…]``)
+    must appear verbatim — otherwise rich would consume the tag and the echo
+    would lie about what actually ran. Guards the ``markup=False`` on the echo.
+    """
+    args = ("echo", "[red]hi[/red]")
+    command_result = CommandResult(args=args, stdout="", stderr="", returncode=0)
+    with mock.patch("toolr.utils.command.run", return_value=command_result):
+        verbose_ctx.run(*args)
+
+    captured = capfd.readouterr()
+    # The literal tag survives (markup not interpreted/stripped).
+    assert "[red]hi[/red]" in captured.err
+
+
 def test_run_command_with_options(verbose_ctx, capfd):
     """Test run method with various options."""
     args = ("test", "command")


### PR DESCRIPTION
## Problem
`ctx.info` wraps rich's `Console.log`, which defaults to `markup=True`. So the
`Running '…'` line that `ctx.run` logs **re-interprets the command line as rich
markup**: a command argument that looks like a rich tag is consumed or rendered
rather than printed. The echo then lies about what actually ran:

```python
ctx.run(["jq", "[.foo]", "f.json"])   # [.foo] parsed as a (broken) rich tag
ctx.run(["grep", "[link=x]", "f"])    # [link=…] rendered as a hyperlink
```

A real shell prints these literally — toolr was *inventing* interpretation a
terminal would not apply. SEC-06.

## Fix
`markup=False` on that one echo, so the cmdline prints **literally**, exactly as
it would appear in the shell. One line. This *advances* toolr's "behave as close
to a TTY as possible" goal rather than fighting it.

This is the single carved-out fidelity fix from SEC-06. The rest of SEC-06 is
**won't-fix by design**:
- `ctx.run` subprocess output streaming stays raw byte-for-byte passthrough —
  colors, progress bars, and `\r` redraws must survive. The threat is identical
  to running the command in your own shell; toolr adds no new surface.
- `ctx.info` is not otherwise filtered — authors legitimately emit color/markup
  through it.

## Tests
`tests/context/test_run.py::test_run_command_echo_is_literal_not_markup` — runs
a cmdline containing `[red]hi[/red]` and asserts the literal tag survives in the
echo. Verified meaningful: with the old `markup=True` rich strips the tag (only
`hi` survives); with `markup=False` the literal text is preserved.