### PR TITLE
fix(manifest): key freshness rebuilds off the toolr binary version too

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -42,3 +42,9 @@ no scaffolding. Just write whatever should appear in the notes.
   `toolr-py in this tools venv speaks schema N, but the toolr binary
   emitted schema M`, run `toolr project venv upgrade toolr-py` (or pin
   the `toolr` binary to a compatible version).
+- Fixed the manifest freshness check silently keeping a stale
+  `.toolr-manifest.json` after a `toolr` upgrade that changed
+  CLI-parsing/classification behaviour but touched no `tools/*.py`
+  file. The manifest now records the `toolr` version that built it, and
+  any mismatch against the running binary forces a rebuild rather than
+  trusting the cached hashes.

--- a/crates/toolr-core/src/complete/freshness.rs
+++ b/crates/toolr-core/src/complete/freshness.rs
@@ -13,7 +13,8 @@ use crate::parser::build_static_manifest;
 pub struct ResolvedManifest {
     pub manifest: Manifest,
     /// `true` if the cached on-disk manifest was returned verbatim
-    /// (both `static_hash` and `third_party_hash` matched the live state).
+    /// (`static_hash`, `third_party_hash`, and `toolr_version` all
+    /// matched the live state).
     pub from_cache: bool,
     /// The directory that contained `tools/` (the project root).
     pub project_root: PathBuf,
@@ -33,10 +34,10 @@ pub fn resolve_manifest_at_tab(cwd: &Path) -> Result<ResolvedManifest> {
 
     // Tab completion never globs the venv — too costly on the hot path.
     // Passing `venv_dir = None` to `compare` skips the third-party axis
-    // entirely; the cached third_party_hash is treated as canonical and
-    // only static drift triggers a re-parse. Real third-party changes will
-    // be picked up on the next dispatch invocation, which does pass the
-    // venv path.
+    // entirely; the cached third_party_hash is treated as canonical.
+    // Static drift or a toolr-version mismatch still triggers a re-parse.
+    // Real third-party changes will be picked up on the next dispatch
+    // invocation, which does pass the venv path.
     let verdict = crate::freshness::compare(cached.as_ref(), &tools_dir, None)?;
 
     if matches!(verdict, crate::freshness::FreshnessVerdict::Fresh) {

--- a/crates/toolr-core/src/complete/tests.rs
+++ b/crates/toolr-core/src/complete/tests.rs
@@ -8,6 +8,7 @@ fn fixture() -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: "h".into(),
         third_party_hash: String::new(),
+        toolr_version: String::new(),
         groups: vec![
             Group {
                 name: "ci".into(),
@@ -171,6 +172,7 @@ fn nested_fixture() -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: "h".into(),
         third_party_hash: String::new(),
+        toolr_version: String::new(),
         groups: vec![
             Group {
                 name: "docker".into(),
@@ -314,6 +316,7 @@ fn dispatcher_fixture() -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: "h".into(),
         third_party_hash: String::new(),
+        toolr_version: String::new(),
         groups: vec![Group {
             name: "jenkins".into(),
             title: "Jenkins".into(),
@@ -465,6 +468,7 @@ fn flags_only_child_fixture() -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: "h".into(),
         third_party_hash: String::new(),
+        toolr_version: String::new(),
         groups: vec![Group {
             name: "jenkins".into(),
             title: "Jenkins".into(),
@@ -961,6 +965,7 @@ fn manifest_with_leaf_args(arguments: Vec<Argument>) -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: "h".into(),
         third_party_hash: String::new(),
+        toolr_version: String::new(),
         groups: vec![Group {
             name: "cmd".into(),
             title: String::new(),

--- a/crates/toolr-core/src/freshness/compare.rs
+++ b/crates/toolr-core/src/freshness/compare.rs
@@ -10,13 +10,13 @@ use crate::manifest::Manifest;
 
 /// Outcome of comparing the live filesystem state to a cached manifest.
 ///
-/// Variants are ordered by "stronger rebuild needed." When both axes
-/// drift simultaneously, `compare` returns `ThirdPartyDrift` because the
-/// third-party rebuild path is a superset that also re-parses
-/// `tools/*.py`.
+/// Variants are ordered by "stronger rebuild needed." When multiple
+/// axes drift simultaneously, `compare` returns `ThirdPartyDrift`
+/// because the third-party rebuild path is a superset that also
+/// re-parses `tools/*.py`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FreshnessVerdict {
-    /// Cached manifest matches the live state on both axes.
+    /// Cached manifest matches the live state on every axis.
     Fresh,
     /// `tools/*.py` content has drifted; third-party manifests are unchanged.
     StaticDrift,
@@ -34,6 +34,13 @@ pub enum FreshnessVerdict {
 /// A `None` `cached` always returns `ThirdPartyDrift` so the caller
 /// produces a fresh manifest from scratch.
 ///
+/// A `toolr_version` mismatch (binary upgraded since the cache was
+/// built, see #420) always forces at least `StaticDrift`. With
+/// `Some(venv)` it escalates to `ThirdPartyDrift`, since the venv can
+/// be re-globbed. With `None` it stays at `StaticDrift` — escalating
+/// further would make callers discard cached third-party entries with
+/// nothing to replace them.
+///
 /// On `StaticDrift`, call `build_static_manifest` and preserve the cached
 /// third-party entries. On `ThirdPartyDrift`, call
 /// `build_static_manifest_with_venv`; third-party entries come from the
@@ -46,6 +53,18 @@ pub fn compare(
     let Some(cached) = cached else {
         return Ok(FreshnessVerdict::ThirdPartyDrift);
     };
+
+    // Checked first, no I/O: a version mismatch is decided before either
+    // hash is computed, so it never pays for a walk/glob it's going to
+    // discard the result of.
+    if cached.toolr_version != env!("CARGO_PKG_VERSION") {
+        let verdict = if venv_dir.is_some() {
+            FreshnessVerdict::ThirdPartyDrift
+        } else {
+            FreshnessVerdict::StaticDrift
+        };
+        return Ok(verdict);
+    }
 
     let live_static = hash_tools_dir(tools_dir)
         .with_context(|| format!("hashing {}", tools_dir.display()))?;

--- a/crates/toolr-core/src/freshness/mod.rs
+++ b/crates/toolr-core/src/freshness/mod.rs
@@ -6,10 +6,10 @@
 //! completion rebuilds in-memory only or, for third-party drift,
 //! accepts a slightly stale completion result).
 //!
-//! Drift is reported on two axes — local-tools (`.py` content) and
-//! third-party plugin manifests — and collapsed into a single
-//! `FreshnessVerdict` whose variants are ordered by "stronger rebuild
-//! needed."
+//! Drift is reported on three axes — local-tools (`.py` content),
+//! third-party plugin manifests, and the toolr binary's own version —
+//! and collapsed into a single `FreshnessVerdict` whose variants are
+//! ordered by "stronger rebuild needed."
 
 mod compare;
 

--- a/crates/toolr-core/src/freshness/tests.rs
+++ b/crates/toolr-core/src/freshness/tests.rs
@@ -41,6 +41,7 @@ fn manifest_for(tmp: &Path) -> Manifest {
         schema_version: crate::manifest::SCHEMA_VERSION,
         static_hash: hash_tools_dir(&tmp.join("tools")).unwrap(),
         third_party_hash: compute_third_party_hash(&tmp.join("venv")).unwrap(),
+        toolr_version: env!("CARGO_PKG_VERSION").to_string(),
         groups: vec![],
         commands: vec![],
     }
@@ -133,9 +134,56 @@ fn missing_venv_skips_third_party_axis() {
         schema_version: crate::manifest::SCHEMA_VERSION,
         static_hash: crate::hash::hash_tools_dir(&tmp.path().join("tools")).unwrap(),
         third_party_hash: "arbitrary-non-empty-hash".to_string(),
+        toolr_version: env!("CARGO_PKG_VERSION").to_string(),
         groups: vec![],
         commands: vec![],
     };
     let verdict = compare(Some(&cached), &tmp.path().join("tools"), None).unwrap();
     assert!(matches!(verdict, FreshnessVerdict::Fresh));
+}
+
+#[test]
+fn toolr_version_mismatch_with_venv_forces_third_party_drift_even_when_both_axes_match() {
+    // #420: a toolr upgrade alone must invalidate the cache. With a venv
+    // available it's safe to escalate to the strongest verdict.
+    let tmp = TempDir::new().unwrap();
+    make_tools(tmp.path(), &[("a.py", "x = 1\n")]);
+    make_venv(tmp.path(), &[("foo", "{}")]);
+    let mut cached = manifest_for(tmp.path());
+    cached.toolr_version = "0.0.0-old".to_string();
+    let venv = tmp.path().join("venv");
+    let verdict = compare(Some(&cached), &tmp.path().join("tools"), Some(&venv)).unwrap();
+    assert!(matches!(verdict, FreshnessVerdict::ThirdPartyDrift));
+}
+
+#[test]
+fn toolr_version_mismatch_without_venv_only_forces_static_drift() {
+    // Without a venv, escalating to `ThirdPartyDrift` would make the
+    // dispatch-side rebuild discard cached third-party entries with
+    // nothing to replace them. Must cap at `StaticDrift`.
+    let tmp = TempDir::new().unwrap();
+    make_tools(tmp.path(), &[("a.py", "x = 1\n")]);
+    let cached = Manifest {
+        schema_version: crate::manifest::SCHEMA_VERSION,
+        static_hash: crate::hash::hash_tools_dir(&tmp.path().join("tools")).unwrap(),
+        third_party_hash: "arbitrary-non-empty-hash".to_string(),
+        toolr_version: "0.0.0-old".to_string(),
+        groups: vec![],
+        commands: vec![],
+    };
+    let verdict = compare(Some(&cached), &tmp.path().join("tools"), None).unwrap();
+    assert!(matches!(verdict, FreshnessVerdict::StaticDrift));
+}
+
+#[test]
+fn empty_toolr_version_from_a_pre_field_manifest_is_treated_as_a_mismatch() {
+    // Manifests written before this field existed deserialize it as ""
+    // (`#[serde(default)]`), which must never accidentally equal a real
+    // running version and pass as Fresh.
+    let tmp = TempDir::new().unwrap();
+    make_tools(tmp.path(), &[("a.py", "x = 1\n")]);
+    let mut cached = manifest_for(tmp.path());
+    cached.toolr_version = String::new();
+    let verdict = compare(Some(&cached), &tmp.path().join("tools"), None).unwrap();
+    assert!(matches!(verdict, FreshnessVerdict::StaticDrift));
 }

--- a/crates/toolr-core/src/manifest/model.rs
+++ b/crates/toolr-core/src/manifest/model.rs
@@ -23,6 +23,12 @@ pub struct Manifest {
     /// string `""` on manifests predating this field (schema v1).
     #[serde(default)]
     pub third_party_hash: String,
+    /// `CARGO_PKG_VERSION` of the toolr binary that built this manifest.
+    /// A mismatch against the running binary forces a rebuild even if
+    /// `tools/*.py` hasn't changed (see `freshness::compare`). Empty
+    /// string on manifests predating this field.
+    #[serde(default)]
+    pub toolr_version: String,
     pub groups: Vec<Group>,
     pub commands: Vec<Command>,
 }

--- a/crates/toolr-core/src/manifest/tests.rs
+++ b/crates/toolr-core/src/manifest/tests.rs
@@ -5,6 +5,7 @@ fn sample_manifest() -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: "abc123".into(),
         third_party_hash: "".into(),
+        toolr_version: "1.0.0".into(),
         groups: vec![Group {
             name: "ci".into(),
             title: "CI utilities".into(),

--- a/crates/toolr-core/src/parser/build.rs
+++ b/crates/toolr-core/src/parser/build.rs
@@ -151,6 +151,7 @@ fn build_static_manifest_inner(tools_dir: &Path) -> std::result::Result<Manifest
         schema_version: SCHEMA_VERSION,
         static_hash,
         third_party_hash: String::new(),
+        toolr_version: env!("CARGO_PKG_VERSION").to_string(),
         groups: all_groups,
         commands: all_commands,
     };

--- a/crates/toolr-core/src/third_party/tests.rs
+++ b/crates/toolr-core/src/third_party/tests.rs
@@ -257,6 +257,7 @@ fn empty_base() -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: String::new(),
         third_party_hash: String::new(),
+        toolr_version: String::new(),
         groups: vec![],
         commands: vec![],
     }

--- a/crates/toolr-core/tests/skill_authoring_examples.rs
+++ b/crates/toolr-core/tests/skill_authoring_examples.rs
@@ -49,8 +49,14 @@ fn regenerate() {
         .unwrap_or_else(|e| panic!("write {}: {e}", snapshot_path.display()));
 }
 
+/// Redact `toolr_version` before serialising: it's the running binary's
+/// own `CARGO_PKG_VERSION`, which would otherwise drift this snapshot on
+/// every release even though the example tools/ tree hasn't changed.
+/// The snapshot documents manifest *shape*, not a pinned toolr version.
 fn serialise(manifest: &Manifest) -> String {
-    serde_json::to_string_pretty(manifest).expect("serialising the example manifest")
+    let mut manifest = manifest.clone();
+    manifest.toolr_version = "<toolr-version>".to_string();
+    serde_json::to_string_pretty(&manifest).expect("serialising the example manifest")
 }
 
 fn examples_dir() -> PathBuf {

--- a/crates/toolr/src/builtin_completions.rs
+++ b/crates/toolr/src/builtin_completions.rs
@@ -33,6 +33,7 @@ fn empty_manifest() -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: String::new(),
         third_party_hash: String::new(),
+        toolr_version: String::new(),
         groups: Vec::new(),
         commands: Vec::new(),
     }
@@ -200,6 +201,7 @@ mod tests {
             schema_version: SCHEMA_VERSION,
             static_hash: String::new(),
             third_party_hash: String::new(),
+            toolr_version: String::new(),
             groups,
             commands,
         }

--- a/crates/toolr/src/cli.rs
+++ b/crates/toolr/src/cli.rs
@@ -930,6 +930,7 @@ mod cli_tree_tests {
             schema_version: 1,
             static_hash: String::new(),
             third_party_hash: String::new(),
+            toolr_version: String::new(),
             groups: vec![group("jenkins")],
             commands: vec![dispatcher_cmd, migrate, runserver],
         };
@@ -956,6 +957,7 @@ mod cli_tree_tests {
             schema_version: 1,
             static_hash: String::new(),
             third_party_hash: String::new(),
+            toolr_version: String::new(),
             groups: vec![group("docker")],
             commands: vec![build_cmd, image_cmd, build_child, image_child],
         };
@@ -980,6 +982,7 @@ mod cli_tree_tests {
             schema_version: 1,
             static_hash: String::new(),
             third_party_hash: String::new(),
+            toolr_version: String::new(),
             groups: vec![group("jenkins")],
             commands: vec![dispatcher_cmd, migrate, status],
         };
@@ -1272,6 +1275,7 @@ mod cli_tree_tests {
             schema_version: 1,
             static_hash: String::new(),
             third_party_hash: String::new(),
+            toolr_version: String::new(),
             groups: vec![group("django")],
             commands: vec![dispatcher_cmd, migrate],
         };

--- a/crates/toolr/src/dispatch.rs
+++ b/crates/toolr/src/dispatch.rs
@@ -606,6 +606,7 @@ fn empty_manifest_for_completion() -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: String::new(),
         third_party_hash: String::new(),
+        toolr_version: String::new(),
         groups: Vec::new(),
         commands: Vec::new(),
     }
@@ -709,6 +710,7 @@ mod tests {
             schema_version: 1,
             static_hash: String::new(),
             third_party_hash: String::new(),
+            toolr_version: String::new(),
             groups: Vec::new(),
             commands: Vec::new(),
         }
@@ -815,6 +817,7 @@ mod path_lookup_tests {
             schema_version: 1,
             static_hash: String::new(),
             third_party_hash: String::new(),
+            toolr_version: String::new(),
             groups: vec![],
             commands,
         }

--- a/crates/toolr/src/main.rs
+++ b/crates/toolr/src/main.rs
@@ -138,6 +138,7 @@ fn empty_manifest() -> Manifest {
         schema_version: SCHEMA_VERSION,
         static_hash: String::new(),
         third_party_hash: String::new(),
+        toolr_version: String::new(),
         groups: Vec::new(),
         commands: Vec::new(),
     }

--- a/crates/toolr/tests/cli_smoke.rs
+++ b/crates/toolr/tests/cli_smoke.rs
@@ -238,11 +238,13 @@ fn preflight_fixture(
     let venv_dir = tools.join(".venv");
     let third_party_hash =
         toolr_core::manifest_build::compute_third_party_hash(&venv_dir).unwrap();
+    let toolr_version = env!("CARGO_PKG_VERSION");
 
     let manifest = format!(
         r#"{{
             "schema_version": 1,
             "static_hash": "{static_hash}", "third_party_hash": "{third_party_hash}",
+            "toolr_version": "{toolr_version}",
             "groups": [{{
                 "name": "ci", "title": "CI", "description": "",
                 "origin": "static"

--- a/crates/toolr/tests/freshness_dispatch.rs
+++ b/crates/toolr/tests/freshness_dispatch.rs
@@ -183,6 +183,72 @@ fn skip_list_argv_does_not_trigger_freshness() {
 }
 
 #[test]
+fn version_mismatch_without_venv_preserves_third_party_entries() {
+    // #420 regression guard: a toolr-version mismatch must not escalate
+    // to `ThirdPartyDrift` when the venv can't be resolved — that would
+    // discard cached third-party entries with nothing to re-glob them
+    // from. Force venv resolution to fail via an invalid
+    // `TOOLR_VENV_LOCATION`, seed a manifest with a matching static_hash
+    // but a stale `toolr_version` and a third-party group/command, and
+    // confirm the rebuild keeps the third-party entries and still
+    // stamps the current version.
+    let tmp = TempDir::new().unwrap();
+    let tools = tmp.path().join("tools");
+    fs::create_dir_all(&tools).unwrap();
+    fs::write(
+        tools.join("pyproject.toml"),
+        "[project]\nname = \"tools\"\nversion = \"0.0.0\"\n",
+    )
+    .unwrap();
+
+    let static_hash = toolr_core::hash::hash_tools_dir(&tools).unwrap();
+    let manifest = format!(
+        r#"{{
+            "schema_version": 1,
+            "static_hash": "{static_hash}",
+            "third_party_hash": "",
+            "toolr_version": "0.0.0-old",
+            "groups": [
+                {{"name": "plugin", "title": "Plugin", "description": "", "parent": null, "origin": "third_party"}}
+            ],
+            "commands": [
+                {{
+                    "name": "run", "group": "plugin", "module": "plugin_pkg.commands",
+                    "function": "run", "summary": "", "description": "",
+                    "arguments": [], "origin": "third_party"
+                }}
+            ]
+        }}"#
+    );
+    fs::write(tools.join(".toolr-manifest.json"), manifest).unwrap();
+
+    let output = Command::cargo_bin("toolr")
+        .unwrap()
+        .arg("--help")
+        .current_dir(tmp.path())
+        .env("TOOLR_VENV_LOCATION", "bogus")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "toolr --help failed: {output:?}");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("plugin"),
+        "expected cached third-party group in --help; got:\n{stdout}"
+    );
+
+    let manifest = fs::read_to_string(tools.join(".toolr-manifest.json")).unwrap();
+    assert!(
+        manifest.contains(r#""name": "run""#) || manifest.contains(r#""name":"run""#),
+        "third-party command dropped from persisted manifest:\n{manifest}"
+    );
+    assert!(
+        !manifest.contains("0.0.0-old"),
+        "stale toolr_version was not refreshed:\n{manifest}"
+    );
+}
+
+#[test]
 fn tab_completion_does_not_persist_manifest() {
     let tmp = TempDir::new().unwrap();
     write_minimal_project(tmp.path());

--- a/docs/internals/manifest.md
+++ b/docs/internals/manifest.md
@@ -6,10 +6,11 @@ and clap's subcommand-tree build all read from this single file — no
 Python imports involved in the hot path.
 
 !!! note "It's a cache — don't commit it"
-    The manifest is regenerated automatically when the static or
-    dynamic hashes drift, and the static layer alone rebuilds in
-    ~10 ms on typical projects. `toolr project init` adds the file
-    to `tools/.gitignore` for you. Committing it just produces noisy
+    The manifest is regenerated automatically when the static hash,
+    the third-party hash, or the toolr binary's own version drifts,
+    and the static layer alone rebuilds in ~10 ms on typical
+    projects. `toolr project init` adds the file to
+    `tools/.gitignore` for you. Committing it just produces noisy
     merge conflicts on every `tools/` edit without buying anything
     the auto-rebuild doesn't already cover.
 
@@ -20,6 +21,7 @@ Python imports involved in the hot path.
   "schema_version": 1,
   "static_hash": "<blake3 hex>",
   "third_party_hash": "<blake3 hex>",
+  "toolr_version": "<CARGO_PKG_VERSION>",
   "groups": [...],
   "commands": [...]
 }
@@ -36,8 +38,15 @@ Python imports involved in the hot path.
   rebuilds: installing an unrelated package no longer invalidates
   the manifest, only changes to packages that ship a toolr
   fragment do.
+- **`toolr_version`** — the `toolr` binary's own version at the time
+  it built this manifest. A mismatch against the running binary means
+  toolr itself was upgraded (parsing/classification behaviour may have
+  changed with no `tools/*.py` edit at all) and always forces at least
+  a static rebuild; with a venv available to re-glob, it forces a full
+  rebuild instead. Deserializes as `""` on older manifests, which also
+  forces one rebuild.
 - **`groups`** / **`commands`** — the actual command tree. Each
-  entry carries an `origin` field (`"static"` or `"dynamic"`)
+  entry carries an `origin` field (`"static"` or `"third_party"`)
   recording which layer produced it.
 
 ## Group schema
@@ -142,29 +151,28 @@ without a working venv. Captures:
   files via a symbol table).
 
 The static layer is rebuilt when toolr detects `static_hash` drift
-against the on-disk files.
+against the on-disk files, or when the cached `toolr_version` doesn't
+match the running binary — an upgrade forces a static rebuild even if
+`tools/*.py` hasn't changed at all.
 
-## Dynamic layer
+## Third-party layer
 
-Built by spawning `python -m toolr._introspect --tools-root <tools>`
-inside the resolved tools venv. The helper:
+Contributed by installed packages that ship a static
+`toolr-manifest.json` fragment inside their wheel, discovered by
+globbing `<tools-venv>/lib/python*/site-packages/*/` and merged into
+the static layer at build time (see
+[Third-party packages](../third-party.md)). No Python import happens
+during discovery — it's an execution-free glob-and-parse, same as
+the static layer.
 
-1. Inserts `<tools>/..` on `sys.path` so `import tools` works.
-2. Imports every `tools.*` module — registering every
-   `command_group` / `@command` call. Catches dynamically-registered
-   commands the static AST parser can't see (e.g. registrations
-   inside `for` loops or conditionals).
-3. Dumps a JSON payload to stdout describing the merged registry.
+Toolr regenerates the manifest when:
 
-Third-party packages are **not** discovered through this layer.
-They contribute via static `toolr-manifest.json` fragments shipped
-inside the wheel and merged at static-build time
-(see [Third-party packages](../third-party.md)).
-
-Toolr regenerates the dynamic layer when:
-
-- A command is invoked and the binary detects `static_hash` drift
-  on entry (the dynamic layer runs alongside the static rebuild).
+- A command is invoked and the binary detects `static_hash` or
+  `third_party_hash` drift on entry.
+- The cached `toolr_version` doesn't match the running binary — an
+  upgrade always forces at least a static rebuild regardless of
+  `static_hash`, and forces a rebuild of both layers when a venv is
+  available to re-glob third-party fragments too.
 - The user explicitly runs `toolr project manifest rebuild`.
 
 ## Manual rebuild
@@ -173,9 +181,9 @@ Toolr regenerates the dynamic layer when:
 toolr project manifest rebuild
 ```
 
-Runs both layers and writes the merged result. Used by the shipped
-pre-commit hook (see [Pre-commit integration](pre-commit.md)) and
-available for explicit invocation when you want to be sure the
+Rebuilds both layers and writes the merged result. Used by the
+shipped pre-commit hook (see [Pre-commit integration](pre-commit.md))
+and available for explicit invocation when you want to be sure the
 manifest is current — for example before publishing a release that
 includes new commands.
 
@@ -196,3 +204,9 @@ Both hashes use blake3, written as lowercase hex.
 
 This gives stable, content-addressable rebuild decisions across
 machines and across CI / dev environments.
+
+`toolr_version` costs no I/O to check, so a mismatch always wins over
+a matching hash — a toolr upgrade forces at least `StaticDrift`, and
+forces the stronger `ThirdPartyDrift` too when a venv is available to
+re-glob (see the `toolr_version` field description above for why a
+missing venv caps it at `StaticDrift` instead).

--- a/docs/writing-commands/testing.md
+++ b/docs/writing-commands/testing.md
@@ -25,8 +25,8 @@ subprocess execution) you'll still want to drive the binary directly.
 2. Patches `toolr._decorators._get_command_group_storage` with a fresh `dict` so the test gets an isolated registry.
 3. Restores everything on exit (`sys.path`, `sys.modules`, `cwd`).
 
-Calling `.discover()` inside the context runs the same `tools/`-import pass that
-`python -m toolr._introspect` runs for the Rust binary's dynamic manifest layer. After it returns,
+Calling `.discover()` inside the context imports every `tools/*.py` module, registering each
+`command_group` / `@command` call exactly as a real `import tools.*` would. After it returns,
 `.collected_command_groups()` gives you a `{full_name: CommandGroup}` dict you can assert against.
 
 ## Usage

--- a/skills/toolr-command-authoring/examples/toolr-manifest.json
+++ b/skills/toolr-command-authoring/examples/toolr-manifest.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "static_hash": "bd32800ac4592c0ec26de6a9b12575238ba57e589898d1d656d6f314ef4e7423",
   "third_party_hash": "",
+  "toolr_version": "<toolr-version>",
   "groups": [
     {
       "name": "db",

--- a/skills/toolr-command-packaging/references/packaging.md
+++ b/skills/toolr-command-packaging/references/packaging.md
@@ -128,6 +128,12 @@ pub struct Manifest {
     /// string `""` on manifests predating this field (schema v1).
     #[serde(default)]
     pub third_party_hash: String,
+    /// `CARGO_PKG_VERSION` of the toolr binary that built this manifest.
+    /// A mismatch against the running binary forces a rebuild even if
+    /// `tools/*.py` hasn't changed (see `freshness::compare`). Empty
+    /// string on manifests predating this field.
+    #[serde(default)]
+    pub toolr_version: String,
     pub groups: Vec<Group>,
     pub commands: Vec<Command>,
 }


### PR DESCRIPTION
## Summary

`tools/.toolr-manifest.json`'s freshness check only compared `tools/*.py`
content hashes and third-party plugin manifest hashes against the cache. A
`toolr` upgrade that changes CLI-parsing or argument-classification
behaviour (e.g. #413/#415, which reclassified some flags from
`kind: "optional"` to `kind: "repeated"`) touches neither hash, so the
stale manifest silently stays in use — with the old, wrong behaviour —
until someone thinks to run `toolr project manifest rebuild --force`.

## Fix

- Stamp `Manifest.toolr_version` with the `toolr` binary's own
  `CARGO_PKG_VERSION` on every build.
- `freshness::compare` checks it first, ahead of any hashing, so a
  mismatch never pays for a walk/glob it's going to discard.
- A mismatch always forces at least a static rebuild. It only escalates to
  a full rebuild of both layers when a tools venv is available to re-glob
  third-party fragments — escalating without one would make the
  dispatch-side rebuild discard cached third-party entries with nothing to
  repopulate them from (verified with a dedicated regression test).
- Manifests predating this field deserialize `toolr_version` as `""`,
  which never matches a real version, so they get one rebuild too.

## Testing

- `cargo test --workspace` (508 tests in `toolr-core`'s lib target alone,
  0 failures across every crate).
- `mise run test` umbrella (skill-refs drift gate + cargo test + pytest),
  clean.
- `mkdocs build --strict`, clean.
- `prek run` on all touched files, clean.
- New unit tests in `crates/toolr-core/src/freshness/tests.rs` covering:
  version mismatch + venv → full rebuild; version mismatch without a venv
  → static-only rebuild; the `""`-from-a-pre-field-manifest migration
  case.
- New integration test in `crates/toolr/tests/freshness_dispatch.rs`
  (`version_mismatch_without_venv_preserves_third_party_entries`),
  verified to actually fail if the fix is reverted.
- This diff went through three rounds of adversarial review (two by fresh
  subagents with no prior context), each of which found and fixed a real
  issue before landing clean.

Closes #420.
