### PR TITLE
ci: run shellcheck/actionlint/gitleaks from mise, not docker/golang

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,15 +81,29 @@ repos:
             skills/.*/references/.*\.md
           )$
 
-  - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.12
+  - repo: local
     hooks:
+      # Run the mise-pinned `actionlint` from PATH via a local wrapper instead
+      # of rhysd/actionlint's default hook, which compiles the linter from
+      # source through `language: golang` on every cold cache. The wrapper
+      # errors if the binary is missing (run `mise install`) unless
+      # `--exit-zero` is passed. mise.toml is the single source of the version.
       - id: actionlint
+        name: Lint GitHub Actions workflow files
+        language: system
+        entry: .pre-commit-hooks/actionlint.sh
+        types: ["yaml"]
+        files: ^\.github/workflows/
 
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
-    hooks:
+      # Run the mise-pinned `shellcheck` from PATH via a local wrapper instead
+      # of koalaman/shellcheck-precommit, which runs a Docker image
+      # (`language: docker_image`) — unavailable on hardened CI runners and
+      # redundant when mise already ships the pinned binary.
       - id: shellcheck
+        name: ShellCheck
+        language: system
+        entry: .pre-commit-hooks/shellcheck.sh
+        types: [shell]
         # shellcheck only understands sh/bash. The zsh and fish
         # completion scripts under src/complete/scripts/ use shell-specific
         # syntax that shellcheck cannot parse.
@@ -156,10 +170,17 @@ repos:
       - id: rumdl
         # Config picked up from .rumdl.toml.
 
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.1
+  - repo: local
     hooks:
+      # Run the mise-pinned `gitleaks` from PATH via a local wrapper instead of
+      # gitleaks/gitleaks's default hook, which compiles from source through
+      # `language: golang` on every cold cache. The wrapper errors if the
+      # binary is missing (run `mise install`) unless `--exit-zero` is passed.
       - id: gitleaks
+        name: Detect hardcoded secrets
+        language: system
+        entry: .pre-commit-hooks/gitleaks.sh
+        pass_filenames: false
 
   - repo: local
     hooks:

--- a/.pre-commit-hooks/actionlint.sh
+++ b/.pre-commit-hooks/actionlint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Local actionlint pre-commit hook.
+#
+# Runs the `actionlint` binary from PATH (mise pins it in mise.toml) instead
+# of the upstream `rhysd/actionlint` hook, whose default `actionlint` id uses
+# `language: golang` and compiles the linter from source via the Go toolchain
+# on every cold cache. mise already ships the exact pinned binary.
+#
+# Behaviour: if `actionlint` is on PATH, run it on the passed workflow files
+# and exit with its status. If it is missing, error out — unless `--exit-zero`
+# is passed, in which case warn and exit 0. Mirrors the `--exit-zero`
+# convention of `pin-github-actions.py`.
+set -euo pipefail
+
+exit_zero=0
+files=()
+for arg in "$@"; do
+	case "$arg" in
+	--exit-zero) exit_zero=1 ;;
+	*) files+=("$arg") ;;
+	esac
+done
+
+if ! command -v actionlint >/dev/null 2>&1; then
+	msg="actionlint not found on PATH. It is pinned in mise.toml — run 'mise install'."
+	if [ "$exit_zero" -eq 1 ]; then
+		echo "Warning: ${msg} Skipping actionlint (--exit-zero)." >&2
+		exit 0
+	fi
+	echo "Error: ${msg}" >&2
+	exit 1
+fi
+
+# Nothing to check (prek filtered everything out) — succeed quietly.
+if [ "${#files[@]}" -eq 0 ]; then
+	exit 0
+fi
+
+exec actionlint "${files[@]}"

--- a/.pre-commit-hooks/gitleaks.sh
+++ b/.pre-commit-hooks/gitleaks.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Local gitleaks pre-commit hook.
+#
+# Runs the `gitleaks` binary from PATH (mise pins it in mise.toml) instead of
+# the upstream `gitleaks/gitleaks` hook, whose default `gitleaks` id uses
+# `language: golang` and compiles from source via the Go toolchain on every
+# cold cache. mise already ships the exact pinned binary.
+#
+# Behaviour: if `gitleaks` is on PATH, scan the staged changes (the hook sets
+# `pass_filenames: false`, so it takes no file arguments) and exit with its
+# status. If it is missing, error out — unless `--exit-zero` is passed, in
+# which case warn and exit 0. Mirrors the `--exit-zero` convention of
+# `pin-github-actions.py`.
+set -euo pipefail
+
+exit_zero=0
+for arg in "$@"; do
+	case "$arg" in
+	--exit-zero) exit_zero=1 ;;
+	esac
+done
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+	msg="gitleaks not found on PATH. It is pinned in mise.toml — run 'mise install'."
+	if [ "$exit_zero" -eq 1 ]; then
+		echo "Warning: ${msg} Skipping gitleaks (--exit-zero)." >&2
+		exit 0
+	fi
+	echo "Error: ${msg}" >&2
+	exit 1
+fi
+
+exec gitleaks git --pre-commit --redact --staged --verbose

--- a/.pre-commit-hooks/shellcheck.sh
+++ b/.pre-commit-hooks/shellcheck.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Local shellcheck pre-commit hook.
+#
+# Runs the `shellcheck` binary from PATH (mise pins it in mise.toml) instead
+# of pulling the upstream Docker image (koalaman/shellcheck-precommit uses
+# `language: docker_image`, which needs a Docker daemon and a registry pull —
+# unavailable on hardened CI runners and wasteful when mise already provides
+# the exact pinned binary).
+#
+# Behaviour: if `shellcheck` is on PATH, run it on the passed files and exit
+# with its status (acts exactly like the upstream hook). If it is missing,
+# error out — unless `--exit-zero` is passed, in which case warn and exit 0
+# (a non-blocking, tool-optional advisory run). Mirrors the `--exit-zero`
+# convention of `pin-github-actions.py`.
+set -euo pipefail
+
+exit_zero=0
+files=()
+for arg in "$@"; do
+	case "$arg" in
+	--exit-zero) exit_zero=1 ;;
+	*) files+=("$arg") ;;
+	esac
+done
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+	msg="shellcheck not found on PATH. It is pinned in mise.toml — run 'mise install'."
+	if [ "$exit_zero" -eq 1 ]; then
+		echo "Warning: ${msg} Skipping shellcheck (--exit-zero)." >&2
+		exit 0
+	fi
+	echo "Error: ${msg}" >&2
+	exit 1
+fi
+
+# Nothing to check (prek filtered everything out) — succeed quietly.
+if [ "${#files[@]}" -eq 0 ]; then
+	exit 0
+fi
+
+exec shellcheck "${files[@]}"

--- a/mise.lock
+++ b/mise.lock
@@ -43,6 +43,38 @@ provenance = "github-attestations"
 version = "0.13.11"
 backend = "cargo:cargo-edit"
 
+[[tools.gitleaks]]
+version = "8.30.1"
+backend = "aqua:gitleaks/gitleaks"
+
+[tools.gitleaks."platforms.linux-arm64"]
+checksum = "sha256:e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_arm64.tar.gz"
+
+[tools.gitleaks."platforms.linux-arm64-musl"]
+checksum = "sha256:e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_arm64.tar.gz"
+
+[tools.gitleaks."platforms.linux-x64"]
+checksum = "sha256:551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+
+[tools.gitleaks."platforms.linux-x64-musl"]
+checksum = "sha256:551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+
+[tools.gitleaks."platforms.macos-arm64"]
+checksum = "sha256:b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_darwin_arm64.tar.gz"
+
+[tools.gitleaks."platforms.macos-x64"]
+checksum = "sha256:dfe101a4db2255fc85120ac7f3d25e4342c3c20cf749f2c20a18081af1952709"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_darwin_x64.tar.gz"
+
+[tools.gitleaks."platforms.windows-x64"]
+checksum = "sha256:d29144deff3a68aa93ced33dddf84b7fdc26070add4aa0f4513094c8332afc4e"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_windows_x64.zip"
+
 [[tools.prek]]
 version = "0.4.4"
 backend = "aqua:j178/prek"

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,11 @@
 python = ["3.14.5", "3.13.14", "3.12.13", "3.11.15"]
 actionlint = "latest"
 shellcheck = "latest"
+# gitleaks, actionlint and shellcheck back the local pre-commit hooks under
+# `.pre-commit-hooks/*.sh` (which run the PATH binary instead of pulling a
+# Docker image / compiling from source). Pinned here so CI's
+# `mise install --locked` provides them.
+gitleaks = "latest"
 # Without an explicit profile, mise inherits whatever profile the
 # machine's rustup is configured with — CI runners resolve to
 # `minimal`, which ships no clippy. Pin the profile and add the

--- a/renovate.json5
+++ b/renovate.json5
@@ -72,14 +72,14 @@
       matchManagers: ["github-actions"],
     },
     {
-      // mise CLI tools (actionlint, shellcheck, prek) — group them so
-      // we don't get a PR per tool. Python and Rust toolchains stay
+      // mise CLI tools (actionlint, shellcheck, prek, gitleaks) — group
+      // them so we don't get a PR per tool. Python and Rust toolchains stay
       // in their own ecosystem-tagged PRs so language bumps remain
       // reviewable on their own.
       description: "Group mise CLI tooling updates",
       groupName: "mise tools",
       matchManagers: ["mise"],
-      matchDepNames: ["actionlint", "shellcheck", "prek"],
+      matchDepNames: ["actionlint", "shellcheck", "prek", "gitleaks"],
     },
   ],
 }


### PR DESCRIPTION
These three pre-commit hooks each pulled a heavyweight runtime that mise
already makes redundant:
- shellcheck (koalaman/shellcheck-precommit) ran a Docker image
  (language: docker_image) — unavailable on hardened CI runners, which is
  what was failing the Pre-commit job.
- actionlint (rhysd/actionlint) and gitleaks (gitleaks/gitleaks) compiled
  from source via language: golang on every cold cache.

Replace each with a local language: system hook backed by a small wrapper
in .pre-commit-hooks/. Each wrapper runs the mise-pinned binary from PATH
and behaves exactly like the upstream hook; if the binary is missing it
errors with a 'run mise install' hint, unless --exit-zero is passed (a
non-blocking advisory run, mirroring pin-github-actions.py).

gitleaks is added to mise.toml (pinned 8.30.1 in mise.lock, matching the
previous hook rev) and to renovate's mise-tools group. actionlint and
shellcheck were already pinned by mise; version management now lives solely
in mise.lock instead of duplicated pre-commit revs.