### PR TITLE
docs(writing-commands): prefer ctx.repo_root and document tools namespace package

### DIFF
--- a/docs/writing-commands/across-files.md
+++ b/docs/writing-commands/across-files.md
@@ -98,4 +98,29 @@ in another. Toolr resolves both through the same registry, so a
 group declared with the bound form is reachable from a string key
 in a different file, and vice versa.
 
+## Sharing plain helper code
+
+The decorator forms above are for wiring *commands* to groups. When
+you just want to reuse ordinary functions between files — a shared
+constant, a `_helpers.py`, a `version.py` — import them directly.
+
+`tools/` is a [PEP 420](https://peps.python.org/pep-0420/) implicit
+namespace package: it needs **no `__init__.py`** (don't add one), and
+toolr puts the repo root on `sys.path` before running your command, so
+fully-qualified imports resolve from any command file:
+
+```python
+# tools/ci.py
+import tools.version                 # module import
+from tools import version            # same module, name-bound
+from tools.helpers import render     # import a name directly
+
+def build(ctx):
+    ctx.info(f"Building {tools.version.CURRENT}")
+```
+
+Always use the full `tools.<module>` path — that is what resolves via
+`sys.path`. This works both under `toolr` at runtime and in tests
+(toolr's testing harness imports every `tools.*` module the same way).
+
 Next: [Nested groups →](nesting.md)

--- a/docs/writing-commands/across-files.md
+++ b/docs/writing-commands/across-files.md
@@ -102,25 +102,30 @@ in a different file, and vice versa.
 
 The decorator forms above are for wiring *commands* to groups. When
 you just want to reuse ordinary functions between files — a shared
-constant, a `_helpers.py`, a `version.py` — import them directly.
+constant, a `helpers.py`, a `version.py` — import them directly.
 
 `tools/` is a [PEP 420](https://peps.python.org/pep-0420/) implicit
-namespace package: it needs **no `__init__.py`** (don't add one), and
-toolr puts the repo root on `sys.path` before running your command, so
-fully-qualified imports resolve from any command file:
+namespace package: it needs **no `__init__.py`** (don't add one).
+toolr puts the repo root on `sys.path` and imports your command
+modules *under* the `tools` package, so both import styles resolve
+from any command file — absolute or relative:
 
 ```python
 # tools/ci.py
-import tools.version                 # module import
-from tools import version            # same module, name-bound
-from tools.helpers import render     # import a name directly
+import tools.version                 # absolute module import
+from tools import version            # absolute, name-bound
+from tools.helpers import render     # absolute, import a name
+
+from . import version                # relative module import
+from .helpers import render          # relative, import a name
 
 def build(ctx):
-    ctx.info(f"Building {tools.version.CURRENT}")
+    ctx.info(f"Building {version.CURRENT}")
 ```
 
-Always use the full `tools.<module>` path — that is what resolves via
-`sys.path`. This works both under `toolr` at runtime and in tests
-(toolr's testing harness imports every `tools.*` module the same way).
+Use whichever reads best; both work under `toolr` at runtime and in
+tests (toolr's testing harness imports every `tools.*` module the same
+way). The only thing to avoid is manual `sys.path` manipulation —
+toolr has already set it up for you.
 
 Next: [Nested groups →](nesting.md)

--- a/docs/writing-commands/context.md
+++ b/docs/writing-commands/context.md
@@ -43,6 +43,12 @@ matter where you invoke `toolr` from — the same convention `make` and
 `cargo` follow. `ctx.repo_root` always points there, and `ctx.run(...)`
 subprocesses inherit it as their cwd unless you override it.
 
+Reach for `ctx.repo_root` whenever you need an absolute path into the
+project. **Prefer it over deriving the root from `__file__`** (for
+example `Path(__file__).parents[2]`): that hard-codes the file's depth
+in the tree, so it breaks the moment the file moves or the command is
+packaged as a plugin. toolr already discovered the root — ask it.
+
 Because of this, a **relative path argument resolves from the repo
 root, not from your current directory**. Running `toolr build ./out.txt`
 from a subdirectory writes `<repo-root>/out.txt`. Pass an absolute path

--- a/skills/toolr-command-authoring/SKILL.md
+++ b/skills/toolr-command-authoring/SKILL.md
@@ -104,10 +104,12 @@ Add this to `tools/greet.py`, then `toolr greet hello --help` works.
   is packaged as a plugin, and toolr already knows the answer.
 - **Importing sibling `tools/` code.** `tools/` is a PEP 420
   implicit namespace package — no `__init__.py`, and none is wanted.
-  toolr puts the repo root on `sys.path`, so fully-qualified imports
-  resolve from any command file: `import tools.helpers` or
-  `from tools import helpers`. Share helpers this way instead of
-  `sys.path` hacks or relative imports.
+  toolr puts the repo root on `sys.path` and imports command modules
+  under the `tools` package, so both forms resolve from any command
+  file: absolute (`import tools.helpers`, `from tools import helpers`)
+  or relative (`from . import helpers`, `from .helpers import render`).
+  Either is fine — share helpers this way rather than with `sys.path`
+  hacks.
 
 ## Runtime working directory
 

--- a/skills/toolr-command-authoring/SKILL.md
+++ b/skills/toolr-command-authoring/SKILL.md
@@ -97,12 +97,23 @@ Add this to `tools/greet.py`, then `toolr greet hello --help` works.
   sections.
 - **Calling subprocesses.** Use `ctx.run(...)`; it inherits stderr
   for TTY-aware tools and propagates timeouts.
+- **Referencing the repo root.** Use `ctx.repo_root` (a
+  `pathlib.Path`). It is toolr's discovered project root — do **not**
+  recompute it from `__file__` (`Path(__file__).parents[N]` and
+  friends). That guess breaks the moment the file moves or the command
+  is packaged as a plugin, and toolr already knows the answer.
+- **Importing sibling `tools/` code.** `tools/` is a PEP 420
+  implicit namespace package — no `__init__.py`, and none is wanted.
+  toolr puts the repo root on `sys.path`, so fully-qualified imports
+  resolve from any command file: `import tools.helpers` or
+  `from tools import helpers`. Share helpers this way instead of
+  `sys.path` hacks or relative imports.
 
 ## Runtime working directory
 
 Commands run with the working directory set to the **repo root**,
 regardless of where you invoke `toolr` from (the `make`/`cargo`
-convention). Two consequences:
+convention). `ctx.repo_root` always points there. Two consequences:
 
 - **Relative path arguments resolve from the repo root, not your
   current directory.** `toolr build ./out.txt` run from `tools/`
@@ -145,6 +156,12 @@ make its registration a top-level, statically-visible declaration.
   description.
 - **Don't write your own `argparse` subparser.** toolr owns the
   parser; you describe shape via decorators and type hints.
+- **Don't recompute the repo root from `__file__`.** No
+  `REPO_ROOT = Path(__file__).parents[1]`. Use `ctx.repo_root`.
+- **Don't add an `__init__.py` to `tools/`.** It's a namespace
+  package on purpose; a package init file is unnecessary and shadows
+  the implicit-namespace behaviour. Import siblings by their full
+  `tools.<module>` path.
 
 ## References
 


### PR DESCRIPTION
## Why

Agents (and humans) authoring toolr commands kept hitting two things the docs never stated plainly:

1. They recomputed the repo root from `__file__` — `REPO_ROOT = Path(__file__).parents[N]` — instead of using the value toolr already discovered. That guess breaks the moment a file moves or the command ships as a plugin.
2. It wasn't clear how to share plain helper code between `tools/*.py` files.

Both have direct answers:

- **`ctx.repo_root`** (a `pathlib.Path`) is toolr's discovered project root. Prefer it over deriving the root from `__file__`.
- **`tools/` is a [PEP 420](https://peps.python.org/pep-0420/) implicit namespace package** — no `__init__.py`, and none is wanted. The runner appends the repo root to `sys.path`, so fully-qualified imports resolve from any command file: `import tools.<mod>` or `from tools import <mod>`.

## What changed

Docs-only, keeping the AI-facing skill and the human-facing guide consistent:

- **`docs/writing-commands/context.md`** — the *Working directory* section now explicitly prefers `ctx.repo_root` over deriving the root from `__file__`.
- **`docs/writing-commands/across-files.md`** — new *Sharing plain helper code* section documenting the `tools/` namespace package and the import forms.
- **`skills/toolr-command-authoring/SKILL.md`** — added *Common authoring moves* bullets for both facts, plus matching anti-patterns (no `Path(__file__).parents[N]`, no `__init__.py` in `tools/`).

## Verification

Doc/skill-only scope:

- `cargo xtask build-skill-refs --check` ✅
- `uv run mkdocs build --strict` ✅
- `prek run` on the changed files ✅