### PR TITLE
test(docstrings): match pyo3 0.29 argument-error message

### DIFF
--- a/tests/utils/docstrings/test_parser_behavior.py
+++ b/tests/utils/docstrings/test_parser_behavior.py
@@ -50,8 +50,11 @@ def test_parser_performance():
 
 def test_parser_error_handling():
     """Test parser error handling with malformed docstrings."""
-    # Test with None input
-    with pytest.raises(TypeError, match="argument 'docstring': 'None' is not an instance of 'str'"):
+    # Test with None input. pyo3 0.29 changed argument-extraction errors to
+    # attach the parameter name as a note ("...\nwhile processing 'docstring'")
+    # rather than prefixing the message ("argument 'docstring': ..."), so match
+    # on the stable type-mismatch text instead of the version-specific framing.
+    with pytest.raises(TypeError, match="'None' is not an instance of 'str'"):
         Docstring.parse(None)
 
     # Test with very long input


### PR DESCRIPTION
pyo3 0.29 changed #[pyfunction] argument-extraction errors to attach the
parameter name as a note ("'None' is not an instance of 'str'\nwhile
processing 'docstring'") instead of prefixing the message ("argument
'docstring': ..."). test_parser_error_handling asserted the old 0.28
framing, so it failed against a fresh toolr-py built with 0.29 (earlier
runs passed only because a cached extension still linked 0.28). Match on
the stable type-mismatch text rather than the version-specific framing.