### PR TITLE
ci(renovate): track our own toolr-py in the dogfood venv, ASAP

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -81,5 +81,28 @@
       matchManagers: ["mise"],
       matchDepNames: ["actionlint", "shellcheck", "prek", "gitleaks"],
     },
+
+    // ---- Keep the dogfood venv in lockstep with our own releases ----
+    {
+      // `toolr-py` is this repo's own published package, dogfooded in
+      // `tools/`. Two things make this rule work:
+      //   1. `tools/pyproject.toml` carries a `>=` floor — a bare name
+      //      yields no update from the pep621 manager, which is why the
+      //      lock silently drifted to 0.20.1 until 0.25.0 broke dispatch.
+      //   2. `update-lockfile` keeps that floor and bumps only the
+      //      `uv.lock` pin.
+      // Override the global weekly schedule so the bump lands on the next
+      // Renovate run after a release publishes (not the following Monday),
+      // keeping the dogfood runner in lockstep with the just-released
+      // binary. `at any time` lifts the PR-timing gate; detection is still
+      // bounded by Renovate's own run cadence — repo config can't make that
+      // instant.
+      description: "Track our own toolr-py release in tools/ ASAP",
+      matchManagers: ["pep621"],
+      matchFileNames: ["tools/pyproject.toml", "tools/uv.lock"],
+      matchPackageNames: ["toolr-py"],
+      rangeStrategy: "update-lockfile",
+      schedule: ["at any time"],
+    },
   ],
 }

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -4,7 +4,14 @@ version = "0.0.0"
 description = "Toolr dogfooding tools venv (in-repo only; not published)"
 requires-python = ">=3.11"
 dependencies = [
-    "toolr-py",
+    # The `>=` floor is what lets Renovate bump the `uv.lock` pin: a bare
+    # `"toolr-py"` has no range to anchor against, so Renovate's pep621
+    # manager produces no update and the lock silently drifts (it sat on
+    # 0.20.1 until 0.25.0 broke dispatch). With the floor + the
+    # `rangeStrategy: update-lockfile` rule in `renovate.json5`, Renovate
+    # keeps this floor and bumps only the locked version. Floor = the first
+    # release whose runner matches the current binary's dispatch contract.
+    "toolr-py>=0.25.0",
 ]
 
 # `tools/` is intentionally NOT part of the root uv workspace, so

--- a/tools/uv.lock
+++ b/tools/uv.lock
@@ -131,4 +131,4 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "toolr-py" }]
+requires-dist = [{ name = "toolr-py", specifier = ">=0.25.0" }]


### PR DESCRIPTION
## Why
The `tools/` dogfood venv pinned `toolr-py` with a **bare, unconstrained** name
(`"toolr-py"`). Renovate's `pep621` manager can't bump an unconstrained dep —
there's no range to anchor against — so the `uv.lock` pin silently drifted to
**0.20.1** until 0.25.0's `-P` contract broke dispatch (`No module named 'tools'`;
see #357, #358). It also wasn't on any "bump it soon after release" path — the
repo's global Renovate schedule is weekly (`before 6am on monday`).

## What
- **`tools/pyproject.toml`**: floor the dep at `toolr-py>=0.25.0` so Renovate has
  a range to anchor against (the actual fix for the silent drift). 0.25.0 is the
  first release whose runner matches the current binary's dispatch contract.
- **`renovate.json5`**: a `packageRule` targeting `toolr-py` in `tools/` with
  - `rangeStrategy: "update-lockfile"` — keep the `>=` floor, bump only the
    `uv.lock` pin;
  - `schedule: ["at any time"]` — override the weekly gate so the bump lands on
    the next Renovate run after a release publishes, keeping the dogfood runner
    in lockstep with the just-released binary.

## Caveat
`"at any time"` lifts the PR-timing *gate*; it does not make detection instant —
that's still bounded by Renovate's own run cadence (~hourly on the hosted app),
which repo config can't change. This is "as soon as it can" without a
release-time trigger. Combined with the schema bump (#358), a stale window now
also fails *loudly* ("venv out of sync") instead of cryptically.

Verified: `uv lock --project tools` is in sync; `config:recommended` already
enables the pep621/uv manager (no global change needed); rule scoped to `tools/`
paths to stay clear of the root workspace.