### PR TITLE
fix(precommit): point mypy hook at the real toolr-py source path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
 
       - id: mypy
         name: Run mypy against the code base
-        files: ^(python/|tests/).*\.py$
+        files: ^(crates/toolr-py/python/|tests/).*\.py$
         exclude: ^tests/support/coverage/.*\.py$
 
       - id: uv-lock


### PR DESCRIPTION
The mypy pre-commit hook's `files` glob referenced a top-level `python/` directory that never existed in this repo — the actual package source lives at `crates/toolr-py/python/`.

As a result, a commit touching only source files (no test file) never triggered mypy, either locally or in CI (`prek run --all-files` filters by the same regex).

mypy was already checking the source transitively via test imports (`follow_imports = normal`), so this was a silent gap rather than a live breakage. Confirmed clean both before and after the fix:

```
mypy tests                          → 4 errors (all intentional broken-import test fixtures)
mypy crates/toolr-py/python/toolr    → Success: no issues found in 22 source files
```