### PR TITLE
fix(ci): cache ~/.rustup so rustup components survive mise cache hits

### DIFF
--- a/.github/actions/setup-virtualenv/action.yml
+++ b/.github/actions/setup-virtualenv/action.yml
@@ -55,6 +55,31 @@ runs:
       shell: bash
       run: echo "MISE_PYTHON_VERSION=${{ inputs.python-version }}" >> "$GITHUB_ENV"
 
+    # `jdx/mise-action` caches only mise's own data dir
+    # (`~/.local/share/mise`), which records that `rust 1.96.0` is
+    # installed — but the toolchain itself, including the `clippy` and
+    # `rustfmt` components, lives in `~/.rustup` (the `core:rust` backend
+    # installs via rustup and symlinks it; see `mise.toml`). `~/.rustup`
+    # is outside mise's cached scope, so on a mise cache *hit* mise reports
+    # "all tools are installed" and skips `rustup component add` — leaving
+    # `~/.rustup` as whatever the bare runner image shipped (a `minimal`
+    # profile with no clippy). The pre-commit `clippy` hook then fails with
+    # `'cargo-clippy' is not installed for the toolchain '1.96.0-...'`, and
+    # maturin's `cargo metadata` fails the same way for the `cargo`
+    # component. Cache `~/.rustup` so the cached "installed" state is
+    # truthful and the components persist across hits.
+    #
+    # Exact-match key only (no `restore-keys`): it is keyed on the same
+    # `mise.toml`/`mise.lock` hash that drives the mise cache below, so the
+    # two co-invalidate on any toolchain change and never restore mismatched
+    # states. Shared across job types (no `cache-prefix`) — the toolchain is
+    # identical regardless of which job installs it.
+    - name: Cache rust toolchain (~/.rustup)
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.rustup
+        key: rustup|${{ inputs.cache-seed }}|${{ inputs.mise-version }}|${{ runner.os }}|${{ runner.arch }}|${{ hashFiles('mise.toml', 'mise.lock') }}
+
     - name: Set up mise
       uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
   FORCE_COLOR: "1"
   # Bump to invalidate every cache (mise install dirs, .venv, prek hooks,
   # mypy/ruff caches, ...) used by this workflow.
-  CACHE_SEED: "3"
+  CACHE_SEED: "4"
   # `MISE_VERSION` lives in `.github/env` — loaded per-job by a
   # "Load shared env vars" step (immediately after `actions/checkout`)
   # so the value is available via `$MISE_VERSION` / `env.MISE_VERSION`


### PR DESCRIPTION
## Summary

CI's `clippy` pre-commit hook (and, intermittently, the distribution
tests' `maturin` build) fail with a missing rustup component:

```
clippy...Failed
  error: 'cargo-clippy' is not installed for the toolchain '1.96.0-x86_64-unknown-linux-gnu'.
```

This happens non-deterministically — it flips between platforms and runs —
because it depends on CI cache state, not the diff under test. This PR
closes the gap by bringing the rust toolchain into the cached scope.

## Root cause

`jdx/mise-action` caches **only mise's own data dir**
(`~/.local/share/mise`), and that dir merely *records* that `rust 1.96.0`
is installed. But our rust pin uses the `core:rust` backend, which installs
through **rustup** — so the toolchain and its `clippy` / `rustfmt`
components actually live in **`~/.rustup`**, which is outside mise's cached
scope.

On a mise cache **hit**, `mise install` short-circuits:

```
Detected a mise lock file, running `mise install --locked`
mise all tools are installed      ← skips `rustup component add`
```

…but `~/.rustup` on that runner is whatever the bare image shipped — a
`minimal` profile with no clippy. The cached "installed" state is
therefore *lying*: mise thinks the components are present, the hook proves
they're not.

The same mechanism produced the earlier `Test Distribution` failures,
where `maturin`'s `cargo metadata` hit `component download failed for
cargo-…` for the `cargo` component of the same toolchain.

This is **not** a key-staleness bug — the mise key *does* change when
`mise.toml`/`mise.lock` change, so the first run after a config bump
reinstalls correctly. The defect is **cache scope**: subsequent valid
cache hits never re-materialise `~/.rustup`.

## Fix

Add one `actions/cache` step in the shared `setup-virtualenv` composite,
**before** the mise step, caching `~/.rustup`:

```yaml
- name: Cache rust toolchain (~/.rustup)
  uses: actions/cache@… # v5.0.5
  with:
    path: ~/.rustup
    key: rustup|${{ inputs.cache-seed }}|${{ inputs.mise-version }}|${{ runner.os }}|${{ runner.arch }}|${{ hashFiles('mise.toml', 'mise.lock') }}
```

Now the cached "rust installed" state is truthful: the components persist
across hits, so mise's short-circuit is safe.

## Why this key

- **Exact match, no `restore-keys`.** Keyed on the same
  `mise.toml`/`mise.lock` hash that drives the mise-action cache, so the
  two **co-invalidate** on any toolchain change and can never restore
  mismatched states (e.g. an old `~/.rustup` against a new mise record).
- **Shared across job types** (no `cache-prefix`). The toolchain is
  identical regardless of which job installs it, so one cache serves all.

`CACHE_SEED` is bumped `3 → 4` as part of this change, and that is
**required for correctness, not hygiene**: the new `~/.rustup` cache only
captures a good snapshot when mise actually *installs* (a mise cache
miss). Existing mise caches — created in the broken regime — would
otherwise **hit** on the first post-merge run, mise would skip
`rustup component add`, `~/.rustup` would stay bare, and we'd then **save
that componentless `~/.rustup`**, poisoning the new cache permanently.
Both keys include the seed, so bumping it forces a coherent cold start:
mise reinstalls, `~/.rustup` is populated with clippy/rustfmt, and both
caches save in sync.

## Verification

- YAML parses; `prek` hooks pass on the changed file.
- The `actions/cache` SHA pin matches the existing `.venv` cache step in
  the same file.
- Once merged, the flaky `clippy` failures on #340 and the
  distribution-test flakes on #346 should clear after they rebase.
