### PR TITLE
fix(parser): honor name= override on command decorators

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -53,6 +53,9 @@ exclude_lines =
     if __name__ == .__main__.:
     if TYPE_CHECKING:
 
+    # Type-checking-only `@overload` stubs are never executed at runtime:
+    @overload
+
 omit =
   setup.py
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,16 @@ this file to empty for the next cycle.
 Empty between releases is the steady-state — there's no header,
 no scaffolding. Just write whatever should appear in the notes.
 -->
+
+Fixed: `@group.command(name="…")` silently dropped the keyword and the
+command took its hyphenated function name instead — the static parser
+only read the positional override. The `name=` keyword is now honoured on
+both `@group.command` and `@command`, which share an identical
+command-name contract: the override may be passed positionally
+(`@command("collect", group="…")`) or by keyword
+(`@command(name="collect", group="…")`), but not both — passing both
+raises `TypeError` at runtime and fails `build-manifest` with a clear
+*conflicting command name* error.
+
+The vestigial, never-implemented `aliases=` keyword has been removed from
+the `@command` decorator.

--- a/crates/toolr-core/src/build_fragment.rs
+++ b/crates/toolr-core/src/build_fragment.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use crate::parser::{list_python_files, module_path_for_prefix, parse_python_file};
 use crate::parser::{
-    commands::extract_commands,
+    commands::{CommandNameConflict, detect_name_conflicts, extract_commands},
     groups::extract_groups,
     symbols::{ArgSectionTable, EnumTable, TypeAliasTable},
     types::{SourcesImports, TypeImports, TypeResolutionError},
@@ -35,6 +35,8 @@ pub enum BuildFragmentError {
     },
     #[error("unsupported parameter types ({count}):\n{details}", count = .0.len(), details = format_type_errors(.0))]
     UnsupportedTypes(Vec<TypeResolutionError>),
+    #[error("conflicting command name ({count}):\n{details}", count = .0.len(), details = format_name_conflicts(.0))]
+    ConflictingCommandName(Vec<CommandNameConflict>),
 }
 
 fn format_type_errors(errors: &[TypeResolutionError]) -> String {
@@ -45,6 +47,23 @@ fn format_type_errors(errors: &[TypeResolutionError]) -> String {
         }
         use std::fmt::Write as _;
         let _ = write!(&mut s, "  - {err}");
+    }
+    s
+}
+
+fn format_name_conflicts(conflicts: &[CommandNameConflict]) -> String {
+    let mut s = String::new();
+    for (i, c) in conflicts.iter().enumerate() {
+        if i > 0 {
+            s.push('\n');
+        }
+        use std::fmt::Write as _;
+        let _ = write!(
+            &mut s,
+            "  - {}::{}: command name passed both positionally and via `name=`. \
+             Pass it one way only, e.g. `command(name=\"…\")`.",
+            c.module, c.function,
+        );
     }
     s
 }
@@ -90,6 +109,7 @@ pub fn build_third_party_fragment(
     let mut global_vars: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
     let mut type_errors: Vec<TypeResolutionError> = Vec::new();
+    let mut name_conflicts: Vec<CommandNameConflict> = Vec::new();
 
     for path in &py_files {
         let module = parse_python_file(path).map_err(|e| BuildFragmentError::Parse {
@@ -98,6 +118,7 @@ pub fn build_third_party_fragment(
         })?;
         let module_path = module_path_for_prefix(source_dir, path, package_name);
         let module_doc = module_docstring(&module);
+        name_conflicts.extend(detect_name_conflicts(&module, &module_path));
         let bindings = extract_groups(&module, &module_doc, &global_vars);
         let type_imports = TypeImports::from_module(&module);
         let sources_imports = SourcesImports::from_module(&module);
@@ -124,6 +145,10 @@ pub fn build_third_party_fragment(
             }
         }
         all_commands.extend(commands);
+    }
+
+    if !name_conflicts.is_empty() {
+        return Err(BuildFragmentError::ConflictingCommandName(name_conflicts));
     }
 
     if !type_errors.is_empty() {
@@ -405,6 +430,36 @@ def subcmd(ctx):
             }
             other => panic!("expected Parse, got {other:?}"),
         }
+    }
+
+    /// A command whose name is passed both positionally and via `name=`
+    /// fails the fragment build with a conflicting-name error naming the
+    /// offending function — same contract as the local manifest build.
+    #[test]
+    fn conflicting_command_name_errors() {
+        let tmp = TempDir::new().unwrap();
+        let pkg = tmp.path().join("conflictpkg");
+        write(&pkg, "__init__.py", "");
+        write(
+            &pkg,
+            "cmds.py",
+            r#"group = command_group("grp", "Grp")
+
+@group.command("positional", name="keyword")
+def do_thing(ctx):
+    pass
+"#,
+        );
+        let err = build_third_party_fragment(&pkg, "conflictpkg", 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, BuildFragmentError::ConflictingCommandName(_)),
+            "got: {err:?}"
+        );
+        assert!(
+            msg.contains("conflicting command name") && msg.contains("do_thing"),
+            "got: {msg}"
+        );
     }
 
     /// Source dir that does not exist surfaces MissingSourceDir.

--- a/crates/toolr-core/src/parser/build.rs
+++ b/crates/toolr-core/src/parser/build.rs
@@ -10,7 +10,7 @@ use crate::hash::hash_tools_dir;
 use crate::manifest::{ArgumentKind, Manifest, SCHEMA_VERSION};
 use crate::parser::types::{SourcesImports, SupportedType, TypeImports, TypeResolutionError};
 use crate::parser::{
-    commands::extract_commands,
+    commands::{CommandNameConflict, detect_name_conflicts, extract_commands},
     groups::extract_groups,
     parse_python_file,
     symbols::{ArgSectionTable, EnumTable, TypeAliasTable},
@@ -63,10 +63,12 @@ fn build_static_manifest_inner(tools_dir: &Path) -> std::result::Result<Manifest
     let mut global_vars: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
     let mut type_errors: Vec<TypeResolutionError> = Vec::new();
+    let mut name_conflicts: Vec<CommandNameConflict> = Vec::new();
     for path in &py_files {
         let module = parse_python_file(path).map_err(BuildError::Build)?;
         let module_path = module_path_for(tools_dir, path);
         let module_doc = module_docstring(&module);
+        name_conflicts.extend(detect_name_conflicts(&module, &module_path));
         let bindings = extract_groups(&module, &module_doc, &global_vars);
         let type_imports = TypeImports::from_module(&module);
         let sources_imports = SourcesImports::from_module(&module);
@@ -97,6 +99,10 @@ fn build_static_manifest_inner(tools_dir: &Path) -> std::result::Result<Manifest
             }
         }
         all_commands.extend(commands);
+    }
+
+    if !name_conflicts.is_empty() {
+        return Err(BuildError::ConflictingCommandName(name_conflicts));
     }
 
     if !type_errors.is_empty() {
@@ -220,8 +226,27 @@ pub enum BuildError {
     UnknownGroupRefs(Vec<UnknownGroupRef>),
     #[error("invalid positional arity ({count}):\n{details}", count = .0.len(), details = format_positional_arity_errors(.0))]
     InvalidPositionalArity(Vec<PositionalArityError>),
+    #[error("conflicting command name ({count}):\n{details}", count = .0.len(), details = format_name_conflicts(.0))]
+    ConflictingCommandName(Vec<CommandNameConflict>),
     #[error("argparse scanner error: {0}")]
     Argparse(#[from] crate::argparse::ArgparseError),
+}
+
+fn format_name_conflicts(conflicts: &[CommandNameConflict]) -> String {
+    let mut s = String::new();
+    for (i, c) in conflicts.iter().enumerate() {
+        if i > 0 {
+            s.push('\n');
+        }
+        use std::fmt::Write as _;
+        let _ = write!(
+            &mut s,
+            "  - {}::{}: command name passed both positionally and via `name=`. \
+             Pass it one way only, e.g. `command(name=\"…\")`.",
+            c.module, c.function,
+        );
+    }
+    s
 }
 
 /// One command whose positional-argument layout violates the
@@ -923,6 +948,28 @@ def f(ctx, maybe: str | None, *files: str) -> None:
         let msg = err.to_string();
         assert!(
             msg.contains("cannot coexist with the variadic positional"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_command_name_passed_both_positionally_and_by_keyword() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "tools/v.py",
+            r#""""Bad."""
+group = command_group("x", "X", docstring=__doc__)
+
+@group.command("positional", name="keyword")
+def f(ctx) -> None:
+    """Ambiguous name."""
+"#,
+        );
+        let err = build_static_manifest(&tmp.path().join("tools")).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("conflicting command name") && msg.contains("v::f"),
             "got: {msg}"
         );
     }

--- a/crates/toolr-core/src/parser/commands.rs
+++ b/crates/toolr-core/src/parser/commands.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use ruff_python_ast::{Decorator, Expr, ModModule, Stmt, StmtFunctionDef};
+use ruff_python_ast::{Arguments, Decorator, Expr, ModModule, Stmt, StmtFunctionDef};
 
 use super::groups::GroupBinding;
 use super::parse_docstring;
@@ -50,13 +50,13 @@ pub fn extract_commands(
             continue;
         };
         let (group_full_path, override_name) = match target {
-            CommandDecorator::LegacyVar { var, explicit_name } => {
+            CommandDecorator::LegacyVar { var, explicit_name, .. } => {
                 let Some(group_name) = by_var.get(var.as_str()) else {
                     continue;
                 };
                 (group_name.clone(), explicit_name)
             }
-            CommandDecorator::Direct { explicit_name, group } => {
+            CommandDecorator::Direct { explicit_name, group, .. } => {
                 // `group=` is required on the direct form. If it's
                 // missing or the targeted group isn't registered
                 // anywhere, we still emit the command — the build-
@@ -92,13 +92,71 @@ enum CommandDecorator {
     LegacyVar {
         var: String,
         explicit_name: Option<String>,
+        /// Both a positional string and a `name=` keyword were passed —
+        /// an ambiguous override the build-time validator rejects via
+        /// [`CommandNameConflict`].
+        name_conflict: bool,
     },
     /// Modern: `@command(group="dotted.path")` or `@command("name", group=...)`
     /// or bare `@command` (no group — caught by validator).
     Direct {
         explicit_name: Option<String>,
         group: Option<String>,
+        /// See [`CommandDecorator::LegacyVar::name_conflict`].
+        name_conflict: bool,
     },
+}
+
+/// A command whose decorator passed the CLI-name override *both*
+/// positionally and via `name=`. Surfaced as a batch build error so the
+/// user fixes the ambiguity rather than silently getting one of the two.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandNameConflict {
+    /// Dotted python module the command lives in (`tools.foo.bar`).
+    pub module: String,
+    /// Python function name of the offending command.
+    pub function: String,
+}
+
+/// Resolve the explicit CLI-name override from a `command(...)` call's
+/// arguments. The name may come from the first positional string literal
+/// (`command("collect")`) or the `name=` keyword (`command(name="collect")`),
+/// but not both. Returns `(resolved_name, conflict)`: when both are
+/// present, `resolved_name` is `None` and `conflict` is `true`.
+fn resolve_explicit_name(args: &Arguments) -> (Option<String>, bool) {
+    let positional = args.args.first().and_then(literal_str);
+    let keyword = keyword_str(args, "name");
+    match (positional, keyword) {
+        (Some(_), Some(_)) => (None, true),
+        (Some(name), None) | (None, Some(name)) => (Some(name), false),
+        (None, None) => (None, false),
+    }
+}
+
+/// Walk a module for `@command`/`@<var>.command` decorators that passed
+/// the name both positionally and via `name=`, returning one
+/// [`CommandNameConflict`] per offender.
+pub fn detect_name_conflicts(module: &ModModule, module_path: &str) -> Vec<CommandNameConflict> {
+    let mut out = Vec::new();
+    for stmt in &module.body {
+        let Stmt::FunctionDef(func) = stmt else {
+            continue;
+        };
+        let Some(target) = command_decorator(&func.decorator_list) else {
+            continue;
+        };
+        let conflict = match target {
+            CommandDecorator::LegacyVar { name_conflict, .. }
+            | CommandDecorator::Direct { name_conflict, .. } => name_conflict,
+        };
+        if conflict {
+            out.push(CommandNameConflict {
+                module: module_path.to_string(),
+                function: func.name.as_str().to_string(),
+            });
+        }
+    }
+    out
 }
 
 fn command_decorator(decorators: &[Decorator]) -> Option<CommandDecorator> {
@@ -129,6 +187,7 @@ fn parse_legacy_command(expr: &Expr) -> Option<CommandDecorator> {
         return Some(CommandDecorator::LegacyVar {
             var: n.id.as_str().to_string(),
             explicit_name: None,
+            name_conflict: false,
         });
     }
     // Call form: `@<var>.command(...)` — func is an Attribute whose
@@ -146,10 +205,15 @@ fn parse_legacy_command(expr: &Expr) -> Option<CommandDecorator> {
     let Expr::Name(n) = attr.value.as_ref() else {
         return None;
     };
-    let explicit_name = call.arguments.args.first().and_then(literal_str);
+    // The CLI-name override may be the first positional string literal
+    // (`@<var>.command("name")`) or the `name=` keyword
+    // (`@<var>.command(name="name")`); the bound `command(self, name)`
+    // method accepts both shapes at runtime, but not both at once.
+    let (explicit_name, name_conflict) = resolve_explicit_name(&call.arguments);
     Some(CommandDecorator::LegacyVar {
         var: n.id.as_str().to_string(),
         explicit_name,
+        name_conflict,
     })
 }
 
@@ -163,6 +227,14 @@ fn literal_str(expr: &Expr) -> Option<String> {
     }
 }
 
+/// Find a string-literal keyword argument by name, e.g. `name="…"`.
+fn keyword_str(args: &Arguments, name: &str) -> Option<String> {
+    args.keywords
+        .iter()
+        .find(|k| k.arg.as_ref().map(ruff_python_ast::Identifier::as_str) == Some(name))
+        .and_then(|k| literal_str(&k.value))
+}
+
 /// Recognise the new `@command` / `@command("name", group="…")` shape.
 fn parse_direct_command(expr: &Expr) -> Option<CommandDecorator> {
     // Bare `@command` — Name expression on the decorator.
@@ -171,6 +243,7 @@ fn parse_direct_command(expr: &Expr) -> Option<CommandDecorator> {
             return Some(CommandDecorator::Direct {
                 explicit_name: None,
                 group: None,
+                name_conflict: false,
             });
         }
         return None;
@@ -185,28 +258,16 @@ fn parse_direct_command(expr: &Expr) -> Option<CommandDecorator> {
     if callee.id.as_str() != "command" {
         return None;
     }
-    // First positional, if a string literal, is the explicit name.
-    let explicit_name = call
-        .arguments
-        .args
-        .first()
-        .and_then(|e| match e {
-            Expr::StringLiteral(s) => Some(s.value.to_str().to_string()),
-            _ => None,
-        });
+    // The explicit name may be the first positional string literal
+    // (`@command("name", group=…)`) or the `name=` keyword
+    // (`@command(name="name", group=…)`), but not both.
+    let (explicit_name, name_conflict) = resolve_explicit_name(&call.arguments);
     // `group=` kwarg, string literal only.
-    let group = call
-        .arguments
-        .keywords
-        .iter()
-        .find(|k| k.arg.as_ref().map(|n| n.as_str()) == Some("group"))
-        .and_then(|k| match &k.value {
-            Expr::StringLiteral(s) => Some(s.value.to_str().to_string()),
-            _ => None,
-        });
+    let group = keyword_str(&call.arguments, "group");
     Some(CommandDecorator::Direct {
         explicit_name,
         group,
+        name_conflict,
     })
 }
 
@@ -435,6 +496,98 @@ def check_snippets(ctx):
     }
 
     #[test]
+    fn direct_command_decorator_supports_name_keyword() {
+        let src = r#"command_group("ci.helm-diff-pr-comment", "Helm diff")
+
+@command(name="snippet-checker", group="ci.helm-diff-pr-comment")
+def check_snippets(ctx):
+    """Check snippets."""
+    pass
+"#;
+        let m = parse_src(src);
+        let bindings = extract_groups(&m, "", &HashMap::new());
+        let commands = extract_commands(
+            &m,
+            "tools.ci",
+            &bindings,
+            &EnumTable::default(),
+            &ConstTable::default(),
+            &TypeImports::default(),
+            &SourcesImports::default(),
+            &TypeAliasTable::default(),
+            &ArgSectionTable::default(),
+            &HashMap::new(),
+            &mut Vec::new(),
+        );
+        assert!(detect_name_conflicts(&m, "tools.ci").is_empty());
+        assert_eq!(commands.len(), 1);
+        // The `name=` keyword wins over the `check-snippets` function name.
+        assert_eq!(commands[0].name, "snippet-checker");
+        assert_eq!(commands[0].group, "ci.helm-diff-pr-comment");
+        assert_eq!(commands[0].function, "check_snippets");
+    }
+
+    #[test]
+    fn legacy_decorator_rejects_positional_and_name_keyword() {
+        let src = r#"group = command_group("ci", "CI")
+
+@group.command("positional", name="keyword")
+def do_thing(ctx):
+    pass
+"#;
+        let m = parse_src(src);
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                Stmt::FunctionDef(f) => Some(f),
+                _ => None,
+            })
+            .unwrap();
+        // The decorator resolves to no explicit name, flagged as a conflict.
+        match command_decorator(&func.decorator_list).unwrap() {
+            CommandDecorator::LegacyVar { explicit_name, name_conflict, .. } => {
+                assert_eq!(explicit_name, None);
+                assert!(name_conflict);
+            }
+            _ => panic!("expected LegacyVar"),
+        }
+        let conflicts = detect_name_conflicts(&m, "tools.ci");
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].module, "tools.ci");
+        assert_eq!(conflicts[0].function, "do_thing");
+    }
+
+    #[test]
+    fn direct_decorator_rejects_positional_and_name_keyword() {
+        let src = r#"command_group("ci", "CI")
+
+@command("positional", name="keyword", group="ci")
+def do_thing(ctx):
+    pass
+"#;
+        let m = parse_src(src);
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                Stmt::FunctionDef(f) => Some(f),
+                _ => None,
+            })
+            .unwrap();
+        match command_decorator(&func.decorator_list).unwrap() {
+            CommandDecorator::Direct { explicit_name, name_conflict, .. } => {
+                assert_eq!(explicit_name, None);
+                assert!(name_conflict);
+            }
+            _ => panic!("expected Direct"),
+        }
+        let conflicts = detect_name_conflicts(&m, "tools.ci");
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].function, "do_thing");
+    }
+
+    #[test]
     fn legacy_var_decorator_still_works() {
         let src = r#"group = command_group("ci", "CI")
 
@@ -496,7 +649,7 @@ def do_thing(ctx):
             .unwrap();
         let decorated = command_decorator(&func.decorator_list).unwrap();
         match decorated {
-            CommandDecorator::LegacyVar { var, explicit_name } => {
+            CommandDecorator::LegacyVar { var, explicit_name, .. } => {
                 assert_eq!(var, "group");
                 assert_eq!(explicit_name, None);
             }
@@ -540,7 +693,7 @@ def do_thing(ctx):
             .unwrap();
         let decorated = command_decorator(&func.decorator_list).unwrap();
         match decorated {
-            CommandDecorator::LegacyVar { var, explicit_name } => {
+            CommandDecorator::LegacyVar { var, explicit_name, .. } => {
                 assert_eq!(var, "group");
                 assert_eq!(explicit_name.as_deref(), Some("hello"));
             }
@@ -550,6 +703,52 @@ def do_thing(ctx):
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].name, "hello");
         assert_eq!(commands[0].function, "do_thing");
+    }
+
+    #[test]
+    fn legacy_decorator_call_form_with_name_keyword() {
+        let src = r#"group = command_group("ci", "CI")
+
+@group.command(name="collect")
+def collect_data(ctx):
+    pass
+"#;
+        let m = parse_src(src);
+        let bindings = extract_groups(&m, "", &HashMap::new());
+        let commands = extract_commands(
+            &m,
+            "tools.ci",
+            &bindings,
+            &EnumTable::default(),
+            &ConstTable::default(),
+            &TypeImports::default(),
+            &SourcesImports::default(),
+            &TypeAliasTable::default(),
+            &ArgSectionTable::default(),
+            &HashMap::new(),
+            &mut Vec::new(),
+        );
+        let func = m
+            .body
+            .iter()
+            .find_map(|s| match s {
+                Stmt::FunctionDef(f) => Some(f),
+                _ => None,
+            })
+            .unwrap();
+        let decorated = command_decorator(&func.decorator_list).unwrap();
+        match decorated {
+            CommandDecorator::LegacyVar { var, explicit_name, .. } => {
+                assert_eq!(var, "group");
+                assert_eq!(explicit_name.as_deref(), Some("collect"));
+            }
+            _ => panic!("expected LegacyVar"),
+        }
+        // The `name=` keyword wins over the hyphenated function name
+        // (`collect`, not the `collect-data` the function name would give).
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "collect");
+        assert_eq!(commands[0].function, "collect_data");
     }
 
     #[test]
@@ -585,7 +784,7 @@ def do_thing(ctx):
             .unwrap();
         let decorated = command_decorator(&func.decorator_list).unwrap();
         match decorated {
-            CommandDecorator::LegacyVar { var, explicit_name } => {
+            CommandDecorator::LegacyVar { var, explicit_name, .. } => {
                 assert_eq!(var, "group");
                 assert_eq!(explicit_name, None);
             }

--- a/crates/toolr-py/python/toolr/_decorators.py
+++ b/crates/toolr-py/python/toolr/_decorators.py
@@ -77,15 +77,21 @@ class CommandGroup(Struct, frozen=True):
     def command(self, name: F) -> F: ...
 
     @overload
-    def command(self, name: str) -> Callable[[F], F]: ...
+    def command(self, name: str | None = ...) -> Callable[[F], F]: ...
 
-    def command(self, name: str | F) -> Callable[[F], F] | F:
+    def command(self, name: str | F | None = None) -> Callable[[F], F] | F:
         """Register a new command via the captured group binding.
 
         The canonical single-file form. Use the standalone
         :func:`toolr.command` decorator with ``group="..."`` when the
         command lives in a different file from its group declaration
         — see *Scaling command groups across files* in the docs.
+
+        Mirrors the standalone :func:`toolr.command` signature (minus
+        ``group=``, which the binding already determines). The command
+        name may be passed positionally (``@group.command("collect")``)
+        or by keyword (``@group.command(name="collect")``) — but not
+        both; doing so raises ``TypeError``.
 
         Args:
             name: Name of the command. If not passed, the function
@@ -104,14 +110,21 @@ class CommandGroup(Struct, frozen=True):
             return inner(cast("F", name))
 
         if TYPE_CHECKING:
-            assert isinstance(name, str)
+            assert name is None or isinstance(name, str)
+
+        explicit_name = name
 
         def register(func: F) -> F:
-            if name in self.__commands:
+            cli_name = (
+                explicit_name if explicit_name is not None else func.__name__.replace("_", "-")
+            )
+            if cli_name in self.__commands:
                 log.debug(
-                    "Command '%s' already exists in group '%s', overriding", name, self.full_name
+                    "Command '%s' already exists in group '%s', overriding",
+                    cli_name,
+                    self.full_name,
                 )
-            self.__commands[name] = func
+            self.__commands[cli_name] = func
             return func
 
         return register
@@ -165,11 +178,18 @@ def _get_command_group_storage() -> dict[str, CommandGroup]:
     return collector
 
 
+@overload
+def command(name: F) -> F: ...
+
+
+@overload
+def command(name: str | None = ..., *, group: str | None = ...) -> Callable[[F], F]: ...
+
+
 def command(
-    name_or_func: str | Callable[..., Any] | None = None,
+    name: str | Callable[..., Any] | None = None,
     *,
     group: str | None = None,
-    aliases: list[str] | None = None,
 ) -> Callable[..., Any]:
     """Register a function as a toolr CLI command.
 
@@ -177,6 +197,12 @@ def command(
     ``@<binding>.command`` form. Lets you declare commands in any
     file without importing a shared ``CommandGroup`` binding — the
     ``group=`` string is the only contract.
+
+    The signature mirrors the bound :meth:`CommandGroup.command`
+    (plus ``group=``). The command name may be passed positionally
+    (``@command("snippet-checker", group=...)``) or by keyword
+    (``@command(name="snippet-checker", group=...)``) — but not both;
+    doing so raises ``TypeError``.
 
     Usage::
 
@@ -193,9 +219,10 @@ def command(
         def check_snippets(ctx): ...
 
     Args:
-        name_or_func: When called as a bare decorator (``@command``),
-            this is the wrapped function. When called with parentheses
-            (``@command("name", group=...)``), this is the override
+        name: When called as a bare decorator (``@command``), this is
+            the wrapped function. When called with parentheses
+            (``@command("name", group=...)`` or
+            ``@command(name="name", group=...)``), this is the override
             for the command's CLI name; the function name (hyphenated)
             is used otherwise.
         group: Dotted full path of the target group
@@ -203,9 +230,6 @@ def command(
             matching ``command_group(...)`` declaration must exist
             elsewhere in ``tools/``; otherwise manifest-build fails
             with a clear error.
-        aliases: Reserved for future use; currently no-op (tracked
-            with the rest of the ``arg(aliases=...)`` plumbing in
-            issue #198).
 
     Returns:
         The decorated function unchanged; the decorator's only job is
@@ -213,14 +237,14 @@ def command(
         toolr calls the function directly with the parsed args.
     """
     # Bare form: @command def f(...) — no kwargs allowed in this shape.
-    if callable(name_or_func):
-        if group is not None or aliases is not None:
+    if callable(name):
+        if group is not None:
             err_msg = (
                 '@command(...) with kwargs must be used as `@command(group="…")`'
                 " — drop the parens-less form or move the kwargs into them."
             )
             raise TypeError(err_msg)
-        return name_or_func
+        return name
 
     # Parameterised form: @command(...) — returns a decorator. The
     # decorator itself is currently a passthrough; the static parser

--- a/crates/xtask/src/build_skill_refs/authoring.rs
+++ b/crates/xtask/src/build_skill_refs/authoring.rs
@@ -341,9 +341,19 @@ fn clone_module(module: &ModModule) -> ModModule {
 }
 
 fn find_definition<'a>(module: &'a ModModule, name: &str) -> Option<&'a Stmt> {
+    // For overloaded functions (`@overload def f(...): ...` stubs
+    // followed by the real implementation), prefer the implementation —
+    // it carries the signature default and the docstring. Fall back to
+    // the first matching def if every one is an overload.
+    let mut fallback: Option<&Stmt> = None;
     for stmt in &module.body {
         match stmt {
-            Stmt::FunctionDef(def) if def.name.as_str() == name => return Some(stmt),
+            Stmt::FunctionDef(def) if def.name.as_str() == name => {
+                if !is_overload(def) {
+                    return Some(stmt);
+                }
+                fallback.get_or_insert(stmt);
+            }
             Stmt::ClassDef(def) if def.name.as_str() == name => return Some(stmt),
             Stmt::Assign(assign) if assign.targets.len() == 1 => match &assign.targets[0] {
                 Expr::Name(n) if n.id.as_str() == name => return Some(stmt),
@@ -356,7 +366,17 @@ fn find_definition<'a>(module: &'a ModModule, name: &str) -> Option<&'a Stmt> {
             _ => {}
         }
     }
-    None
+    fallback
+}
+
+/// Whether a function def is a `typing.@overload` stub (so the skill-ref
+/// generator skips it in favour of the real implementation).
+fn is_overload(def: &ruff_python_ast::StmtFunctionDef) -> bool {
+    def.decorator_list.iter().any(|d| match &d.expression {
+        Expr::Name(n) => n.id.as_str() == "overload",
+        Expr::Attribute(a) => a.attr.as_str() == "overload",
+        _ => false,
+    })
 }
 
 fn render_entry(
@@ -555,4 +575,63 @@ fn render_docstring_block(doc: &str) -> String {
     }
     out.push_str("```\n");
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn module(src: &str) -> ModModule {
+        ruff_python_parser::parse_module(src)
+            .expect("valid python")
+            .into_syntax()
+    }
+
+    fn is_overload_stmt(stmt: &Stmt) -> bool {
+        matches!(stmt, Stmt::FunctionDef(def) if is_overload(def))
+    }
+
+    #[test]
+    fn find_definition_returns_implementation_over_overload_stubs() {
+        let m = module(
+            "from typing import overload\n\
+             @overload\n\
+             def f(x: int) -> int: ...\n\
+             @overload\n\
+             def f(x: str) -> str: ...\n\
+             def f(x):\n    return x\n",
+        );
+        let found = find_definition(&m, "f").expect("f found");
+        assert!(
+            !is_overload_stmt(found),
+            "should return the implementation, not an @overload stub"
+        );
+    }
+
+    #[test]
+    fn find_definition_recognises_attribute_spelled_overload() {
+        let m = module(
+            "import typing\n\
+             @typing.overload\n\
+             def f(x: int) -> int: ...\n\
+             def f(x):\n    return x\n",
+        );
+        let found = find_definition(&m, "f").expect("f found");
+        assert!(!is_overload_stmt(found));
+    }
+
+    #[test]
+    fn find_definition_falls_back_to_first_when_all_overloads() {
+        let m = module(
+            "from typing import overload\n\
+             @overload\n\
+             def f(x: int) -> int: ...\n\
+             @overload\n\
+             def f(x: str) -> str: ...\n",
+        );
+        // No implementation present — fall back to the first stub rather
+        // than returning nothing.
+        let found = find_definition(&m, "f").expect("falls back to a stub");
+        assert!(is_overload_stmt(found));
+    }
 }

--- a/skills/toolr-command-authoring/references/commands.md
+++ b/skills/toolr-command-authoring/references/commands.md
@@ -209,10 +209,9 @@ Returns:
 
 ```python
 def command(
-    name_or_func: str | Callable[..., Any] | None = None,
+    name: str | Callable[..., Any] | None = None,
     *,
     group: str | None = None,
-    aliases: list[str] | None = None,
 ) -> Callable[..., Any]:
 ```
 
@@ -223,6 +222,12 @@ String-path attachment to a group, an alternative to the bound
 ``@<binding>.command`` form. Lets you declare commands in any
 file without importing a shared ``CommandGroup`` binding — the
 ``group=`` string is the only contract.
+
+The signature mirrors the bound :meth:`CommandGroup.command`
+(plus ``group=``). The command name may be passed positionally
+(``@command("snippet-checker", group=...)``) or by keyword
+(``@command(name="snippet-checker", group=...)``) — but not both;
+doing so raises ``TypeError``.
 
 Usage::
 
@@ -239,9 +244,10 @@ Usage::
     def check_snippets(ctx): ...
 
 Args:
-    name_or_func: When called as a bare decorator (``@command``),
-        this is the wrapped function. When called with parentheses
-        (``@command("name", group=...)``), this is the override
+    name: When called as a bare decorator (``@command``), this is
+        the wrapped function. When called with parentheses
+        (``@command("name", group=...)`` or
+        ``@command(name="name", group=...)``), this is the override
         for the command's CLI name; the function name (hyphenated)
         is used otherwise.
     group: Dotted full path of the target group
@@ -249,9 +255,6 @@ Args:
         matching ``command_group(...)`` declaration must exist
         elsewhere in ``tools/``; otherwise manifest-build fails
         with a clear error.
-    aliases: Reserved for future use; currently no-op (tracked
-        with the rest of the ``arg(aliases=...)`` plumbing in
-        issue #198).
 
 Returns:
     The decorated function unchanged; the decorator's only job is

--- a/tests/decorators/test_decorators_unit.py
+++ b/tests/decorators/test_decorators_unit.py
@@ -100,6 +100,51 @@ def test_group_command_with_explicit_name_returns_decorator():
     assert decorator(f) is f
 
 
+def test_group_command_with_name_keyword_registers_under_that_name():
+    g = command_group("legacy", "Legacy", description="Legacy group for tests")
+
+    @g.command(name="collect")
+    def collect_data(ctx) -> None: ...
+
+    commands = g.get_commands()
+    # The `name=` keyword wins over the hyphenated function name.
+    assert "collect" in commands
+    assert "collect-data" not in commands
+
+
+def test_group_command_empty_parens_registers_under_function_name():
+    g = command_group("legacy", "Legacy", description="Legacy group for tests")
+
+    @g.command()
+    def collect_data(ctx) -> None: ...
+
+    assert "collect-data" in g.get_commands()
+
+
+def test_group_command_duplicate_name_overrides_and_logs(caplog: pytest.LogCaptureFixture):
+    g = command_group("legacy", "Legacy", description="Legacy group for tests")
+
+    @g.command(name="dup")
+    def first(ctx) -> None: ...
+
+    with caplog.at_level(logging.DEBUG, logger="toolr._decorators"):
+
+        @g.command(name="dup")
+        def second(ctx) -> None: ...
+
+    # The second registration overrides the first under the same name.
+    assert g.get_commands()["dup"].__name__ == "second"
+    assert any("already exists" in r.message for r in caplog.records)
+
+
+def test_group_command_rejects_positional_and_name_keyword():
+    # A single `name` parameter means Python itself rejects passing the
+    # name both positionally and by keyword — no explicit guard needed.
+    g = command_group("legacy", "Legacy", description="Legacy group for tests")
+    with pytest.raises(TypeError, match="multiple values for argument 'name'"):
+        g.command("positional", name="keyword")
+
+
 def test_parent_command_group_method_still_emits_deprecation():
     """The bound-subgroup form (`parent.command_group("child", ...)`) is
     still on track for removal in toolr 1.0 — guard the warning stays."""
@@ -156,6 +201,23 @@ def test_command_parameterised_form_with_string_first_arg():
     def f(ctx) -> None: ...
 
     assert decorator(f) is f
+
+
+def test_command_parameterised_form_with_name_keyword():
+    # `name=` is the keyword spelling of the same first positional; it
+    # mirrors the bound `@group.command(name=...)` form.
+    decorator = command(name="rename-me", group="ci")
+    assert callable(decorator)
+
+    def f(ctx) -> None: ...
+
+    assert decorator(f) is f
+
+
+def test_command_rejects_positional_and_name_keyword():
+    # Single `name` parameter → Python rejects the redundant override.
+    with pytest.raises(TypeError, match="multiple values for argument 'name'"):
+        command("positional", name="keyword", group="ci")
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes a bug where `@group.command(name="collect")` silently dropped the
keyword — the static parser only read the positional override, so the
command took its hyphenated function name (`collect-data`) instead. The
fix also unifies the command-name contract across the two decorators so
they behave identically.

### The contract (now identical across both decorators)

| Form | `@group.command` (bound) | `@command` (standalone) |
|---|---|---|
| Bare (`@…command`) | ✓ | ✓ |
| Positional name (`("collect")`) | ✓ | ✓ |
| Keyword name (`(name="collect")`) | ✓ | ✓ |
| **Both** (`("a", name="b")`) | ✗ `TypeError` / build error | ✗ `TypeError` / build error |
| `group=` | n/a (binding determines it) | ✓ |

Both Python decorators now share a single `name` parameter
(`name: str | F | None`), so the redundant-override case is rejected by
Python itself at runtime (`got multiple values for argument 'name'`). The
static parser detects the same conflict and fails `build-manifest` with a
`conflicting command name` error, so the CI gate catches it too. The
third-party fragment builder enforces it identically.

## Why

`@group.command(name="collect")` previously parsed to *no* explicit name —
the static parser only read the first positional argument — so the command
silently took its hyphenated function name (`collect-data`) instead of the
requested `collect`. The two decorators also disagreed on how the name was
spelled (`name_or_func` vs `name`), which was confusing.

## Also in this PR

- Drops the vestigial `aliases=` keyword from `@command`. It was a no-op
  whose docstring cited the unrelated, already-closed #198 (that issue was
  about `arg()` *argument* metadata, not command-name aliases).
- Fixes the skill-ref generator to render a function's real implementation
  instead of the first `@overload` stub (which has no docstring).

## Tests

- Rust: `name=` keyword on the direct form; positional+`name=` conflict
  detection on both forms; build-level `ConflictingCommandName` error.
- Python: keyword forms on both decorators; runtime `TypeError` on the
  conflict; empty-parens registers under the function name.
- `cargo xtask build-skill-refs --check` + full `mise run test` umbrella
  green (396 passed).

## Compatibility

Non-breaking: every existing form (bare, positional name) keeps working,
including the `docs/migration.md` guarantee that
`@group.command("custom-name")` continues to work. Only the
previously-silent keyword form gains meaning, and the genuinely-ambiguous
both-at-once case becomes an error.
