### PR TITLE
fix(cli): don't apply unresolvable <expr> default sentinel as a real clap default

### DIFF
--- a/crates/toolr/src/cli.rs
+++ b/crates/toolr/src/cli.rs
@@ -682,8 +682,15 @@ fn build_user_command(cmd: &toolr_core::manifest::Command) -> Command {
                 if let Some(def) = &arg.default {
                     // Empty default means "no observable default at the
                     // CLI" — let Python's function default kick in
-                    // (e.g. `param: str | None = None`).
-                    if !def.is_empty() {
+                    // (e.g. `param: str | None = None`). `<expr>` is
+                    // toolr-core's sentinel for a default it couldn't
+                    // resolve to a literal (e.g. `Path("~/projects")`,
+                    // `uuid.uuid4()`) — applying it as a literal clap
+                    // default would ship the string `"<expr>"` itself
+                    // as the value, so treat it the same as "no CLI
+                    // default" and let Python's own default expression
+                    // run instead.
+                    if !def.is_empty() && def != "<expr>" {
                         a = a.default_value(def.clone());
                     }
                 }
@@ -982,6 +989,51 @@ mod cli_tree_tests {
             .try_get_matches_from(vec!["wrapup-company", "--skip_warm_cache"])
             .expect("underscored form must parse");
         assert!(underscored.get_flag("skip_warm_cache"));
+    }
+
+    #[test]
+    fn unresolvable_expr_default_is_not_applied_as_a_clap_default() {
+        // Mirrors `param: Path = Path("~/projects")` — toolr-core can't
+        // serialise the call expression to a literal, so it emits the
+        // `<expr>` sentinel. That sentinel must never reach clap as a
+        // real default_value (it would ship the literal string
+        // "<expr>" whenever the flag is omitted); Python's own default
+        // expression should run instead.
+        let mut arg = empty_arg("root", ArgumentKind::Optional);
+        arg.default = Some("<expr>".to_string());
+
+        let mut cmd = normal_leaf("sync", "jenkins");
+        cmd.arguments = vec![arg];
+
+        let clap_cmd = build_user_command(&cmd);
+        let matches = clap_cmd
+            .try_get_matches_from(vec!["sync"])
+            .expect("omitting the flag must still parse");
+        assert_eq!(matches.get_one::<String>("root"), None);
+    }
+
+    #[test]
+    fn resolvable_literal_default_still_applies_for_typed_arguments() {
+        // Contrast with the `<expr>` case above: a plain string literal
+        // default (the actually-supported spelling, e.g.
+        // `id: uuid.UUID = "12345678-1234-5678-1234-567812345678"`)
+        // resolves cleanly in `literal_default()` and must still reach
+        // clap as a real default — and pass the type's own value_parser.
+        let mut arg = empty_arg("id", ArgumentKind::Optional);
+        arg.default = Some("12345678-1234-5678-1234-567812345678".to_string());
+        arg.resolved_type = Some(toolr_core::parser::SupportedType::Uuid);
+
+        let mut cmd = normal_leaf("sync", "jenkins");
+        cmd.arguments = vec![arg];
+
+        let clap_cmd = build_user_command(&cmd);
+        let matches = clap_cmd
+            .try_get_matches_from(vec!["sync"])
+            .expect("omitting the flag must still parse using the default");
+        assert_eq!(
+            matches.get_one::<String>("id").map(String::as_str),
+            Some("12345678-1234-5678-1234-567812345678")
+        );
     }
 
     #[test]

--- a/skills/toolr-command-authoring/SKILL.md
+++ b/skills/toolr-command-authoring/SKILL.md
@@ -42,9 +42,14 @@ cannot drift.
    than redeclaring it.
 4. **Write the function.** Take `ctx: Context` as the first
    parameter, then your CLI arguments as ordinary Python parameters.
-   Type hints drive argparse binding; defaults make arguments
-   optional; `Annotated[T, arg(...)]` adds clap metadata
-   (`aliases`, `metavar`, `help_section`, `must_exist`, etc.).
+   The **type hint alone** decides how a value is parsed and coerced
+   — the default's shape is irrelevant, so `root: str = "~/projects"`
+   stays a `str` even though it looks path-like; annotate `root: Path`
+   if you want a `pathlib.Path`. Defaults make arguments optional;
+   `Annotated[T, arg(...)]` adds clap metadata (`aliases`, `metavar`,
+   `help_section`, `must_exist`, etc.). See
+   [`docs/writing-commands/arguments.md`](../../docs/writing-commands/arguments.md)
+   for the full supported-type table.
 5. **Document via Google-style docstring.** The first line is the
    short help (`toolr <group> --help`). The rest is the long help
    (`toolr <group> <cmd> --help`). `Args:` populates per-argument


### PR DESCRIPTION
## What

`toolr-core`'s parser renders any default value it can't serialise to a
literal (call expressions like `Path("~/projects")`, `uuid.uuid4()`,
`Version("1.0")`, etc.) as the sentinel string `"<expr>"`. `--help`
already knew to hide that sentinel, but `crates/toolr/src/cli.rs` still
handed it to clap as a real `default_value()`. So omitting the flag at
runtime shipped the literal string `"<expr>"` to Python instead of
letting the function's own default expression run — silently, with no
error anywhere, for **any** supported type (the bug isn't type-specific;
neither `literal_default()` nor the clap-default code branch on
`resolved_type`).

This treats `<expr>` the same as the existing empty-string ("no CLI
default", used for `param: str | None = None`) case: don't set a clap
default, fall through to Python.

Also nudges `toolr-command-authoring`'s SKILL.md to point authors at
the existing type table in `docs/writing-commands/arguments.md` and
call out that coercion is driven by the **annotation**, not the
default's shape — `root: str = "~/projects"` stays a `str`.

## Repro

```python
def sync(ctx: Context, root: Path = Path("~/projects")) -> None:
    ...
```

Before: `toolr sync` (flag omitted) → `root == Path("<expr>")`.
After: `toolr sync` (flag omitted) → `root == Path("~/projects")` (Python's own default runs).

## Testing

- New unit tests in `crates/toolr/src/cli.rs` (`cli_tree_tests`):
  - `unresolvable_expr_default_is_not_applied_as_a_clap_default` — fails without the fix, passes with it.
  - `resolvable_literal_default_still_applies_for_typed_arguments` — confirms the actually-supported pattern (plain string-literal default, e.g. a UUID string) is untouched and still passes clap's per-type value_parser.
- `cargo test -p toolr --bin toolr` and `cargo test -p toolr --test '*'` green.
