### PR TITLE
fix(argparse): keep zero-arg Django management commands in the scanner

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,7 +17,9 @@ no scaffolding. Just write whatever should appear in the notes.
   for "this isn't a real command," which also matched genuine zero-arg
   commands. A new opt-in `django = true` block setting recognises a
   module-level `class Command(...)` or `Command = <Name>` alias to a
-  same-module class — Django's own loader contract — and skips
-  underscore-prefixed filenames outright, so zero-arg commands are kept
-  and stray helper modules are still excluded. Plain argparse blocks
-  (the default) are unaffected.
+  same-module class — Django's own loader contract — so zero-arg
+  commands are kept while stray helper modules are still excluded.
+  Plain argparse blocks (the default) are unaffected. Separately,
+  underscore-prefixed filenames (`_helpers.py`, `__init__.py`) are now
+  skipped outright for every block, Django or not — that convention is
+  plain Python, not Django-specific.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,13 @@ this file to empty for the next cycle.
 Empty between releases is the steady-state — there's no header,
 no scaffolding. Just write whatever should appear in the notes.
 -->
+- Fixed the built-in argparse scanner (`[tool.toolr.argparse.*]`) silently
+  dropping Django management commands that take no CLI arguments at all —
+  e.g. a `BaseCommand` subclass with no `add_arguments` method, such as a
+  long-running queue consumer. The scanner used "found zero
+  `add_argument()` calls" as its only signal for "this isn't a real
+  command," which also matched genuine zero-arg commands. It now also
+  recognises a module-level `class Command(...)` or `Command = <Name>`
+  alias to a same-module class — Django's own loader contract — and skips
+  underscore-prefixed filenames outright, so zero-arg commands are kept
+  and stray helper modules are still excluded.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,11 +12,12 @@ no scaffolding. Just write whatever should appear in the notes.
 -->
 - Fixed the built-in argparse scanner (`[tool.toolr.argparse.*]`) silently
   dropping Django management commands that take no CLI arguments at all —
-  e.g. a `BaseCommand` subclass with no `add_arguments` method, such as a
-  long-running queue consumer. The scanner used "found zero
-  `add_argument()` calls" as its only signal for "this isn't a real
-  command," which also matched genuine zero-arg commands. It now also
-  recognises a module-level `class Command(...)` or `Command = <Name>`
-  alias to a same-module class — Django's own loader contract — and skips
+  e.g. a `BaseCommand` subclass with no `add_arguments` method. The
+  scanner used "found zero `add_argument()` calls" as its only signal
+  for "this isn't a real command," which also matched genuine zero-arg
+  commands. A new opt-in `django = true` block setting recognises a
+  module-level `class Command(...)` or `Command = <Name>` alias to a
+  same-module class — Django's own loader contract — and skips
   underscore-prefixed filenames outright, so zero-arg commands are kept
-  and stray helper modules are still excluded.
+  and stray helper modules are still excluded. Plain argparse blocks
+  (the default) are unaffected.

--- a/crates/toolr-core/src/argparse/attach.rs
+++ b/crates/toolr-core/src/argparse/attach.rs
@@ -316,6 +316,7 @@ mod tests {
             description: "".into(),
             arguments: vec![],
             warnings: vec![],
+            is_command_class: false,
         }];
         let children = graft_children(&block, &scanned, &parents_with_django()).unwrap();
         assert_eq!(children.len(), 1);

--- a/crates/toolr-core/src/argparse/attach.rs
+++ b/crates/toolr-core/src/argparse/attach.rs
@@ -199,6 +199,7 @@ mod tests {
             name: name.into(),
             scan_paths: vec![],
             common_args: vec![],
+            django: false,
             attach: vec![Attachment {
                 parent: parent.into(),
             }],
@@ -306,6 +307,7 @@ mod tests {
             name: "django".into(),
             scan_paths: vec![],
             common_args: vec![],
+            django: false,
             attach: vec![Attachment {
                 parent: "django".into(),
             }],

--- a/crates/toolr-core/src/argparse/attach.rs
+++ b/crates/toolr-core/src/argparse/attach.rs
@@ -318,7 +318,7 @@ mod tests {
             description: "".into(),
             arguments: vec![],
             warnings: vec![],
-            is_command_class: false,
+            is_django_command_class: false,
         }];
         let children = graft_children(&block, &scanned, &parents_with_django()).unwrap();
         assert_eq!(children.len(), 1);

--- a/crates/toolr-core/src/argparse/config.rs
+++ b/crates/toolr-core/src/argparse/config.rs
@@ -19,12 +19,11 @@ pub struct ArgparseBlock {
     pub common_args: Vec<CommonArg>,
     #[serde(default)]
     pub attach: Vec<Attachment>,
-    /// Opt in to Django management-command conventions for this block: a scanned file with zero
-    /// `add_argument()` calls is still kept as a command if it defines Django's `Command` entry
-    /// point (`class Command(...)`, or `Command = <Name>` aliased to a same-module class), and
-    /// underscore-prefixed filenames are skipped outright. Plain argparse blocks (the default) keep
-    /// neither behaviour — a file with no `add_argument()` calls is always treated as a non-command
-    /// helper, regardless of its name or class shape.
+    /// Opt in to the Django `Command`-entry-point convention for this block: a scanned file with
+    /// zero `add_argument()` calls is still kept as a command if it defines Django's `Command`
+    /// entry point (`class Command(...)`, or `Command = <Name>` aliased to a same-module class).
+    /// Plain argparse blocks (the default) treat a zero-arg file as a non-command helper,
+    /// regardless of its name or class shape.
     #[serde(default)]
     pub django: bool,
 }

--- a/crates/toolr-core/src/argparse/config.rs
+++ b/crates/toolr-core/src/argparse/config.rs
@@ -19,14 +19,12 @@ pub struct ArgparseBlock {
     pub common_args: Vec<CommonArg>,
     #[serde(default)]
     pub attach: Vec<Attachment>,
-    /// Opt in to Django management-command conventions for this block:
-    /// a scanned file with zero `add_argument()` calls is still kept as
-    /// a command if it defines Django's `Command` entry point (`class
-    /// Command(...)`, or `Command = <Name>` aliased to a same-module
-    /// class), and underscore-prefixed filenames are skipped outright.
-    /// Plain argparse blocks (the default) keep neither behaviour — a
-    /// file with no `add_argument()` calls is always treated as a
-    /// non-command helper, regardless of its name or class shape.
+    /// Opt in to Django management-command conventions for this block: a scanned file with zero
+    /// `add_argument()` calls is still kept as a command if it defines Django's `Command` entry
+    /// point (`class Command(...)`, or `Command = <Name>` aliased to a same-module class), and
+    /// underscore-prefixed filenames are skipped outright. Plain argparse blocks (the default) keep
+    /// neither behaviour — a file with no `add_argument()` calls is always treated as a non-command
+    /// helper, regardless of its name or class shape.
     #[serde(default)]
     pub django: bool,
 }

--- a/crates/toolr-core/src/argparse/config.rs
+++ b/crates/toolr-core/src/argparse/config.rs
@@ -19,6 +19,16 @@ pub struct ArgparseBlock {
     pub common_args: Vec<CommonArg>,
     #[serde(default)]
     pub attach: Vec<Attachment>,
+    /// Opt in to Django management-command conventions for this block:
+    /// a scanned file with zero `add_argument()` calls is still kept as
+    /// a command if it defines Django's `Command` entry point (`class
+    /// Command(...)`, or `Command = <Name>` aliased to a same-module
+    /// class), and underscore-prefixed filenames are skipped outright.
+    /// Plain argparse blocks (the default) keep neither behaviour — a
+    /// file with no `add_argument()` calls is always treated as a
+    /// non-command helper, regardless of its name or class shape.
+    #[serde(default)]
+    pub django: bool,
 }
 
 impl ArgparseBlock {

--- a/crates/toolr-core/src/argparse/mod.rs
+++ b/crates/toolr-core/src/argparse/mod.rs
@@ -64,10 +64,11 @@ pub fn run_for_project(
     let mut out: HashMap<String, Vec<Command>> = HashMap::new();
     let mut dispatchers: HashSet<String> = HashSet::new();
     for block in &blocks {
-        let scanned: Vec<scan::ScannedCommand> = scan::scan_block_paths(project_root, &block.scan_paths)?
-            .into_iter()
-            .map(|s| scan::with_common_args(s, &block.common_args))
-            .collect();
+        let scanned: Vec<scan::ScannedCommand> =
+            scan::scan_block_paths(project_root, &block.scan_paths, block.django)?
+                .into_iter()
+                .map(|s| scan::with_common_args(s, &block.common_args))
+                .collect();
         for (parent, children) in attach::graft_children(block, &scanned, parents)? {
             if !children.is_empty() {
                 dispatchers.insert(parent.clone());

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -535,16 +535,15 @@ fn split_docstring(raw: &str) -> (String, String) {
 
 use std::path::Path;
 
-/// Expand every glob in `scan_paths` against `root`, scan each match,
-/// and return one `ScannedCommand` per file. Files that failed to parse
-/// become placeholder `ScannedCommand`s (no arguments) with the failure
-/// recorded in their `warnings` field — the rest of the build continues.
+/// Expand every glob in `scan_paths` against `root`, scan each match, and return one
+/// `ScannedCommand` per file. Files that failed to parse become placeholder `ScannedCommand`s
+/// (no arguments) with the failure recorded in their `warnings` field — the rest of the build
+/// continues. Underscore-prefixed filenames (`_helpers.py`, `__init__.py`) are always skipped.
 ///
-/// `django` opts this block into Django management-command conventions: underscore-prefixed
-/// filenames are skipped outright, and a file with no `add_argument()` calls is still kept if
-/// it defines Django's `Command` entry point. Plain argparse blocks (`django == false`) ignore
-/// both — a file with no `add_argument()` calls is always treated as a non-command helper
-/// there, regardless of name or shape.
+/// `django` opts this block into one additional Django management-command convention: a file
+/// with no `add_argument()` calls is still kept if it defines Django's `Command` entry point.
+/// Plain argparse blocks (`django == false`) treat a file with no `add_argument()` calls as a
+/// non-command helper regardless of its shape.
 pub fn scan_block_paths(
     root: &Path,
     scan_paths: &[String],
@@ -580,9 +579,9 @@ pub fn scan_block_paths(
             .and_then(|s| s.to_str())
             .unwrap_or("?")
             .to_string();
-        // `_helpers.py`/`__init__.py` are Django/Python convention for "not a command"; a plain
-        // block relies on the empty-args rule below instead.
-        if django && stem.starts_with('_') {
+        // `_helpers.py`/`__init__.py` are plain Python convention for "not a command" —
+        // applies regardless of `django`.
+        if stem.starts_with('_') {
             continue;
         }
         let text = match std::fs::read_to_string(&path) {
@@ -1076,8 +1075,8 @@ def add_arguments(self, parser):
         // Regression: helper modules (`__init__.py`, `_setup_*.py`, shared utilities) parse fine
         // but contain zero `add_argument` calls. They must not become commands — multiple
         // `__init__.py` files under one parent would collide on the stem and crash clap with a
-        // "command name is duplicated" panic at startup. `django` is off here, so `__init__.py` is
-        // caught by the empty-arguments rule, not the underscore filter.
+        // "command name is duplicated" panic at startup. Both are caught by the (unconditional)
+        // underscore filter here, regardless of `django`.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
@@ -1248,39 +1247,29 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
     }
 
     #[test]
-    fn scan_paths_underscore_skip_only_applies_when_django() {
-        // Defines `Command` but is underscore-prefixed: the underscore filter runs first, so it's
-        // dropped under `django = true` too.
+    fn scan_paths_skips_underscore_prefixed_files_regardless_of_django() {
+        // The underscore convention is plain Python, not Django-specific — must be skipped
+        // even with real `add_argument` calls, so the empty-args rule can't be what's doing it.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
         std::fs::write(
             cmds.join("_internal_command.py"),
-            "class Command(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n",
+            "def add_arguments(self, parser):\n    parser.add_argument('--flag', action='store_true')\n",
         )
         .unwrap();
 
-        let with_django = scan_block_paths(
-            project.path(),
-            &["apps/*/management/commands/*.py".to_string()],
-            true,
-        )
-        .unwrap();
-        assert!(
-            with_django.is_empty(),
-            "underscore-prefixed stem must be skipped outright under django = true, \
-             even though it defines Command",
-        );
-
-        let without_django = scan_block_paths(
-            project.path(),
-            &["apps/*/management/commands/*.py".to_string()],
-            false,
-        )
-        .unwrap();
-        assert!(
-            without_django.is_empty(),
-            "without django, the file is still dropped, but via the empty-arguments rule",
-        );
+        for django in [true, false] {
+            let scanned = scan_block_paths(
+                project.path(),
+                &["apps/*/management/commands/*.py".to_string()],
+                django,
+            )
+            .unwrap();
+            assert!(
+                scanned.is_empty(),
+                "underscore-prefixed stem with real args must still be skipped (django={django})",
+            );
+        }
     }
 }

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -584,12 +584,8 @@ pub fn scan_block_paths(
             .and_then(|s| s.to_str())
             .unwrap_or("?")
             .to_string();
-        // Leading-underscore stems (`_helpers.py`, `__init__.py`) are
-        // Django/Python convention for "not a command" — mirrors the
-        // filter Python tooling in caller repos already applies when
-        // walking `management/commands/`. Only meaningful for Django
-        // blocks: a plain argparse helper module is caught below
-        // regardless of its name, by having no `add_argument` calls.
+        // `_helpers.py`/`__init__.py` are Django/Python convention for
+        // "not a command"; a plain block relies on the empty-args rule below instead.
         if django && stem.starts_with('_') {
             continue;
         }
@@ -609,15 +605,9 @@ pub fn scan_block_paths(
         };
         match scan_source(&stem, &text) {
             Ok(cmd) => {
-                // A file with no `add_argument` calls is almost always a
-                // helper module that happens to live inside the scan
-                // glob. Grafting it as a child would either collide on
-                // common stems — a clap startup panic — or surface a
-                // ghost command the user never wrote. Skip silently,
-                // unless this is a Django block and the file defines
-                // Django's `Command` entry point — that's a genuine
-                // management command even with zero args (e.g. a
-                // long-running consumer), so it's kept.
+                // A no-arg file is usually a helper, not a command — grafting it
+                // would risk a clap stem collision. Kept anyway for a Django block
+                // whose file defines `Command`: that's a genuine zero-arg command.
                 if cmd.arguments.is_empty() && !(django && cmd.is_command_class) {
                     continue;
                 }
@@ -1091,10 +1081,9 @@ def add_arguments(self, parser):
         // utilities) parse fine but contain zero `add_argument` calls.
         // They must not become commands — multiple `__init__.py` files
         // under one parent would collide on the stem and crash clap with
-        // a "command name is duplicated" panic at startup. `django` is
-        // off here — this is the plain-argparse baseline, so `__init__.py`
-        // is dropped by the empty-arguments rule alone, not the
-        // underscore filter (which only applies to Django blocks).
+        // a "command name is duplicated" panic at startup. `django` is off
+        // here, so `__init__.py` is caught by the empty-arguments rule, not the
+        // underscore filter.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
@@ -1144,9 +1133,8 @@ def add_arguments(self, parser):
 
     #[test]
     fn scan_source_detects_command_alias_to_same_module_class() {
-        // Mirrors a real-world shape: a Django command class under its own
-        // name, aliased to `Command` for Django's loader, with no
-        // `add_arguments` method at all (e.g. a long-running consumer).
+        // Real-world shape: a command class under its own name, aliased to
+        // `Command` for Django's loader, with no `add_arguments` at all.
         let source = "\
 class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n\nCommand = SegmentationDocumentsUpdater\n";
         let scanned = scan_source("x", source).unwrap();
@@ -1201,10 +1189,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_paths_keeps_zero_arg_command_alias_files_when_django() {
-        // Regression: a Django management command with no CLI arguments
-        // at all (e.g. a PubSubConsumer-style listener) still defines
-        // `Command`, so it must survive — unlike a stray helper module.
-        // Only kicks in when the block opts in via `django = true`.
+        // A zero-arg command (e.g. a PubSubConsumer-style listener) still
+        // defines `Command`, so it must survive when `django = true`.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
@@ -1243,10 +1229,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_paths_drops_zero_arg_command_alias_files_without_django() {
-        // The same file as above, but the block doesn't opt in — the
-        // Command-symbol carve-out must not apply to plain argparse
-        // blocks, so this is dropped exactly like any other zero-arg
-        // file.
+        // Same file as above, but the block doesn't opt in — the
+        // carve-out must not apply to plain argparse blocks.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
@@ -1272,11 +1256,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_paths_underscore_skip_only_applies_when_django() {
-        // An underscore-prefixed file that *does* define `Command` and
-        // has zero args: dropped under `django = true` (the underscore
-        // filter runs first), kept-or-dropped the same way as any other
-        // file under `django = false` (dropped here too, since it has
-        // no `add_argument` calls) — asserting both to pin the ordering.
+        // Defines `Command` but is underscore-prefixed: the underscore
+        // filter runs first, so it's dropped under `django = true` too.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -20,6 +20,13 @@ pub struct ScannedCommand {
     pub description: String, // rest of module docstring
     pub arguments: Vec<Argument>,
     pub warnings: Vec<String>,
+    /// True when the module defines Django's `Command` entry point —
+    /// either `class Command(...)` directly, or `Command = <Name>`
+    /// aliased to a class defined earlier in the same module. Lets
+    /// `scan_block_paths` keep zero-argument management commands
+    /// (e.g. a `BaseCommand` subclass with no `add_arguments` at all)
+    /// instead of mistaking them for stray helper modules.
+    pub is_command_class: bool,
 }
 
 /// argparse keyword arguments we recognise — the signature-shape filter
@@ -41,6 +48,7 @@ pub fn scan_source(command_name: &str, source_text: &str) -> Result<ScannedComma
     })?;
     let module = parsed.into_syntax();
     let (summary, description) = split_docstring(&module_docstring(&module));
+    let is_command_class = defines_command_class(&module);
 
     let mut out = ScannedCommand {
         name: command_name.to_string(),
@@ -48,6 +56,7 @@ pub fn scan_source(command_name: &str, source_text: &str) -> Result<ScannedComma
         description,
         arguments: Vec::new(),
         warnings: Vec::new(),
+        is_command_class,
     };
 
     for stmt in &module.body {
@@ -55,6 +64,44 @@ pub fn scan_source(command_name: &str, source_text: &str) -> Result<ScannedComma
     }
 
     Ok(out)
+}
+
+/// True when the module's top level defines Django's `Command` entry
+/// point: a literal `class Command(...)`, or `Command = <Name>` where
+/// `<Name>` is a class defined at module top level. Only same-module
+/// classes are resolved — an alias to an imported name (`Command =
+/// SomeImportedClass`) isn't verifiable without import resolution, so
+/// it's treated as unresolved rather than guessed at.
+fn defines_command_class(module: &ModModule) -> bool {
+    let mut top_level_classes: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for stmt in &module.body {
+        if let Stmt::ClassDef(class_def) = stmt {
+            top_level_classes.insert(class_def.name.as_str());
+        }
+    }
+    if top_level_classes.contains("Command") {
+        return true;
+    }
+    for stmt in &module.body {
+        let Stmt::Assign(assign) = stmt else {
+            continue;
+        };
+        if assign.targets.len() != 1 {
+            continue;
+        }
+        let Expr::Name(target) = &assign.targets[0] else {
+            continue;
+        };
+        if target.id.as_str() != "Command" {
+            continue;
+        }
+        if let Expr::Name(value) = assign.value.as_ref() {
+            if top_level_classes.contains(value.id.as_str()) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Recursively walk statements looking for `Expr::Call` whose `.func` is
@@ -529,6 +576,13 @@ pub fn scan_block_paths(
             .and_then(|s| s.to_str())
             .unwrap_or("?")
             .to_string();
+        // Leading-underscore stems (`_helpers.py`, `__init__.py`) are
+        // Django/Python convention for "not a command" — mirrors the
+        // filter Python tooling in caller repos already applies when
+        // walking `management/commands/`.
+        if stem.starts_with('_') {
+            continue;
+        }
         let text = match std::fs::read_to_string(&path) {
             Ok(t) => t,
             Err(err) => {
@@ -545,14 +599,18 @@ pub fn scan_block_paths(
         };
         match scan_source(&stem, &text) {
             Ok(cmd) => {
-                // A file with no `add_argument` calls is almost always a
-                // helper module (`_setup_*.py`, `__init__.py`, shared
-                // utilities) that happens to live inside the scan glob.
-                // Grafting it as a child would either collide on common
-                // stems (e.g. multiple `__init__.py` files under one
-                // parent — a clap startup panic) or surface a no-arg
-                // ghost command the user never wrote. Skip silently.
-                if cmd.arguments.is_empty() {
+                // A file with no `add_argument` calls and no resolvable
+                // `Command` symbol is almost always a helper module that
+                // happens to live inside the scan glob (the underscore
+                // filter above already caught the common case; this
+                // catches an unprefixed stray helper too). Grafting it
+                // as a child would either collide on common stems — a
+                // clap startup panic — or surface a ghost command the
+                // user never wrote. Skip silently. A file that *does*
+                // define `Command` is a genuine management command
+                // even with zero args (e.g. a long-running consumer),
+                // so it's kept.
+                if cmd.arguments.is_empty() && !cmd.is_command_class {
                     continue;
                 }
                 out.push(cmd);
@@ -967,6 +1025,7 @@ def add_arguments(self, parser):
                 long_flag: Some("--verbosity".into()),
             }],
             warnings: vec![],
+            is_command_class: false,
         };
         let common = vec![
             CommonArg {
@@ -1057,6 +1116,75 @@ def add_arguments(self, parser):
         assert!(
             !names.contains("_helpers"),
             "helper module has no add_argument calls — must not become a command",
+        );
+    }
+
+    #[test]
+    fn scan_source_detects_literal_command_class() {
+        let source = "class Command(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(scanned.is_command_class);
+        assert!(scanned.arguments.is_empty());
+    }
+
+    #[test]
+    fn scan_source_detects_command_alias_to_same_module_class() {
+        // Mirrors a real-world shape: a Django command class under its own
+        // name, aliased to `Command` for Django's loader, with no
+        // `add_arguments` method at all (e.g. a long-running consumer).
+        let source = "\
+class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n\nCommand = SegmentationDocumentsUpdater\n";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(scanned.is_command_class);
+        assert!(scanned.arguments.is_empty());
+    }
+
+    #[test]
+    fn scan_source_does_not_guess_alias_to_imported_class() {
+        // `Command = SomeImportedClass` isn't verifiable without import
+        // resolution — treated as unresolved, not guessed at.
+        let source = "from elsewhere import SomeImportedClass\n\nCommand = SomeImportedClass\n";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(!scanned.is_command_class);
+    }
+
+    #[test]
+    fn scan_paths_keeps_zero_arg_command_alias_files() {
+        // Regression: a Django management command with no CLI arguments
+        // at all (e.g. a PubSubConsumer-style listener) still defines
+        // `Command`, so it must survive — unlike a stray helper module.
+        let project = tempfile::tempdir().unwrap();
+        let cmds = project.path().join("apps/x/management/commands");
+        std::fs::create_dir_all(&cmds).unwrap();
+
+        std::fs::write(
+            cmds.join("segmentation_documents_updater.py"),
+            "class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n\nCommand = SegmentationDocumentsUpdater\n",
+        )
+        .unwrap();
+        // A stray helper with no underscore prefix and no `Command` symbol
+        // must still be dropped.
+        std::fs::write(
+            cmds.join("shared_utils.py"),
+            "def configure(parser):\n    pass\n",
+        )
+        .unwrap();
+
+        let scanned = scan_block_paths(
+            project.path(),
+            &["apps/*/management/commands/*.py".to_string()],
+        )
+        .unwrap();
+
+        let names: std::collections::BTreeSet<_> =
+            scanned.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains("segmentation_documents_updater"),
+            "zero-arg command that defines Command must still scan",
+        );
+        assert!(
+            !names.contains("shared_utils"),
+            "helper module with no Command symbol and no add_argument calls must not become a command",
         );
     }
 }

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -20,12 +20,10 @@ pub struct ScannedCommand {
     pub description: String, // rest of module docstring
     pub arguments: Vec<Argument>,
     pub warnings: Vec<String>,
-    /// True when the module defines Django's `Command` entry point —
-    /// either `class Command(...)` directly, or `Command = <Name>`
-    /// aliased to a class defined earlier in the same module. Lets
-    /// `scan_block_paths` keep zero-argument management commands
-    /// (e.g. a `BaseCommand` subclass with no `add_arguments` at all)
-    /// instead of mistaking them for stray helper modules.
+    /// True when the module defines Django's `Command` entry point — either `class Command(...)`
+    /// directly, or `Command = <Name>` aliased to a class defined earlier in the same module. Lets
+    /// `scan_block_paths` keep zero-argument management commands (e.g. a `BaseCommand` subclass
+    /// with no `add_arguments` at all) instead of mistaking them for stray helper modules.
     pub is_django_command_class: bool,
 }
 
@@ -66,12 +64,11 @@ pub fn scan_source(command_name: &str, source_text: &str) -> Result<ScannedComma
     Ok(out)
 }
 
-/// True when the module's top level defines Django's `Command` entry
-/// point: a literal `class Command(...)`, or `Command = <Name>` where
-/// `<Name>` is a class defined at module top level. Only same-module
-/// classes are resolved — an alias to an imported name (`Command =
-/// SomeImportedClass`) isn't verifiable without import resolution, so
-/// it's treated as unresolved rather than guessed at.
+/// True when the module's top level defines Django's `Command` entry point: a literal `class
+/// Command(...)`, or `Command = <Name>` where `<Name>` is a class defined at module top level.
+/// Only same-module classes are resolved — an alias to an imported name (`Command =
+/// SomeImportedClass`) isn't verifiable without import resolution, so it's treated as unresolved
+/// rather than guessed at.
 fn defines_django_command_class(module: &ModModule) -> bool {
     let mut top_level_classes: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for stmt in &module.body {
@@ -543,12 +540,11 @@ use std::path::Path;
 /// become placeholder `ScannedCommand`s (no arguments) with the failure
 /// recorded in their `warnings` field — the rest of the build continues.
 ///
-/// `django` opts this block into Django management-command conventions:
-/// underscore-prefixed filenames are skipped outright, and a file with
-/// no `add_argument()` calls is still kept if it defines Django's
-/// `Command` entry point. Plain argparse blocks (`django == false`)
-/// ignore both — a file with no `add_argument()` calls is always
-/// treated as a non-command helper there, regardless of name or shape.
+/// `django` opts this block into Django management-command conventions: underscore-prefixed
+/// filenames are skipped outright, and a file with no `add_argument()` calls is still kept if
+/// it defines Django's `Command` entry point. Plain argparse blocks (`django == false`) ignore
+/// both — a file with no `add_argument()` calls is always treated as a non-command helper
+/// there, regardless of name or shape.
 pub fn scan_block_paths(
     root: &Path,
     scan_paths: &[String],
@@ -584,8 +580,8 @@ pub fn scan_block_paths(
             .and_then(|s| s.to_str())
             .unwrap_or("?")
             .to_string();
-        // `_helpers.py`/`__init__.py` are Django/Python convention for
-        // "not a command"; a plain block relies on the empty-args rule below instead.
+        // `_helpers.py`/`__init__.py` are Django/Python convention for "not a command"; a plain
+        // block relies on the empty-args rule below instead.
         if django && stem.starts_with('_') {
             continue;
         }
@@ -605,9 +601,9 @@ pub fn scan_block_paths(
         };
         match scan_source(&stem, &text) {
             Ok(cmd) => {
-                // A no-arg file is usually a helper, not a command — grafting it
-                // would risk a clap stem collision. Kept anyway for a Django block
-                // whose file defines `Command`: that's a genuine zero-arg command.
+                // A no-arg file is usually a helper, not a command — grafting it would risk a clap
+                // stem collision. Kept anyway for a Django block whose file defines `Command`:
+                // that's a genuine zero-arg command.
                 if cmd.arguments.is_empty() && !(django && cmd.is_django_command_class) {
                     continue;
                 }
@@ -1077,13 +1073,11 @@ def add_arguments(self, parser):
 
     #[test]
     fn scan_paths_skips_files_with_no_add_argument_calls() {
-        // Regression: helper modules (`__init__.py`, `_setup_*.py`, shared
-        // utilities) parse fine but contain zero `add_argument` calls.
-        // They must not become commands — multiple `__init__.py` files
-        // under one parent would collide on the stem and crash clap with
-        // a "command name is duplicated" panic at startup. `django` is off
-        // here, so `__init__.py` is caught by the empty-arguments rule, not the
-        // underscore filter.
+        // Regression: helper modules (`__init__.py`, `_setup_*.py`, shared utilities) parse fine
+        // but contain zero `add_argument` calls. They must not become commands — multiple
+        // `__init__.py` files under one parent would collide on the stem and crash clap with a
+        // "command name is duplicated" panic at startup. `django` is off here, so `__init__.py` is
+        // caught by the empty-arguments rule, not the underscore filter.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
@@ -1133,8 +1127,8 @@ def add_arguments(self, parser):
 
     #[test]
     fn scan_source_detects_command_alias_to_same_module_class() {
-        // Real-world shape: a command class under its own name, aliased to
-        // `Command` for Django's loader, with no `add_arguments` at all.
+        // Real-world shape: a command class under its own name, aliased to `Command` for Django's
+        // loader, with no `add_arguments` at all.
         let source = "\
 class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n\nCommand = SegmentationDocumentsUpdater\n";
         let scanned = scan_source("x", source).unwrap();
@@ -1144,8 +1138,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_source_does_not_guess_alias_to_imported_class() {
-        // `Command = SomeImportedClass` isn't verifiable without import
-        // resolution — treated as unresolved, not guessed at.
+        // `Command = SomeImportedClass` isn't verifiable without import resolution — treated as
+        // unresolved, not guessed at.
         let source = "from elsewhere import SomeImportedClass\n\nCommand = SomeImportedClass\n";
         let scanned = scan_source("x", source).unwrap();
         assert!(!scanned.is_django_command_class);
@@ -1153,8 +1147,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_source_ignores_unrelated_module_level_assignment() {
-        // `LOGGER = ...` is a common module-level assignment that isn't
-        // `Command` at all — must not be mistaken for one.
+        // `LOGGER = ...` is a common module-level assignment that isn't `Command` at all — must not
+        // be mistaken for one.
         let source = "class Foo(BaseCommand):\n    pass\n\nLOGGER = 'x'\n";
         let scanned = scan_source("x", source).unwrap();
         assert!(!scanned.is_django_command_class);
@@ -1162,8 +1156,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_source_ignores_command_assignment_with_non_name_target() {
-        // `obj.Command = Foo` targets an attribute, not a bare name —
-        // doesn't satisfy Django's module-level `Command` contract.
+        // `obj.Command = Foo` targets an attribute, not a bare name — doesn't satisfy Django's
+        // module-level `Command` contract.
         let source = "class Foo(BaseCommand):\n    pass\n\nobj.Command = Foo\n";
         let scanned = scan_source("x", source).unwrap();
         assert!(!scanned.is_django_command_class);
@@ -1171,8 +1165,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_source_ignores_command_assignment_with_multiple_targets() {
-        // `a = Command = Foo` has two assignment targets — not the
-        // single-target `Command = <Name>` shape this detects.
+        // `a = Command = Foo` has two assignment targets — not the single-target `Command = <Name>`
+        // shape this detects.
         let source = "class Foo(BaseCommand):\n    pass\n\na = Command = Foo\n";
         let scanned = scan_source("x", source).unwrap();
         assert!(!scanned.is_django_command_class);
@@ -1180,8 +1174,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_source_ignores_command_assignment_with_non_name_value() {
-        // `Command = make_command()` doesn't alias to a same-module
-        // class by name — nothing to resolve statically.
+        // `Command = make_command()` doesn't alias to a same-module class by name — nothing to
+        // resolve statically.
         let source = "class Foo(BaseCommand):\n    pass\n\nCommand = make_command()\n";
         let scanned = scan_source("x", source).unwrap();
         assert!(!scanned.is_django_command_class);
@@ -1189,8 +1183,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_paths_keeps_zero_arg_command_alias_files_when_django() {
-        // A zero-arg command (e.g. a PubSubConsumer-style listener) still
-        // defines `Command`, so it must survive when `django = true`.
+        // A zero-arg command (e.g. a PubSubConsumer-style listener) still defines `Command`, so it
+        // must survive when `django = true`.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
@@ -1200,8 +1194,7 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
             "class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n\nCommand = SegmentationDocumentsUpdater\n",
         )
         .unwrap();
-        // A stray helper with no underscore prefix and no `Command` symbol
-        // must still be dropped.
+        // A stray helper with no underscore prefix and no `Command` symbol must still be dropped.
         std::fs::write(
             cmds.join("shared_utils.py"),
             "def configure(parser):\n    pass\n",
@@ -1229,8 +1222,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_paths_drops_zero_arg_command_alias_files_without_django() {
-        // Same file as above, but the block doesn't opt in — the
-        // carve-out must not apply to plain argparse blocks.
+        // Same file as above, but the block doesn't opt in — the carve-out must not apply to plain
+        // argparse blocks.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
@@ -1256,8 +1249,8 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
 
     #[test]
     fn scan_paths_underscore_skip_only_applies_when_django() {
-        // Defines `Command` but is underscore-prefixed: the underscore
-        // filter runs first, so it's dropped under `django = true` too.
+        // Defines `Command` but is underscore-prefixed: the underscore filter runs first, so it's
+        // dropped under `django = true` too.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -542,9 +542,17 @@ use std::path::Path;
 /// and return one `ScannedCommand` per file. Files that failed to parse
 /// become placeholder `ScannedCommand`s (no arguments) with the failure
 /// recorded in their `warnings` field — the rest of the build continues.
+///
+/// `django` opts this block into Django management-command conventions:
+/// underscore-prefixed filenames are skipped outright, and a file with
+/// no `add_argument()` calls is still kept if it defines Django's
+/// `Command` entry point. Plain argparse blocks (`django == false`)
+/// ignore both — a file with no `add_argument()` calls is always
+/// treated as a non-command helper there, regardless of name or shape.
 pub fn scan_block_paths(
     root: &Path,
     scan_paths: &[String],
+    django: bool,
 ) -> Result<Vec<ScannedCommand>, ScanError> {
     let mut all_paths: Vec<std::path::PathBuf> = Vec::new();
     for pattern in scan_paths {
@@ -579,8 +587,10 @@ pub fn scan_block_paths(
         // Leading-underscore stems (`_helpers.py`, `__init__.py`) are
         // Django/Python convention for "not a command" — mirrors the
         // filter Python tooling in caller repos already applies when
-        // walking `management/commands/`.
-        if stem.starts_with('_') {
+        // walking `management/commands/`. Only meaningful for Django
+        // blocks: a plain argparse helper module is caught below
+        // regardless of its name, by having no `add_argument` calls.
+        if django && stem.starts_with('_') {
             continue;
         }
         let text = match std::fs::read_to_string(&path) {
@@ -599,18 +609,16 @@ pub fn scan_block_paths(
         };
         match scan_source(&stem, &text) {
             Ok(cmd) => {
-                // A file with no `add_argument` calls and no resolvable
-                // `Command` symbol is almost always a helper module that
-                // happens to live inside the scan glob (the underscore
-                // filter above already caught the common case; this
-                // catches an unprefixed stray helper too). Grafting it
-                // as a child would either collide on common stems — a
-                // clap startup panic — or surface a ghost command the
-                // user never wrote. Skip silently. A file that *does*
-                // define `Command` is a genuine management command
-                // even with zero args (e.g. a long-running consumer),
-                // so it's kept.
-                if cmd.arguments.is_empty() && !cmd.is_command_class {
+                // A file with no `add_argument` calls is almost always a
+                // helper module that happens to live inside the scan
+                // glob. Grafting it as a child would either collide on
+                // common stems — a clap startup panic — or surface a
+                // ghost command the user never wrote. Skip silently,
+                // unless this is a Django block and the file defines
+                // Django's `Command` entry point — that's a genuine
+                // management command even with zero args (e.g. a
+                // long-running consumer), so it's kept.
+                if cmd.arguments.is_empty() && !(django && cmd.is_command_class) {
                     continue;
                 }
                 out.push(cmd);
@@ -1063,7 +1071,9 @@ def add_arguments(self, parser):
         let scanned = scan_block_paths(
             project.path(),
             &["apps/*/management/commands/*.py".to_string()],
-        ).unwrap();
+            false,
+        )
+        .unwrap();
 
         // Expect migrate + runserver scanned successfully, broken recorded as a warning placeholder.
         let names: std::collections::BTreeSet<_> = scanned.iter().map(|s| s.name.as_str()).collect();
@@ -1081,7 +1091,10 @@ def add_arguments(self, parser):
         // utilities) parse fine but contain zero `add_argument` calls.
         // They must not become commands — multiple `__init__.py` files
         // under one parent would collide on the stem and crash clap with
-        // a "command name is duplicated" panic at startup.
+        // a "command name is duplicated" panic at startup. `django` is
+        // off here — this is the plain-argparse baseline, so `__init__.py`
+        // is dropped by the empty-arguments rule alone, not the
+        // underscore filter (which only applies to Django blocks).
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
@@ -1103,6 +1116,7 @@ def add_arguments(self, parser):
         let scanned = scan_block_paths(
             project.path(),
             &["apps/*/management/commands/*.py".to_string()],
+            false,
         )
         .unwrap();
 
@@ -1121,7 +1135,8 @@ def add_arguments(self, parser):
 
     #[test]
     fn scan_source_detects_literal_command_class() {
-        let source = "class Command(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n";
+        let source =
+            "class Command(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n";
         let scanned = scan_source("x", source).unwrap();
         assert!(scanned.is_command_class);
         assert!(scanned.arguments.is_empty());
@@ -1149,10 +1164,47 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
     }
 
     #[test]
-    fn scan_paths_keeps_zero_arg_command_alias_files() {
+    fn scan_source_ignores_unrelated_module_level_assignment() {
+        // `LOGGER = ...` is a common module-level assignment that isn't
+        // `Command` at all — must not be mistaken for one.
+        let source = "class Foo(BaseCommand):\n    pass\n\nLOGGER = 'x'\n";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(!scanned.is_command_class);
+    }
+
+    #[test]
+    fn scan_source_ignores_command_assignment_with_non_name_target() {
+        // `obj.Command = Foo` targets an attribute, not a bare name —
+        // doesn't satisfy Django's module-level `Command` contract.
+        let source = "class Foo(BaseCommand):\n    pass\n\nobj.Command = Foo\n";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(!scanned.is_command_class);
+    }
+
+    #[test]
+    fn scan_source_ignores_command_assignment_with_multiple_targets() {
+        // `a = Command = Foo` has two assignment targets — not the
+        // single-target `Command = <Name>` shape this detects.
+        let source = "class Foo(BaseCommand):\n    pass\n\na = Command = Foo\n";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(!scanned.is_command_class);
+    }
+
+    #[test]
+    fn scan_source_ignores_command_assignment_with_non_name_value() {
+        // `Command = make_command()` doesn't alias to a same-module
+        // class by name — nothing to resolve statically.
+        let source = "class Foo(BaseCommand):\n    pass\n\nCommand = make_command()\n";
+        let scanned = scan_source("x", source).unwrap();
+        assert!(!scanned.is_command_class);
+    }
+
+    #[test]
+    fn scan_paths_keeps_zero_arg_command_alias_files_when_django() {
         // Regression: a Django management command with no CLI arguments
         // at all (e.g. a PubSubConsumer-style listener) still defines
         // `Command`, so it must survive — unlike a stray helper module.
+        // Only kicks in when the block opts in via `django = true`.
         let project = tempfile::tempdir().unwrap();
         let cmds = project.path().join("apps/x/management/commands");
         std::fs::create_dir_all(&cmds).unwrap();
@@ -1173,6 +1225,7 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
         let scanned = scan_block_paths(
             project.path(),
             &["apps/*/management/commands/*.py".to_string()],
+            true,
         )
         .unwrap();
 
@@ -1180,11 +1233,80 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
             scanned.iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains("segmentation_documents_updater"),
-            "zero-arg command that defines Command must still scan",
+            "zero-arg command that defines Command must still scan when django = true",
         );
         assert!(
             !names.contains("shared_utils"),
             "helper module with no Command symbol and no add_argument calls must not become a command",
+        );
+    }
+
+    #[test]
+    fn scan_paths_drops_zero_arg_command_alias_files_without_django() {
+        // The same file as above, but the block doesn't opt in — the
+        // Command-symbol carve-out must not apply to plain argparse
+        // blocks, so this is dropped exactly like any other zero-arg
+        // file.
+        let project = tempfile::tempdir().unwrap();
+        let cmds = project.path().join("apps/x/management/commands");
+        std::fs::create_dir_all(&cmds).unwrap();
+
+        std::fs::write(
+            cmds.join("segmentation_documents_updater.py"),
+            "class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n\nCommand = SegmentationDocumentsUpdater\n",
+        )
+        .unwrap();
+
+        let scanned = scan_block_paths(
+            project.path(),
+            &["apps/*/management/commands/*.py".to_string()],
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            scanned.is_empty(),
+            "zero-arg Command file must be dropped when django = false",
+        );
+    }
+
+    #[test]
+    fn scan_paths_underscore_skip_only_applies_when_django() {
+        // An underscore-prefixed file that *does* define `Command` and
+        // has zero args: dropped under `django = true` (the underscore
+        // filter runs first), kept-or-dropped the same way as any other
+        // file under `django = false` (dropped here too, since it has
+        // no `add_argument` calls) — asserting both to pin the ordering.
+        let project = tempfile::tempdir().unwrap();
+        let cmds = project.path().join("apps/x/management/commands");
+        std::fs::create_dir_all(&cmds).unwrap();
+        std::fs::write(
+            cmds.join("_internal_command.py"),
+            "class Command(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n",
+        )
+        .unwrap();
+
+        let with_django = scan_block_paths(
+            project.path(),
+            &["apps/*/management/commands/*.py".to_string()],
+            true,
+        )
+        .unwrap();
+        assert!(
+            with_django.is_empty(),
+            "underscore-prefixed stem must be skipped outright under django = true, \
+             even though it defines Command",
+        );
+
+        let without_django = scan_block_paths(
+            project.path(),
+            &["apps/*/management/commands/*.py".to_string()],
+            false,
+        )
+        .unwrap();
+        assert!(
+            without_django.is_empty(),
+            "without django, the file is still dropped, but via the empty-arguments rule",
         );
     }
 }

--- a/crates/toolr-core/src/argparse/scan.rs
+++ b/crates/toolr-core/src/argparse/scan.rs
@@ -26,7 +26,7 @@ pub struct ScannedCommand {
     /// `scan_block_paths` keep zero-argument management commands
     /// (e.g. a `BaseCommand` subclass with no `add_arguments` at all)
     /// instead of mistaking them for stray helper modules.
-    pub is_command_class: bool,
+    pub is_django_command_class: bool,
 }
 
 /// argparse keyword arguments we recognise — the signature-shape filter
@@ -48,7 +48,7 @@ pub fn scan_source(command_name: &str, source_text: &str) -> Result<ScannedComma
     })?;
     let module = parsed.into_syntax();
     let (summary, description) = split_docstring(&module_docstring(&module));
-    let is_command_class = defines_command_class(&module);
+    let is_django_command_class = defines_django_command_class(&module);
 
     let mut out = ScannedCommand {
         name: command_name.to_string(),
@@ -56,7 +56,7 @@ pub fn scan_source(command_name: &str, source_text: &str) -> Result<ScannedComma
         description,
         arguments: Vec::new(),
         warnings: Vec::new(),
-        is_command_class,
+        is_django_command_class,
     };
 
     for stmt in &module.body {
@@ -72,7 +72,7 @@ pub fn scan_source(command_name: &str, source_text: &str) -> Result<ScannedComma
 /// classes are resolved — an alias to an imported name (`Command =
 /// SomeImportedClass`) isn't verifiable without import resolution, so
 /// it's treated as unresolved rather than guessed at.
-fn defines_command_class(module: &ModModule) -> bool {
+fn defines_django_command_class(module: &ModModule) -> bool {
     let mut top_level_classes: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for stmt in &module.body {
         if let Stmt::ClassDef(class_def) = stmt {
@@ -608,7 +608,7 @@ pub fn scan_block_paths(
                 // A no-arg file is usually a helper, not a command — grafting it
                 // would risk a clap stem collision. Kept anyway for a Django block
                 // whose file defines `Command`: that's a genuine zero-arg command.
-                if cmd.arguments.is_empty() && !(django && cmd.is_command_class) {
+                if cmd.arguments.is_empty() && !(django && cmd.is_django_command_class) {
                     continue;
                 }
                 out.push(cmd);
@@ -1023,7 +1023,7 @@ def add_arguments(self, parser):
                 long_flag: Some("--verbosity".into()),
             }],
             warnings: vec![],
-            is_command_class: false,
+            is_django_command_class: false,
         };
         let common = vec![
             CommonArg {
@@ -1127,7 +1127,7 @@ def add_arguments(self, parser):
         let source =
             "class Command(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n";
         let scanned = scan_source("x", source).unwrap();
-        assert!(scanned.is_command_class);
+        assert!(scanned.is_django_command_class);
         assert!(scanned.arguments.is_empty());
     }
 
@@ -1138,7 +1138,7 @@ def add_arguments(self, parser):
         let source = "\
 class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **options):\n        pass\n\nCommand = SegmentationDocumentsUpdater\n";
         let scanned = scan_source("x", source).unwrap();
-        assert!(scanned.is_command_class);
+        assert!(scanned.is_django_command_class);
         assert!(scanned.arguments.is_empty());
     }
 
@@ -1148,7 +1148,7 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
         // resolution — treated as unresolved, not guessed at.
         let source = "from elsewhere import SomeImportedClass\n\nCommand = SomeImportedClass\n";
         let scanned = scan_source("x", source).unwrap();
-        assert!(!scanned.is_command_class);
+        assert!(!scanned.is_django_command_class);
     }
 
     #[test]
@@ -1157,7 +1157,7 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
         // `Command` at all — must not be mistaken for one.
         let source = "class Foo(BaseCommand):\n    pass\n\nLOGGER = 'x'\n";
         let scanned = scan_source("x", source).unwrap();
-        assert!(!scanned.is_command_class);
+        assert!(!scanned.is_django_command_class);
     }
 
     #[test]
@@ -1166,7 +1166,7 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
         // doesn't satisfy Django's module-level `Command` contract.
         let source = "class Foo(BaseCommand):\n    pass\n\nobj.Command = Foo\n";
         let scanned = scan_source("x", source).unwrap();
-        assert!(!scanned.is_command_class);
+        assert!(!scanned.is_django_command_class);
     }
 
     #[test]
@@ -1175,7 +1175,7 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
         // single-target `Command = <Name>` shape this detects.
         let source = "class Foo(BaseCommand):\n    pass\n\na = Command = Foo\n";
         let scanned = scan_source("x", source).unwrap();
-        assert!(!scanned.is_command_class);
+        assert!(!scanned.is_django_command_class);
     }
 
     #[test]
@@ -1184,7 +1184,7 @@ class SegmentationDocumentsUpdater(BaseCommand):\n    def handle(self, *args, **
         // class by name — nothing to resolve statically.
         let source = "class Foo(BaseCommand):\n    pass\n\nCommand = make_command()\n";
         let scanned = scan_source("x", source).unwrap();
-        assert!(!scanned.is_command_class);
+        assert!(!scanned.is_django_command_class);
     }
 
     #[test]

--- a/docs/writing-commands/external-sources.md
+++ b/docs/writing-commands/external-sources.md
@@ -93,6 +93,7 @@ And you wire the two together in `tools/pyproject.toml`:
 ```toml
 [tool.toolr.argparse.django]
 scan_paths = ["apps/*/management/commands/*.py"]
+django = true
 
 [[tool.toolr.argparse.django.attach]]
 parent = "django"
@@ -152,13 +153,15 @@ any dispatcher.
 
 | Key | Type | Meaning |
 |-----|------|---------|
-| `scan_paths` | list of glob strings | Files to scan, relative to the project root. Each matched file becomes one command. Files with no `add_argument` calls are skipped. |
+| `scan_paths` | list of glob strings | Files to scan, relative to the project root. Each matched file becomes one command. By default, files with no `add_argument` calls are skipped — see `django` below for the exception. |
 | `common_args` | list of tables | Arguments merged into *every* command discovered by this block — handy for flags the upstream tool accepts globally (e.g. Django's `--verbosity`). Each entry takes `name`, `kind` (`positional` / `optional` / `flag` / `repeated`), and optional `help`, `default`, `choices`. |
 | `attach` | list of tables | Where to graft the discovered commands. Each `[[…attach]]` entry takes a `parent` dotted path naming the dispatcher. |
+| `django` | boolean, default `false` | Opts this block into two Django-specific conventions: a file with no `add_argument` calls is still kept as a command if it defines Django's `Command` entry point (`class Command(...)`, or `Command = <Name>` aliased to a class in the same file) — this covers commands with no CLI arguments at all, such as a long-running queue consumer — and underscore-prefixed filenames (`_helpers.py`, `__init__.py`) are skipped outright rather than relying on the empty-arguments rule. Leave unset for non-Django argparse sources. |
 
 ```toml
 [tool.toolr.argparse.django]
 scan_paths = ["apps/*/management/commands/*.py"]
+django = true
 common_args = [
   { name = "verbosity", kind = "optional", default = "1", help = "Verbosity level" },
 ]

--- a/docs/writing-commands/external-sources.md
+++ b/docs/writing-commands/external-sources.md
@@ -153,10 +153,10 @@ any dispatcher.
 
 | Key | Type | Meaning |
 |-----|------|---------|
-| `scan_paths` | list of glob strings | Files to scan, relative to the project root. Each matched file becomes one command. By default, files with no `add_argument` calls are skipped — see `django` below for the exception. |
+| `scan_paths` | list of glob strings | Files to scan, relative to the project root. Each matched file becomes one command. Underscore-prefixed filenames (`_helpers.py`, `__init__.py`) are always skipped, and by default files with no `add_argument` calls are skipped too — see `django` below for the exception. |
 | `common_args` | list of tables | Arguments merged into *every* command discovered by this block — handy for flags the upstream tool accepts globally (e.g. Django's `--verbosity`). Each entry takes `name`, `kind` (`positional` / `optional` / `flag` / `repeated`), and optional `help`, `default`, `choices`. |
 | `attach` | list of tables | Where to graft the discovered commands. Each `[[…attach]]` entry takes a `parent` dotted path naming the dispatcher. |
-| `django` | boolean, default `false` | Opts this block into two Django-specific conventions: a file with no `add_argument` calls is still kept as a command if it defines Django's `Command` entry point (`class Command(...)`, or `Command = <Name>` aliased to a class in the same file) — this covers commands with no CLI arguments at all, such as a long-running queue consumer — and underscore-prefixed filenames (`_helpers.py`, `__init__.py`) are skipped outright rather than relying on the empty-arguments rule. Leave unset for non-Django argparse sources. |
+| `django` | boolean, default `false` | Opts this block into the Django `Command`-entry-point convention: a file with no `add_argument` calls is still kept as a command if it defines Django's `Command` entry point (`class Command(...)`, or `Command = <Name>` aliased to a class in the same file). Leave unset for non-Django argparse sources. |
 
 ```toml
 [tool.toolr.argparse.django]


### PR DESCRIPTION
The built-in argparse scanner used "found zero add_argument() calls" as
its only signal that a scanned file wasn't a real Django management
command. That also matched genuine zero-arg commands (e.g. a BaseCommand
subclass with no add_arguments at all, such as a long-running consumer),
so they were silently dropped from the dispatcher's subcommand list.

Detect Django's actual Command entry point instead: a module-level
class Command(...), or Command = <Name> aliased to a same-module class.
Files with neither the Command symbol nor any add_argument calls are
still skipped as stray helpers, and underscore-prefixed filenames
(__init__.py, _helpers.py) are now skipped up front by filename
convention rather than relying solely on the empty-args heuristic.