### PR TITLE
fix(cli): suppress passive cache hint under --quiet

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,3 +30,9 @@ the first-class one-liner for running a command-package's tests
 (`toolr project venv run -- pytest tools/`). By default it syncs the venv first
 (like `venv shell`); `--no-sync` runs against the existing venv and errors if it
 is missing or stale, for deterministic CI.
+
+`--quiet` now suppresses the passive "your cache is big, consider pruning" hint.
+The hint is non-error output, so `--quiet` (which promises to suppress exactly
+that) now keeps it silent — including the per-`cd` `toolr project venv sync
+--quiet` the mise enter-hook runs, which previously leaked the hint to stderr in
+non-toolr directories once the cache accumulated enough orphans.

--- a/crates/toolr/src/main.rs
+++ b/crates/toolr/src/main.rs
@@ -72,8 +72,18 @@ fn maybe_emit_cache_hint_from_argv() {
     if std::env::var_os("TOOLR_NO_CACHE_HINT").is_some() {
         return;
     }
-    // Suppress for tab-completion and `self cache ...` invocations.
     let argv: Vec<String> = std::env::args().collect();
+    // `--quiet` promises to "suppress non-error output"; the passive
+    // hint is non-error output, so honour it here. We scan argv by hand
+    // because this runs before clap and because `--quiet` is accepted
+    // both root-level and per-subcommand. Detect both `--quiet` and any
+    // short cluster containing `q` (e.g. `-q`), and stop at the `--`
+    // separator so a wrapped command's own `--quiet`
+    // (`run -- pytest --quiet`) doesn't count.
+    if argv_requests_quiet(&argv) {
+        return;
+    }
+    // Suppress for tab-completion and `self cache ...` invocations.
     let positional: Vec<&str> = argv
         .iter()
         .skip(1)
@@ -95,6 +105,26 @@ fn maybe_emit_cache_hint_from_argv() {
     }
 }
 
+/// Best-effort scan of `argv` for a `--quiet` / `-q` request, used to
+/// gate the passive cache hint. Stops at the `--` separator so args
+/// belonging to a wrapped command (`toolr project venv run -- <cmd>
+/// --quiet`) are never mistaken for toolr's own quiet flag.
+fn argv_requests_quiet(argv: &[String]) -> bool {
+    for arg in argv.iter().skip(1) {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--quiet" {
+            return true;
+        }
+        // Short-flag cluster (`-q`, `-dq`, …) but not a long flag.
+        if arg.starts_with('-') && !arg.starts_with("--") && arg[1..].contains('q') {
+            return true;
+        }
+    }
+    false
+}
+
 fn load_or_empty(cwd: &std::path::Path) -> Manifest {
     let Ok(root) = discover_project_root(cwd) else {
         return empty_manifest();
@@ -110,5 +140,45 @@ fn empty_manifest() -> Manifest {
         third_party_hash: String::new(),
         groups: Vec::new(),
         commands: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::argv_requests_quiet;
+
+    fn argv(args: &[&str]) -> Vec<String> {
+        std::iter::once("toolr")
+            .chain(args.iter().copied())
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn detects_long_and_short_quiet() {
+        assert!(argv_requests_quiet(&argv(&["project", "venv", "sync", "--quiet"])));
+        assert!(argv_requests_quiet(&argv(&["-q", "project", "venv", "sync"])));
+        // Short cluster.
+        assert!(argv_requests_quiet(&argv(&["-dq", "ci", "hello"])));
+    }
+
+    #[test]
+    fn absent_quiet_is_not_detected() {
+        assert!(!argv_requests_quiet(&argv(&["project", "venv", "sync"])));
+        assert!(!argv_requests_quiet(&argv(&["--debug", "ci", "hello"])));
+        // `--quiet` is a long flag; a bare `q` in a value must not match.
+        assert!(!argv_requests_quiet(&argv(&["ci", "hello", "queen"])));
+    }
+
+    #[test]
+    fn wrapped_command_quiet_after_separator_is_ignored() {
+        // The `--quiet` belongs to pytest, not toolr.
+        assert!(!argv_requests_quiet(&argv(&[
+            "project", "venv", "run", "--", "pytest", "--quiet",
+        ])));
+        // But toolr's own quiet before the separator still counts.
+        assert!(argv_requests_quiet(&argv(&[
+            "project", "venv", "run", "--quiet", "--", "pytest",
+        ])));
     }
 }

--- a/crates/toolr/tests/cache_hint_quiet.rs
+++ b/crates/toolr/tests/cache_hint_quiet.rs
@@ -1,0 +1,90 @@
+//! The passive "your cache is big, consider pruning" hint is
+//! *non-error output*. `--quiet` promises to "suppress non-error
+//! output", so the hint must not leak under `--quiet` — even when the
+//! cache is dirty enough to trip the emission threshold.
+//!
+//! This is the contract the mise enter-hook recipe depends on: the hook
+//! runs `toolr project venv sync --quiet` on every `cd`, and must stay
+//! silent in non-toolr directories regardless of the developer's cache
+//! state.
+
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use chrono::Utc;
+use tempfile::TempDir;
+
+/// Write a single orphan cache entry (its `repo_path` points nowhere,
+/// so the classifier counts it as an orphan).
+fn write_orphan(cache_root: &Path, key: &str) {
+    let cache_dir = cache_root.join(key);
+    fs::create_dir_all(cache_dir.join("venv")).unwrap();
+    fs::write(cache_dir.join("venv/blob.bin"), vec![0u8; 1024]).unwrap();
+    let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let meta = serde_json::json!({
+        "schema_version": 1,
+        "repo_path": format!("/no/such/repo/{key}"),
+        "toolr_version": "1.0.0",
+        "python_version": "3.13.1",
+        "created_at": now,
+        "last_used_at": now,
+    });
+    fs::write(cache_dir.join("meta.json"), meta.to_string()).unwrap();
+}
+
+/// Build an `XDG_CACHE_HOME` whose `toolr/` cache root holds enough
+/// orphans to trip the hint (default threshold is `> 10`).
+fn dirty_cache() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let cache_root = tmp.path().join("toolr");
+    fs::create_dir_all(&cache_root).unwrap();
+    for i in 0..12 {
+        write_orphan(&cache_root, &format!("orphan-{i}"));
+    }
+    tmp
+}
+
+fn toolr(xdg_cache: &Path, work: &Path, args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("toolr")
+        .unwrap()
+        .current_dir(work)
+        .env("XDG_CACHE_HOME", xdg_cache)
+        .env_remove("HOME")
+        // Deliberately NOT setting TOOLR_NO_CACHE_HINT — this suite is
+        // about the hint actually firing (or being suppressed by --quiet).
+        .env_remove("TOOLR_NO_CACHE_HINT")
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+/// Control: without `--quiet`, the dirty cache DOES surface the hint on
+/// stderr. Proves the fixture trips the threshold, so the suppression
+/// test below can't pass vacuously.
+#[test]
+fn dirty_cache_surfaces_hint_without_quiet() {
+    let cache = dirty_cache();
+    let work = TempDir::new().unwrap();
+    let out = toolr(cache.path(), work.path(), &["project", "venv", "sync"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Run `toolr self cache prune`"),
+        "expected the passive cache hint on stderr, got:\n{stderr}"
+    );
+}
+
+/// Regression: `--quiet` suppresses the passive cache hint even with a
+/// dirty cache. Before the fix the hint leaked to stderr and broke the
+/// "`--quiet` must be silent" contract whenever the cache was dirty.
+#[test]
+fn quiet_suppresses_passive_cache_hint() {
+    let cache = dirty_cache();
+    let work = TempDir::new().unwrap();
+    let out = toolr(cache.path(), work.path(), &["project", "venv", "sync", "--quiet"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("cache has"),
+        "--quiet must suppress the passive cache hint, got stderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Problem

The passive "your cache is big, consider pruning" hint (`crates/toolr/src/main.rs`, `maybe_emit_cache_hint_from_argv`) runs *before* clap parses argv and was suppressed only for `TOOLR_NO_CACHE_HINT`, tab-completion, and `self cache …`. It never honoured **`--quiet`**.

`--quiet` promises to "suppress non-error output", and the hint is non-error output — so under `--quiet` it leaked to stderr anyway, once the cache accumulated enough orphans to trip the threshold. That breaks the "`--quiet` must be silent" contract the **mise enter-hook** depends on: `toolr project venv sync --quiet` runs on every `cd` and must stay silent in non-toolr directories regardless of cache state.

It surfaced as a flaky-looking failure of `project_venv_sync::sync_quiet_silently_exits_when_not_a_toolr_repo` — but only on a developer machine whose real cache had crossed the orphan threshold (CI's cache is clean, so CI never saw it). The test was right; the product was wrong.

## Fix

Scan argv for `--quiet` / `-q` and gate the hint on it. The scan stops at the `--` separator so a wrapped command's own quiet flag (`toolr project venv run -- pytest --quiet`) is never mistaken for toolr's, and it matches short clusters (`-dq`) as well as the long form.

## Tests

- **Unit** (`argv_requests_quiet`): long/short/cluster detection, absence, and the `--`-separator boundary in both directions.
- **Integration** (`tests/cache_hint_quiet.rs`): builds a dirty cache (12 orphans), asserts the hint *fires* without `--quiet` (so the suppression test can't pass vacuously) and is *suppressed* with it.

## Verification

Full `mise run test` umbrella passes **against a real dirty local cache with no `XDG_CACHE_HOME` isolation** — 382 passed, 8 skipped — proving the fix makes the suite robust to cache state, not just the isolated case. `cargo clippy` clean.

Independent of #379 (deps upgrade); branches off `main`.