### PR TITLE
fix(runner): return exit code 130 on KeyboardInterrupt instead of a raw traceback

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,3 +18,8 @@ no scaffolding. Just write whatever should appear in the notes.
   days"` dependency cooldown, inherited by `tools/`, is meant for
   third-party releases; `toolr-py` is exempted from it specifically since
   it ships from the same release as the binary that runs against it.
+- Fixed Ctrl-C during a running command printing a raw Python traceback
+  and exiting with an arbitrary code instead of the conventional 130.
+  The toolr binary already forwards SIGINT to the Python runner
+  subprocess; the runner now catches the resulting `KeyboardInterrupt`
+  and exits 130 cleanly instead of leaking it as an unhandled exception.

--- a/crates/toolr-py/python/toolr/_runner.py
+++ b/crates/toolr-py/python/toolr/_runner.py
@@ -556,6 +556,14 @@ def run(spec: RunnerSpec) -> int:  # noqa: PLR0911
         traceback.print_exc(file=sys.stderr)
         _print_missing_dep_hint(exc, sys.stderr)
         return 1
+    except KeyboardInterrupt:
+        # SIGINT forwarded from the parent toolr process (see
+        # `crates/toolr-core/src/execute/signals.rs`) surfaces here as
+        # `KeyboardInterrupt`, not a process-level signal death — so the
+        # Rust side's "128 + signal" exit-code logic never sees it. Match
+        # the conventional shell exit code (128 + SIGINT) ourselves rather
+        # than letting the interpreter print its default traceback.
+        return 130
     except Exception:  # noqa: BLE001
         traceback.print_exc(file=sys.stderr)
         return 1

--- a/tests/runner/test_runner_coverage.py
+++ b/tests/runner/test_runner_coverage.py
@@ -550,6 +550,20 @@ def test_run_returns_1_on_unhandled_exception(
     assert "toolr project venv sync" not in err
 
 
+def test_run_returns_130_on_keyboard_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_target(ctx, **_kw) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("toolr._runner._import_target", lambda _spec: fake_target)
+    assert run(_runner_spec(repo_root=tmp_path)) == 130
+    # No traceback noise — Ctrl-C is expected user behaviour, not a bug.
+    assert capsys.readouterr().err == ""
+
+
 def test_run_emits_missing_dep_hint_for_function_body_importerror(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## What

Ctrl-C during a running command dumped a raw Python traceback and exited
with an arbitrary code instead of the conventional `130`.

## Why

`crates/toolr-core/src/execute/signals.rs` already forwards `SIGINT`/`SIGTERM`
from the parent `toolr` process to the Python runner subprocess. On the
Python side that forwarded `SIGINT` surfaces as `KeyboardInterrupt` — a
`BaseException`, not an `Exception` — so `run()`'s catch-all `except
Exception` in `_runner.py` never caught it. It fell through to CPython's
default traceback printer, and the exit code ended up being whatever the
interpreter happened to pick rather than the shell-conventional `128 + SIGINT`.

## Fix

Catch `KeyboardInterrupt` explicitly in `run()` and return `130`, ahead of
the bare `except Exception`. No traceback noise — Ctrl-C is expected user
behaviour, not a bug.

## Testing

- Added `test_run_returns_130_on_keyboard_interrupt` in
  `tests/runner/test_runner_coverage.py`, asserting exit code `130` and
  empty stderr.
- `uv run pytest tests/runner/test_runner_coverage.py -q` — 60 passed.
- Queued a release note in `UNRELEASED.md`.
