### PR TITLE
fix(runner): harden dispatch spec-file handling [SEC-05][SEC-14]

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -71,6 +71,14 @@ so no separate verification workflow is needed.
   caches the release *archive* (not the extracted binary), so a poisoned cache
   entry is rejected by attestation before it can execute. `skip-attestation:
   true` remains the only bypass.
+- The runner hardens how it handles the dispatch spec file (defense-in-depth).
+  Before reading `$TOOLR_SPEC_FILE` it now refuses a spec that is a symlink, not
+  a regular file, owned by another user, or group/world-writable — so a
+  forgeable spec can't become a forgeable import target. It also unlinks the
+  spec immediately after reading it, rather than waiting for the binary to drop
+  its handle, so the 0600 spec JSON (which can carry CLI argument values) does
+  not linger in `TMPDIR` if the process is hard-killed. No change to normal
+  dispatch.
 
 ### Changed
 

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -213,18 +213,25 @@ def _validate_spec_file(path: str) -> None:
     if not stat.S_ISREG(info.st_mode):
         msg = f"toolr spec file is not a regular file: {path}"
         raise SpecError(msg)
-    # POSIX-only: the binary creates the spec 0600 and owned by us. Refuse
-    # if another user owns it or it is group/world-writable (the classic
-    # tmp-swap scenarios). Windows lacks these semantics; the
-    # not-a-symlink + regular-file checks above are what we can portably
-    # assert there.
-    if hasattr(os, "getuid"):
-        if info.st_uid != os.getuid():
-            msg = f"toolr spec file is not owned by the current user: {path}"
-            raise SpecError(msg)
-        if info.st_mode & 0o022:
-            msg = f"toolr spec file is group/world-writable; refusing to read it: {path}"
-            raise SpecError(msg)
+    # POSIX-only: the binary creates the spec 0600 and owned by us. Windows
+    # lacks these ownership/permission semantics, so the not-a-symlink +
+    # regular-file checks above are what we can portably assert there.
+    if hasattr(os, "getuid"):  # pragma: no cover - POSIX guard; the skip is Windows-only
+        _check_spec_file_owner_and_mode(info, path)
+
+
+def _check_spec_file_owner_and_mode(info: os.stat_result, path: str) -> None:
+    """Refuse a spec file owned by another user or group/world-writable.
+
+    The POSIX half of :func:`_validate_spec_file` (the classic tmp-swap
+    scenarios); guarded there behind ``hasattr(os, "getuid")``.
+    """
+    if info.st_uid != os.getuid():
+        msg = f"toolr spec file is not owned by the current user: {path}"
+        raise SpecError(msg)
+    if info.st_mode & 0o022:
+        msg = f"toolr spec file is group/world-writable; refusing to read it: {path}"
+        raise SpecError(msg)
 
 
 def load_spec_from_env() -> RunnerSpec:

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -15,6 +15,7 @@ on are all supported "for free" via msgspec's coercion rules.
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import importlib
 import inspect
@@ -233,7 +234,18 @@ def load_spec_from_env() -> RunnerSpec:
         msg = f"{_SPEC_ENV_VAR} is not set. The toolr runner must be invoked by the toolr binary, not directly."
         raise SpecError(msg)
     _validate_spec_file(spec_path)
-    return load_spec(spec_path)
+    spec = load_spec(spec_path)
+    # SEC-14(A): we are the last reader, so unlink the spec now rather than
+    # waiting for the binary to drop its NamedTempFile handle after we exit.
+    # That shrinks the window in which the 0600 spec JSON (which can carry
+    # CLI argument values) lingers in TMPDIR if the process is SIGKILLed.
+    # Best-effort: on Unix the unlink succeeds (the binary's open handle
+    # keeps the inode alive until it drops, and its drop tolerates the
+    # already-removed file); on Windows the binary still holds the file open
+    # so the unlink may fail — harmless, the binary cleans up on drop.
+    with contextlib.suppress(OSError):
+        os.unlink(spec_path)
+    return spec
 
 
 def _build_context(spec: RunnerSpec) -> Context:

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -21,6 +21,7 @@ import inspect
 import ipaddress
 import os
 import pathlib
+import stat
 import sys
 import traceback
 import uuid
@@ -182,12 +183,56 @@ def load_spec(path: str | os.PathLike[str]) -> RunnerSpec:
     return spec
 
 
+def _validate_spec_file(path: str) -> None:
+    """Refuse a spec file that isn't a private, we-own-it regular file.
+
+    Defense-in-depth (SEC-05). The toolr binary writes the spec to a 0600
+    ``O_EXCL`` tempfile it owns and hands us the path via
+    ``$TOOLR_SPEC_FILE``; ``_import_target`` then imports whatever
+    ``spec.module`` says. That chain is trusted today, but this guards a
+    future regression where the spec path becomes attacker-influenceable:
+    a symlink, a file owned by another user, or a group/world-writable
+    file is rejected with :class:`SpecError` rather than read-from (and
+    imported-from). If the spec can't be forged, the import target can't
+    be either.
+    """
+    try:
+        info = os.lstat(path)
+    except FileNotFoundError as exc:
+        # Keep the wording load_spec() uses for a missing file, so the
+        # validation step doesn't change the message users (and tests) see.
+        msg = f"toolr spec file not found: {path}"
+        raise SpecError(msg) from exc
+    except OSError as exc:
+        msg = f"toolr spec file is not accessible: {path} ({exc})"
+        raise SpecError(msg) from exc
+    if stat.S_ISLNK(info.st_mode):
+        msg = f"toolr spec file must not be a symlink: {path}"
+        raise SpecError(msg)
+    if not stat.S_ISREG(info.st_mode):
+        msg = f"toolr spec file is not a regular file: {path}"
+        raise SpecError(msg)
+    # POSIX-only: the binary creates the spec 0600 and owned by us. Refuse
+    # if another user owns it or it is group/world-writable (the classic
+    # tmp-swap scenarios). Windows lacks these semantics; the
+    # not-a-symlink + regular-file checks above are what we can portably
+    # assert there.
+    if hasattr(os, "getuid"):
+        if info.st_uid != os.getuid():
+            msg = f"toolr spec file is not owned by the current user: {path}"
+            raise SpecError(msg)
+        if info.st_mode & 0o022:
+            msg = f"toolr spec file is group/world-writable; refusing to read it: {path}"
+            raise SpecError(msg)
+
+
 def load_spec_from_env() -> RunnerSpec:
     """Read ``$TOOLR_SPEC_FILE`` and call :func:`load_spec` on it."""
     spec_path = os.environ.get(_SPEC_ENV_VAR)
     if not spec_path:
         msg = f"{_SPEC_ENV_VAR} is not set. The toolr runner must be invoked by the toolr binary, not directly."
         raise SpecError(msg)
+    _validate_spec_file(spec_path)
     return load_spec(spec_path)
 
 

--- a/tests/runner/test_spec_loader.py
+++ b/tests/runner/test_spec_loader.py
@@ -96,6 +96,62 @@ def test_load_spec_from_env_raises_when_unset(monkeypatch: pytest.MonkeyPatch) -
     assert "TOOLR_SPEC_FILE" in str(exc_info.value)
 
 
+def test_load_spec_from_env_reports_missing_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing spec path is reported as 'not found' — the provenance check
+    keeps the wording load_spec() used, so error messages don't shift."""
+    monkeypatch.setenv("TOOLR_SPEC_FILE", str(tmp_path / "absent.json"))
+    with pytest.raises(SpecError) as exc_info:
+        load_spec_from_env()
+    assert "not found" in str(exc_info.value)
+
+
+def test_load_spec_from_env_rejects_non_regular_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spec path that resolves to a directory (or anything non-regular) is
+    refused before it is read."""
+    monkeypatch.setenv("TOOLR_SPEC_FILE", str(tmp_path))
+    with pytest.raises(SpecError) as exc_info:
+        load_spec_from_env()
+    assert "regular file" in str(exc_info.value)
+
+
+@posix_only
+def test_load_spec_from_env_reports_unreadable_path(
+    spec_file: Callable[..., Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A path whose parent isn't a directory (ENOTDIR) surfaces as a generic
+    'not accessible' SpecError rather than crashing."""
+    spec_path = spec_file()
+    # `<regular file>/child` makes lstat raise NotADirectoryError (an OSError
+    # that is not FileNotFoundError), exercising the generic-OSError branch.
+    monkeypatch.setenv("TOOLR_SPEC_FILE", str(spec_path / "child.json"))
+    with pytest.raises(SpecError) as exc_info:
+        load_spec_from_env()
+    assert "not accessible" in str(exc_info.value)
+
+
+@posix_only
+def test_load_spec_from_env_rejects_foreign_owner(
+    spec_file: Callable[..., Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spec file owned by a different user is refused. We simulate it by
+    making os.getuid() report a uid other than the file's owner."""
+    spec_path = spec_file()
+    spec_path.chmod(0o600)
+    monkeypatch.setattr(os, "getuid", lambda: os.stat(spec_path).st_uid + 1)
+    monkeypatch.setenv("TOOLR_SPEC_FILE", str(spec_path))
+    with pytest.raises(SpecError) as exc_info:
+        load_spec_from_env()
+    assert "not owned" in str(exc_info.value)
+
+
 @posix_only
 def test_load_spec_from_env_rejects_group_or_world_writable(
     spec_file: Callable[..., Path],

--- a/tests/runner/test_spec_loader.py
+++ b/tests/runner/test_spec_loader.py
@@ -139,3 +139,16 @@ def test_load_spec_from_env_accepts_private_regular_file(
     monkeypatch.setenv("TOOLR_SPEC_FILE", str(spec_path))
     spec = load_spec_from_env()
     assert spec.group == "ci"
+
+
+def test_load_spec_from_env_unlinks_after_reading(
+    spec_file: Callable[..., Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once read, the spec file is removed, so a normal run leaves nothing
+    behind in TMPDIR (SEC-14A). The decoded spec is unaffected."""
+    spec_path = spec_file()
+    monkeypatch.setenv("TOOLR_SPEC_FILE", str(spec_path))
+    spec = load_spec_from_env()
+    assert spec.group == "ci"
+    assert not spec_path.exists()

--- a/tests/runner/test_spec_loader.py
+++ b/tests/runner/test_spec_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Callable
 from pathlib import Path
 
@@ -10,6 +11,13 @@ from toolr._runner import SCHEMA_VERSION
 from toolr._runner import SpecError
 from toolr._runner import load_spec
 from toolr._runner import load_spec_from_env
+
+#: POSIX ownership / permission-bit semantics that the spec-file provenance
+#: checks rely on (``os.getuid``, meaningful mode bits, symlinks without
+#: elevation). Skipped on Windows, which lacks them.
+posix_only = pytest.mark.skipif(
+    not hasattr(os, "getuid"), reason="requires POSIX ownership/permission semantics"
+)
 
 
 @pytest.fixture
@@ -86,3 +94,48 @@ def test_load_spec_from_env_raises_when_unset(monkeypatch: pytest.MonkeyPatch) -
     with pytest.raises(SpecError) as exc_info:
         load_spec_from_env()
     assert "TOOLR_SPEC_FILE" in str(exc_info.value)
+
+
+@posix_only
+def test_load_spec_from_env_rejects_group_or_world_writable(
+    spec_file: Callable[..., Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spec file anyone but the owner can write is refused before it is read
+    (defense-in-depth: a forgeable spec is a forgeable import target)."""
+    spec_path = spec_file()
+    spec_path.chmod(0o666)
+    monkeypatch.setenv("TOOLR_SPEC_FILE", str(spec_path))
+    with pytest.raises(SpecError) as exc_info:
+        load_spec_from_env()
+    assert "writable" in str(exc_info.value)
+
+
+@posix_only
+def test_load_spec_from_env_rejects_symlink(
+    spec_file: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A symlinked spec path is refused — the binary never writes one, so it
+    signals a swapped path."""
+    spec_path = spec_file()
+    link = tmp_path / "spec-link.json"
+    link.symlink_to(spec_path)
+    monkeypatch.setenv("TOOLR_SPEC_FILE", str(link))
+    with pytest.raises(SpecError) as exc_info:
+        load_spec_from_env()
+    assert "symlink" in str(exc_info.value)
+
+
+def test_load_spec_from_env_accepts_private_regular_file(
+    spec_file: Callable[..., Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A normal 0600 regular file we own loads cleanly — the guard doesn't get
+    in the way of the real dispatch path."""
+    spec_path = spec_file()
+    spec_path.chmod(0o600)
+    monkeypatch.setenv("TOOLR_SPEC_FILE", str(spec_path))
+    spec = load_spec_from_env()
+    assert spec.group == "ci"


### PR DESCRIPTION
Two Info-tier, defense-in-depth hardening items on the execution pipeline,
bundled because both harden how the runner handles the dispatch spec file. No
live threat today; this raises the floor against future regressions. Three
commits.

## SEC-05 — confine the dispatch import target
The runner imports whatever `spec.module`/`spec.function` the spec names. That
chain is trusted today (the binary writes a 0600 `O_EXCL` tempfile it owns and
passes the path via `$TOOLR_SPEC_FILE`), but if the path ever became
attacker-influenceable the import target would be too.

**Done:** `load_spec_from_env` now validates spec-file provenance before reading
— refuses a symlink, a non-regular file, a file owned by another user, or a
group/world-writable file, with `SpecError`. POSIX ownership/permission checks
are guarded behind `hasattr(os, "getuid")`; on Windows the not-a-symlink /
regular-file checks are what we can portably assert.

**Won't-fix (the other half):** the prescribed module-namespace allowlist +
runtime command marker doesn't fit the architecture — the decorators leave no
runtime marker (`@command(group=…)` is a pure passthrough), and a `tools.`-only
allowlist would reject legitimate third-party plugin commands. Locking down the
spec file's provenance defends the same threat without that risk.

## SEC-14 — execution hardening notes
**Done (A):** the runner unlinks the spec file immediately after decoding it,
rather than waiting for the binary to drop its `NamedTempFile` handle after the
runner exits. Shrinks the window in which the 0600 spec JSON (which can carry
CLI argument values) lingers in `TMPDIR` on a SIGKILL. Best-effort and
cross-platform: Unix unlink succeeds (the binary's open handle keeps the inode
alive; its drop already tolerates the missing file); Windows may fail the unlink
(binary still holds it open) — harmless, the binary cleans up on drop.

**Won't-fix (B):** sending signals to the child's process group instead of its
pid would require isolating the child's process group, which risks
`SIGTTIN`/`SIGTTOU` stalls for interactive subprocesses unless paired with the
full `tcsetpgrp` job-control dance — disproportionate for an Info-tier
"grandchildren orphaned on abrupt exit" note, and it fights toolr's
TTY-transparency design. The child itself is already signalled fine via its pid.

## Tests
`tests/runner/test_spec_loader.py`: rejects group/world-writable spec, rejects
symlinked spec, accepts a private 0600 regular file, and unlinks after reading
(POSIX-gated where ownership/permission semantics apply). Full `tests/runner`
suite green (82 passed); the missing-file error wording is preserved so the
existing e2e error-path test still passes.