### PR TITLE
fix(docs): drop navigation.tabs so all top-level pages stay reachable

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,6 @@ theme:
     - navigation.instant.progress
     - navigation.path
     - navigation.sections
-    - navigation.tabs
     - navigation.top
     - navigation.tracking
     - search.suggest


### PR DESCRIPTION
Material's tab bar has no overflow menu, so with 15 top-level nav
entries the tabs past 'Third-party packages' were clipped off-screen
with no way to reach them. Nav now renders in the sidebar only, where
everything scrolls and every link is reachable.