### PR TITLE
fix(parser): classify list[T] | None / tuple[...] | None as repeatable

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,3 +23,10 @@ no scaffolding. Just write whatever should appear in the notes.
   The toolr binary already forwards SIGINT to the Python runner
   subprocess; the runner now catches the resulting `KeyboardInterrupt`
   and exits 130 cleanly instead of leaking it as an unhandled exception.
+- Fixed `list[T] | None` and `tuple[...] | None` keyword parameters
+  being classified as single-value flags instead of repeatable ones,
+  so `--items a` failed the runner's `array | null` type check and
+  `--items a --items b` was rejected by clap as a repeated single-value
+  flag. The syntactic classifier couldn't see through the `| None`
+  union; the type resolver already could, so the fix promotes the
+  argument's kind from the resolved type once it's known.

--- a/crates/toolr-core/src/parser/commands.rs
+++ b/crates/toolr-core/src/parser/commands.rs
@@ -528,6 +528,89 @@ def check_snippets(ctx):
     }
 
     #[test]
+    fn optional_list_keyword_resolves_to_repeated() {
+        // Regression for #435: `list[T] | None` was classified as
+        // `Optional` (single-value) by the syntactic pass, since it
+        // can't see through the `| None` union — only the post-resolution
+        // override in `resolve_arguments` catches it.
+        let src = r#"command_group("repro", "Repro")
+
+@command(group="repro")
+def go(ctx, items: list[str] | None = None):
+    """Repro."""
+    pass
+"#;
+        let m = parse_src(src);
+        let bindings = extract_groups(&m, "", &HashMap::new());
+        let commands = extract_commands(
+            &m,
+            "tools.repro",
+            &bindings,
+            &EnumTable::default(),
+            &ConstTable::default(),
+            &TypeImports::default(),
+            &SourcesImports::default(),
+            &TypeAliasTable::default(),
+            &ArgSectionTable::default(),
+            &HashMap::new(),
+            &mut Vec::new(),
+        );
+        assert_eq!(commands.len(), 1);
+        let items = &commands[0].arguments[0];
+        assert_eq!(items.name, "items");
+        assert_eq!(items.kind, crate::manifest::ArgumentKind::Repeated);
+        assert_eq!(
+            items.resolved_type,
+            Some(crate::parser::types::SupportedType::Optional(Box::new(
+                crate::parser::types::SupportedType::List(Box::new(
+                    crate::parser::types::SupportedType::Str
+                ))
+            )))
+        );
+    }
+
+    #[test]
+    fn optional_tuple_keyword_resolves_to_repeated() {
+        // Same fix as `optional_list_keyword_resolves_to_repeated`, for
+        // the other collection shape `is_list_like_annotation` accepts.
+        let src = r#"command_group("repro", "Repro")
+
+@command(group="repro")
+def go(ctx, pair: tuple[str, int] | None = None):
+    """Repro."""
+    pass
+"#;
+        let m = parse_src(src);
+        let bindings = extract_groups(&m, "", &HashMap::new());
+        let commands = extract_commands(
+            &m,
+            "tools.repro",
+            &bindings,
+            &EnumTable::default(),
+            &ConstTable::default(),
+            &TypeImports::default(),
+            &SourcesImports::default(),
+            &TypeAliasTable::default(),
+            &ArgSectionTable::default(),
+            &HashMap::new(),
+            &mut Vec::new(),
+        );
+        assert_eq!(commands.len(), 1);
+        let pair = &commands[0].arguments[0];
+        assert_eq!(pair.name, "pair");
+        assert_eq!(pair.kind, crate::manifest::ArgumentKind::Repeated);
+        assert_eq!(
+            pair.resolved_type,
+            Some(crate::parser::types::SupportedType::Optional(Box::new(
+                crate::parser::types::SupportedType::Tuple(vec![
+                    crate::parser::types::SupportedType::Str,
+                    crate::parser::types::SupportedType::Int,
+                ])
+            )))
+        );
+    }
+
+    #[test]
     fn legacy_decorator_rejects_positional_and_name_keyword() {
         let src = r#"group = command_group("ci", "CI")
 

--- a/crates/toolr-core/src/parser/types/resolve.rs
+++ b/crates/toolr-core/src/parser/types/resolve.rs
@@ -137,6 +137,16 @@ fn resolve_one(
             // and module-level aliases.
             if is_count_type(&ty) {
                 arg.kind = ArgumentKind::Count;
+            } else if arg.kind == ArgumentKind::Optional && is_optional_list_or_tuple(&ty) {
+                // `list[T] | None` / `tuple[...] | None` (or
+                // `Annotated`/alias equivalents): the syntactic classifier
+                // can't see through the union, so it defaulted to a
+                // single-value `Optional` keyword. Promote it to
+                // `Repeated` now that the resolved type confirms the
+                // element is a list or tuple — matches how the bare
+                // (non-`Optional`) shape is already classified, and
+                // mirrors the `Count` override above.
+                arg.kind = ArgumentKind::Repeated;
             }
             arg.resolved_type = Some(ty);
         }
@@ -153,6 +163,10 @@ fn resolve_one(
 fn is_count_type(ty: &SupportedType) -> bool {
     matches!(ty, SupportedType::Count)
         || matches!(ty, SupportedType::Optional(inner) if matches!(inner.as_ref(), SupportedType::Count))
+}
+
+fn is_optional_list_or_tuple(ty: &SupportedType) -> bool {
+    matches!(ty, SupportedType::Optional(inner) if matches!(inner.as_ref(), SupportedType::List(_) | SupportedType::Tuple(_)))
 }
 
 fn follow_alias_for_path_constraints(

--- a/crates/toolr/src/execute_build.rs
+++ b/crates/toolr/src/execute_build.rs
@@ -261,7 +261,7 @@ fn extract_value(arg: &Argument, matches: &ArgMatches) -> Option<Value> {
         Some(SupportedType::Tuple(_))
     );
     if is_tuple {
-        return Some(Value::Array(extract_many(arg, matches)));
+        return extract_optional_many(arg, matches);
     }
     match arg.kind {
         ArgumentKind::Flag => {
@@ -279,9 +279,8 @@ fn extract_value(arg: &Argument, matches: &ArgMatches) -> Option<Value> {
         ArgumentKind::Positional | ArgumentKind::Optional | ArgumentKind::OptionalPositional => {
             extract_scalar(arg, matches)
         }
-        ArgumentKind::Repeated | ArgumentKind::VarPositional => {
-            Some(Value::Array(extract_many(arg, matches)))
-        }
+        ArgumentKind::Repeated => extract_optional_many(arg, matches),
+        ArgumentKind::VarPositional => Some(Value::Array(extract_many(arg, matches))),
         ArgumentKind::FixedArity => {
             // Positional-style is always `required(true)`, so it's
             // always present when parsing succeeds — but keyword-style
@@ -296,6 +295,22 @@ fn extract_value(arg: &Argument, matches: &ArgMatches) -> Option<Value> {
                 None
             }
         }
+    }
+}
+
+/// Multi-value extraction for `list[T] | None` / `tuple[...] | None`
+/// (kind `Repeated`, or `Tuple`'s early-return above). An omitted flag
+/// has no clap value to collect, but the wire value must stay absent
+/// too — so the Python function's own `= None` default runs — rather
+/// than sending `[]`, which would silently turn `None` into an empty
+/// collection (and, for a fixed-arity tuple, fail its own schema).
+fn extract_optional_many(arg: &Argument, matches: &ArgMatches) -> Option<Value> {
+    if !matches.contains_id(arg.name.as_str())
+        && matches!(arg.resolved_type.as_ref(), Some(SupportedType::Optional(_)))
+    {
+        None
+    } else {
+        Some(Value::Array(extract_many(arg, matches)))
     }
 }
 
@@ -792,6 +807,44 @@ mod tests {
     }
 
     #[test]
+    fn build_spec_omits_optional_repeated_when_absent() {
+        // Regression for #435: `list[T] | None` is promoted to
+        // `Repeated`, but an omitted flag must stay absent from the
+        // wire spec (not `[]`) so the Python function's own `= None`
+        // default runs.
+        let cmd = cmd_with(vec![arg_of(
+            "items",
+            ArgumentKind::Repeated,
+            SupportedType::Optional(Box::new(SupportedType::List(Box::new(SupportedType::Str)))),
+        )]);
+        let matches = clap::Command::new("test")
+            .arg(Arg::new("items").long("items").action(ArgAction::Append))
+            .get_matches_from(["test"]);
+        let spec = build_spec(&cmd, &matches, Path::new("/repo"), &OutputOptions::default());
+        assert_eq!(spec.args.get("items"), None);
+    }
+
+    #[test]
+    fn build_spec_extracts_optional_repeated_when_present() {
+        let cmd = cmd_with(vec![arg_of(
+            "items",
+            ArgumentKind::Repeated,
+            SupportedType::Optional(Box::new(SupportedType::List(Box::new(SupportedType::Str)))),
+        )]);
+        let matches = clap::Command::new("test")
+            .arg(Arg::new("items").long("items").action(ArgAction::Append))
+            .get_matches_from(["test", "--items", "a", "--items", "b"]);
+        let spec = build_spec(&cmd, &matches, Path::new("/repo"), &OutputOptions::default());
+        assert_eq!(
+            spec.args.get("items"),
+            Some(&Value::Array(vec![
+                Value::String("a".into()),
+                Value::String("b".into()),
+            ])),
+        );
+    }
+
+    #[test]
     fn build_spec_extracts_repeated_path_as_json_strings() {
         let cmd = cmd_with(vec![arg_of(
             "files",
@@ -840,6 +893,28 @@ mod tests {
                 Value::String("42".into()),
             ])),
         );
+    }
+
+    #[test]
+    fn build_spec_omits_optional_tuple_when_absent() {
+        // Regression for #435 (tuple half): `tuple[...] | None` resolves
+        // as `Optional(Tuple(_))`, which the `is_tuple` early-return
+        // above would otherwise route straight to `extract_many` and
+        // send `[]` for an omitted flag — failing the tuple's own
+        // fixed-arity schema instead of letting `= None` run.
+        let cmd = cmd_with(vec![arg_of(
+            "pair",
+            ArgumentKind::Repeated,
+            SupportedType::Optional(Box::new(SupportedType::Tuple(vec![
+                SupportedType::Str,
+                SupportedType::Int,
+            ]))),
+        )]);
+        let matches = clap::Command::new("test")
+            .arg(Arg::new("pair").long("pair").num_args(2))
+            .get_matches_from(["test"]);
+        let spec = build_spec(&cmd, &matches, Path::new("/repo"), &OutputOptions::default());
+        assert_eq!(spec.args.get("pair"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `classify_keyword_kind` peels `Annotated[...]` but never `X | None`, so
  `list[str] | None` / `tuple[...] | None` fell through to a single-value
  `Optional` kind instead of `Repeated`. One value tripped the runner's
  `array | null` type check; two values were rejected by clap as a
  repeated single-value flag.
- The type resolver already understood the union correctly
  (`Optional(List/Tuple(...))`), so the fix promotes the kind from the
  resolved type once it's known — mirroring the existing `Count` override
  in the same function.
- Also fixes a related bug in `execute_build`'s tuple early-return, which
  would otherwise send `[]` for an omitted `Optional`-wrapped tuple flag
  instead of leaving it absent for the Python `= None` default to run.

## Test plan
- [x] `cargo test --workspace` — all green
- [x] `mise run test` (skill-refs drift gate + cargo test + pytest) — all green
- [x] New regression tests: `commands.rs::optional_list_keyword_resolves_to_repeated`,
      `commands.rs::optional_tuple_keyword_resolves_to_repeated`,
      `execute_build.rs::build_spec_omits_optional_repeated_when_absent`,
      `execute_build.rs::build_spec_extracts_optional_repeated_when_present`,
      `execute_build.rs::build_spec_omits_optional_tuple_when_absent`

Fixes #435