### PR TITLE
fix(execute): bump dispatch schema to 2 for the `-P`/`sys.path` contract

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,14 @@ this file to empty for the next cycle.
 Empty between releases is the steady-state — there's no header,
 no scaffolding. Just write whatever should appear in the notes.
 -->
+
+### Changed
+
+- The binary↔runner dispatch schema is bumped to `2`. The 0.25.0 binary changed
+  the runtime contract (it starts the runner with `-P` and relies on the runner
+  to put the repo root on `sys.path`) without bumping the schema, so pairing it
+  with an older `toolr-py` failed with a cryptic `No module named 'tools'`
+  instead of the schema guard's clear "venv out of sync" message. The schema now
+  covers that contract, so a future binary paired with a stale `toolr-py` fails
+  loudly and points you at `toolr project venv upgrade toolr-py`. Re-sync your
+  tools venv after upgrading toolr.

--- a/crates/toolr-core/src/execute/spec.rs
+++ b/crates/toolr-core/src/execute/spec.rs
@@ -27,6 +27,17 @@ use serde::{Deserialize, Serialize};
 ///   the runner consumes.
 /// - Change the env-var / stdin / stdout / exit-code conventions between
 ///   the toolr binary and the Python runner.
+/// - Change the runtime invocation contract the runner must honor — e.g.
+///   the interpreter flags the binary passes (`-P`) or which side sets up
+///   `sys.path` / the working directory. An older runner that doesn't
+///   implement the new contract can't run a newer binary's dispatch even
+///   though the JSON shape is unchanged.
+///
+/// `2` covers the `-P` + runner-side `sys.path` setup contract introduced
+/// in the 0.25.0 binary (which shipped as `1`, so it couldn't detect an
+/// older runner lacking `_append_repo_root` — surfacing as a silent
+/// `No module named 'tools'` instead of a clear "venv out of sync").
+/// Enforced from here on.
 ///
 /// # When *not* to bump
 ///
@@ -40,7 +51,7 @@ use serde::{Deserialize, Serialize};
 /// Toolr is pre-1.0, so we don't carve out "major" / "minor" — bumps are
 /// monotonic integers tied 1:1 to "the protocol changed in a way an
 /// older peer can't handle".
-pub const RUNNER_SCHEMA_VERSION: u32 = 1;
+pub const RUNNER_SCHEMA_VERSION: u32 = 2;
 
 /// Reduced view of `toolr.Context` reconstructable from JSON.
 ///
@@ -206,7 +217,7 @@ mod tests {
         let spec = ExecutionSpec::new("ci", "hello", "tools.ci", "hello", "/repo");
         let json = serde_json::to_string(&spec).expect("serialize");
         // These exact strings are what `toolr._runner.RunnerSpec` decodes.
-        assert!(json.contains("\"schema_version\":1"), "got: {json}");
+        assert!(json.contains("\"schema_version\":2"), "got: {json}");
         assert!(json.contains("\"group\":\"ci\""), "got: {json}");
         assert!(json.contains("\"command\":\"hello\""), "got: {json}");
         assert!(json.contains("\"repo_root\":\"/repo\""), "got: {json}");
@@ -214,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_constant_is_1() {
-        assert_eq!(RUNNER_SCHEMA_VERSION, 1);
+    fn schema_version_constant_is_2() {
+        assert_eq!(RUNNER_SCHEMA_VERSION, 2);
     }
 }

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 # keeps output bounded across runs with many deprecated call sites.
 warnings.simplefilter("default", ToolrDeprecationWarning)
 
-SCHEMA_VERSION: int = 1
+SCHEMA_VERSION: int = 2
 """Schema version of the toolr ↔ toolr-py dispatch protocol.
 
 This constant **must** match ``RUNNER_SCHEMA_VERSION`` in
@@ -78,6 +78,11 @@ together when the two sides would no longer understand each other:
   runner consumes.
 * Change the env-var / stdin / stdout / exit-code conventions between
   the toolr binary and the Python runner.
+* Change the runtime invocation contract this runner must honor — e.g.
+  the interpreter flags the binary passes (``-P``) or which side sets up
+  ``sys.path`` / the working directory. An older runner that doesn't
+  implement the new contract can't run a newer binary's dispatch even
+  though the JSON shape is unchanged.
 
 **When *not* to bump**:
 
@@ -89,6 +94,11 @@ together when the two sides would no longer understand each other:
 
 Toolr is pre-1.0, so bumps are monotonic integers tied 1:1 to "the
 protocol changed in a way an older peer can't handle".
+
+``2`` covers the ``-P`` + runner-side ``sys.path`` setup contract the
+0.25.0 binary introduced (which shipped as ``1``, so it couldn't detect
+an older runner lacking :func:`_append_repo_root` — a silent
+``No module named 'tools'`` instead of a clear "venv out of sync").
 """
 
 _SPEC_ENV_VAR = "TOOLR_SPEC_FILE"

--- a/tests/runner/test_module_shipped.py
+++ b/tests/runner/test_module_shipped.py
@@ -11,7 +11,7 @@ def test_runner_module_is_importable() -> None:
     mod = importlib.import_module("toolr._runner")
     assert hasattr(mod, "main")
     assert hasattr(mod, "RunnerSpec")
-    assert mod.SCHEMA_VERSION == 1
+    assert mod.SCHEMA_VERSION == 2
 
 
 def test_runner_module_file_is_under_toolr_package() -> None:

--- a/tests/runner/test_spec_schema.py
+++ b/tests/runner/test_spec_schema.py
@@ -8,8 +8,8 @@ from toolr._runner import ContextSpec
 from toolr._runner import RunnerSpec
 
 
-def test_schema_version_constant_is_1() -> None:
-    assert SCHEMA_VERSION == 1
+def test_schema_version_constant_is_2() -> None:
+    assert SCHEMA_VERSION == 2
 
 
 def test_runner_spec_round_trips_through_json() -> None:


### PR DESCRIPTION
## Why
The 0.25.0 release broke main's dogfood CI with a cryptic `No module named
'tools'` (fixed in #357). The deeper cause: 0.25.0's binary changed the
**binary↔runner runtime contract** — it starts the runner with `-P` (dropping
CWD from `sys.path`) and relies on the runner's `_append_repo_root` to resolve
`import tools.*` — but shipped as schema `1`. So a 0.25.0 binary paired with an
older `toolr-py` (which has no `_append_repo_root`) couldn't be caught by the
schema guard: instead of the clear "venv out of sync" message, dispatch failed
with the confusing import error.

## What
- Bump `RUNNER_SCHEMA_VERSION` (Rust) and `SCHEMA_VERSION` (Python) `1 → 2`
  together — the CI lockstep gate (`schema_version_lockstep.rs`) enforces they
  match.
- Document that **runtime invocation-contract** changes (interpreter flags like
  `-P`, or which side sets up `sys.path`/cwd) require a schema bump — not just
  JSON-shape changes — and record that `2` covers the 0.25.0 `-P` contract.

From here on, a newer binary paired with a stale `toolr-py` fails loudly and
points at `toolr project venv upgrade toolr-py`.

## Tradeoff
This enforces strict binary↔runner version lockstep: a future schema-2 binary
won't accept a schema-1 (0.25.0) runner even though that runner technically
*has* `_append_repo_root`. Acceptable pre-1.0 — "keep the two halves in
lockstep" is the safer default, and the failure is now diagnostic.

## Verification
`cargo test -p toolr-core` lockstep gate + the two `execute::spec` unit tests
(`schema_version_constant_is_2`, `spec_json_uses_python_field_names`) pass. The
Python spec tests read `SCHEMA_VERSION` via the constant (factory) or test a 999
mismatch, so they follow the bump. No `--help` snippet content changes.

Follow-up still open: configure Renovate to keep `tools/`'s `toolr-py` current
ASAP after each release (so the lockstep window the schema guard now surfaces
closes quickly).