### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2327,7 +2327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,14 @@
   timezone: "Etc/UTC",
   schedule: ["before 6am on monday"],
 
+  // Remediate vulnerable *transitive* crates directly from OSV data.
+  // Without this, an advisory on an indirect dep (one that lives only in
+  // Cargo.lock, never in a Cargo.toml) produces no PR — the cargo manager
+  // only bumps manifest-declared deps. This is exactly how quinn-proto
+  // sat at 0.11.14 under RUSTSEC-2026-0185 until Scorecard's OSV scan
+  // flagged it. Security PRs bypass the weekly schedule above.
+  osvVulnerabilityAlerts: true,
+
   assignees: ["s0undt3ch"],
   labels: ["dependencies"],
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,17 @@
   // flagged it. Security PRs bypass the weekly schedule above.
   osvVulnerabilityAlerts: true,
 
+  // Once a month, regenerate the lockfiles (`cargo update`, `uv lock`) to
+  // pull every dep — direct and transitive — up to the newest version its
+  // existing manifest range already allows. This does NOT widen the ranges
+  // themselves (that's the regular per-dep PRs); it just keeps the locked
+  // graph current, so transitive drift is caught before it turns into an
+  // OSV advisory. One low-noise PR per month.
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["before 6am on the first day of the month"],
+  },
+
   assignees: ["s0undt3ch"],
   labels: ["dependencies"],
 


### PR DESCRIPTION
quinn-proto < 0.11.15 is vulnerable to remote memory exhaustion via
unbounded out-of-order QUIC stream reassembly (RUSTSEC-2026-0185, OSV
high). It enters the tree only as an inactive optional dependency of
reqwest (the http3/quinn feature is not enabled here), so it is never
compiled, but Scorecard/OSV flags the locked version regardless.

The resolver also unifies tempfile onto getrandom 0.4.2 as a side
effect of the bump; workspace builds and checks pass.