### PR TITLE
fix(parser): key enum CLI choices by defining module, not bare class name

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,3 +10,10 @@ this file to empty for the next cycle.
 Empty between releases is the steady-state — there's no header,
 no scaffolding. Just write whatever should appear in the notes.
 -->
+
+- Fixed the manifest builder resolving enum CLI choices by bare class
+  name instead of by defining module, which meant two unrelated
+  `tools/*.py` modules declaring a same-named `Enum` subclass (e.g.
+  `Database`) clobbered each other's `--help` choices depending on
+  scan order. `allowed_values` and enum-attribute defaults now resolve
+  against the class actually in scope for each module ([#449](https://github.com/s0undt3ch/ToolR/issues/449)).

--- a/crates/toolr-core/src/build_fragment.rs
+++ b/crates/toolr-core/src/build_fragment.rs
@@ -97,7 +97,8 @@ pub fn build_third_party_fragment(
             path: path.clone(),
             source: e,
         })?;
-        enums.merge(EnumTable::from_module(&module));
+        let module_path = module_path_for_prefix(source_dir, path, package_name);
+        enums.merge(EnumTable::from_module(&module, &module_path));
         aliases.merge(TypeAliasTable::from_module(&module));
         sections.merge(ArgSectionTable::from_module(&module));
     }

--- a/crates/toolr-core/src/parser/build.rs
+++ b/crates/toolr-core/src/parser/build.rs
@@ -41,7 +41,8 @@ fn build_static_manifest_inner(tools_dir: &Path) -> std::result::Result<Manifest
     let mut sections = ArgSectionTable::default();
     for path in &py_files {
         let module = parse_python_file(path).map_err(BuildError::Build)?;
-        enums.merge(EnumTable::from_module(&module));
+        let module_path = module_path_for(tools_dir, path);
+        enums.merge(EnumTable::from_module(&module, &module_path));
         aliases.merge(TypeAliasTable::from_module(&module));
         sections.merge(ArgSectionTable::from_module(&module));
     }
@@ -1115,5 +1116,59 @@ def f(ctx, name: str, alias: str | None = None) -> None:
         // `alias` should be Optional (flag), not a positional.
         let kinds: Vec<ArgumentKind> = f.arguments.iter().map(|a| a.kind).collect();
         assert_eq!(kinds, vec![ArgumentKind::Positional, ArgumentKind::Optional]);
+    }
+
+    /// GH #449: two unrelated modules each declaring a same-named enum
+    /// class (`Database`, with different members) must not clobber each
+    /// other's `allowed_values` in the manifest — each command's flag
+    /// keeps the choices from *its own* module's enum.
+    #[test]
+    fn colliding_bare_enum_names_across_modules_resolve_independently() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "tools/module_a.py",
+            r#""""Module A."""
+import enum
+
+group = command_group("a", "A", docstring=__doc__)
+
+class Database(enum.StrEnum):
+    PRIMARY = "primary"
+    STANDBY = "standby"
+
+@group.command
+def cmd_a(ctx, *, database: Database = Database.PRIMARY) -> None:
+    """Cmd A."""
+"#,
+        );
+        write(
+            tmp.path(),
+            "tools/module_b.py",
+            r#""""Module B."""
+import enum
+
+group = command_group("b", "B", docstring=__doc__)
+
+class Database(enum.StrEnum):
+    REPLICA = "replica"
+    ARCHIVE = "archive"
+
+@group.command
+def cmd_b(ctx, *, database: Database = Database.REPLICA) -> None:
+    """Cmd B."""
+"#,
+        );
+
+        let m = build_static_manifest(&tmp.path().join("tools")).unwrap();
+        let cmd_a = m.commands.iter().find(|c| c.name == "cmd-a").unwrap();
+        let cmd_b = m.commands.iter().find(|c| c.name == "cmd-b").unwrap();
+        let arg_a = cmd_a.arguments.iter().find(|a| a.name == "database").unwrap();
+        let arg_b = cmd_b.arguments.iter().find(|a| a.name == "database").unwrap();
+
+        assert_eq!(arg_a.allowed_values, vec!["primary".to_string(), "standby".to_string()]);
+        assert_eq!(arg_a.default.as_deref(), Some("primary"));
+        assert_eq!(arg_b.allowed_values, vec!["replica".to_string(), "archive".to_string()]);
+        assert_eq!(arg_b.default.as_deref(), Some("replica"));
     }
 }

--- a/crates/toolr-core/src/parser/commands.rs
+++ b/crates/toolr-core/src/parser/commands.rs
@@ -313,7 +313,7 @@ fn build_command(
         .as_ref()
         .map(|d| d.full_description())
         .unwrap_or_default();
-    let mut arguments = extract_arguments(func, enums, consts, sources);
+    let mut arguments = extract_arguments(func, enums, consts, sources, module_path);
     if let Some(d) = parsed.as_ref() {
         for arg in &mut arguments {
             if let Some(Some(help)) = d.params.get(&arg.name) {

--- a/crates/toolr-core/src/parser/signatures.rs
+++ b/crates/toolr-core/src/parser/signatures.rs
@@ -19,6 +19,7 @@ pub fn extract_arguments(
     enums: &EnumTable,
     consts: &ConstTable,
     sources: &SourcesImports,
+    module: &str,
 ) -> Vec<Argument> {
     let params = func.parameters.as_ref();
     let mut out = Vec::new();
@@ -39,6 +40,7 @@ pub fn extract_arguments(
             p.default.as_deref(),
             enums,
             consts,
+            module,
         ));
     }
 
@@ -52,6 +54,7 @@ pub fn extract_arguments(
             None,
             enums,
             consts,
+            module,
         ));
     }
 
@@ -78,12 +81,14 @@ pub fn extract_arguments(
             p.default.as_deref(),
             enums,
             consts,
+            module,
         ));
     }
 
     out
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_argument(
     name: String,
     kind: ArgumentKind,
@@ -91,15 +96,16 @@ fn build_argument(
     default: Option<&Expr>,
     enums: &EnumTable,
     consts: &ConstTable,
+    module: &str,
 ) -> Argument {
     let allowed_values = annotation
-        .map(|a| collect_allowed_values(a, enums))
+        .map(|a| collect_allowed_values(a, enums, module))
         .unwrap_or_default();
     Argument {
         name,
         kind,
         help: String::new(),
-        default: default.map(|d| literal_default(d, enums, consts)),
+        default: default.map(|d| literal_default(d, enums, consts, module)),
         type_annotation: annotation.map(annotation_to_string),
         resolved_type: None,
         path_constraints: None,
@@ -172,13 +178,13 @@ fn is_list_like_annotation(expr: &Expr) -> bool {
     matches!(head, "list" | "List" | "tuple" | "Tuple")
 }
 
-fn collect_allowed_values(annotation: &Expr, enums: &EnumTable) -> Vec<String> {
+fn collect_allowed_values(annotation: &Expr, enums: &EnumTable, module: &str) -> Vec<String> {
     let mut allowed = literal_values(annotation);
     if !allowed.is_empty() {
         return allowed;
     }
     if let Some(name) = referenced_name(annotation) {
-        if let Some(vals) = enums.lookup(name) {
+        if let Some(vals) = enums.lookup(name, module) {
             allowed = vals.to_vec();
         }
     }
@@ -201,7 +207,7 @@ fn referenced_name(expr: &Expr) -> Option<&str> {
 /// `Class.MEMBER` attribute defaults are resolved via `enums` to their
 /// serialised value (so `Operation.ADD` becomes `"add"` for a
 /// `StrEnum`).
-fn literal_default(expr: &Expr, enums: &EnumTable, consts: &ConstTable) -> String {
+fn literal_default(expr: &Expr, enums: &EnumTable, consts: &ConstTable, module: &str) -> String {
     match expr {
         Expr::StringLiteral(s) => s.value.to_str().to_string(),
         Expr::NumberLiteral(n) => match &n.value {
@@ -219,7 +225,7 @@ fn literal_default(expr: &Expr, enums: &EnumTable, consts: &ConstTable) -> Strin
         // in cli.rs:build_user_command skips applying it).
         Expr::NoneLiteral(_) => String::new(),
         Expr::List(l) if l.elts.is_empty() => String::new(),
-        Expr::Attribute(attr) => resolve_enum_attribute_default(attr, enums)
+        Expr::Attribute(attr) => resolve_enum_attribute_default(attr, enums, module)
             .unwrap_or_else(|| "<expr>".to_string()),
         // Bare name reference (e.g. `mode: str = DEFAULT_MODE`) — look up
         // the resolved literal in the same-module constant table. Falls
@@ -239,13 +245,14 @@ fn literal_default(expr: &Expr, enums: &EnumTable, consts: &ConstTable) -> Strin
 fn resolve_enum_attribute_default(
     attr: &ruff_python_ast::ExprAttribute,
     enums: &EnumTable,
+    module: &str,
 ) -> Option<String> {
     let class = match attr.value.as_ref() {
         Expr::Name(n) => n.id.as_str(),
         _ => return None,
     };
     enums
-        .lookup_member(class, attr.attr.as_str())
+        .lookup_member(class, attr.attr.as_str(), module)
         .map(str::to_string)
 }
 
@@ -313,7 +320,7 @@ mod tests {
     #[test]
     fn skips_ctx_first_argument() {
         let func = first_func("def f(ctx, name): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].name, "name");
     }
@@ -321,7 +328,7 @@ mod tests {
     #[test]
     fn marks_arguments_with_defaults_as_optional() {
         let func = first_func("def f(ctx, name=\"x\"): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].kind, ArgumentKind::Optional);
         assert_eq!(args[0].default.as_deref(), Some("x"));
     }
@@ -329,7 +336,7 @@ mod tests {
     #[test]
     fn bool_with_false_default_classified_as_flag() {
         let func = first_func("def f(ctx, verbose: bool = False): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].kind, ArgumentKind::Flag);
         assert_eq!(args[0].default.as_deref(), Some("false"));
     }
@@ -346,7 +353,7 @@ mod tests {
              from toolr import arg\n\
              def f(ctx, verbose: Annotated[bool, arg(env=\"VERBOSE\")] = False): pass\n",
         );
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].kind, ArgumentKind::Flag);
     }
 
@@ -357,21 +364,21 @@ mod tests {
              from toolr import arg\n\
              def f(ctx, items: Annotated[list[str], arg(aliases=[\"-i\"])] = []): pass\n",
         );
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].kind, ArgumentKind::Repeated);
     }
 
     #[test]
     fn list_keyword_classified_as_repeated() {
         let func = first_func("def f(ctx, files: list[str] = []): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].kind, ArgumentKind::Repeated);
     }
 
     #[test]
     fn star_args_emits_var_positional() {
         let func = first_func("def f(ctx, *files: str): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].name, "files");
         assert_eq!(args[0].kind, ArgumentKind::VarPositional);
@@ -381,14 +388,14 @@ mod tests {
     #[test]
     fn integer_default_serialized_without_format_noise() {
         let func = first_func("def f(ctx, n: int = 5): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].default.as_deref(), Some("5"));
     }
 
     #[test]
     fn string_default_has_no_embedded_quotes() {
         let func = first_func("def f(ctx, name: str = \"world\"): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].default.as_deref(), Some("world"));
     }
 
@@ -405,7 +412,7 @@ def f(ctx, op: Operation = Operation.ADD): pass
 "#;
         let m = module(src);
         let mut enums = EnumTable::default();
-        enums.merge(EnumTable::from_module(&m));
+        enums.merge(EnumTable::from_module(&m, "tools.test"));
         let func = m
             .body
             .iter()
@@ -414,14 +421,14 @@ def f(ctx, op: Operation = Operation.ADD): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &enums, &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &enums, &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].default.as_deref(), Some("add"));
     }
 
     #[test]
     fn unknown_enum_attribute_falls_back_to_expr_placeholder() {
         let func = first_func("def f(ctx, x = Unknown.MEMBER): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].default.as_deref(), Some("<expr>"));
     }
 
@@ -434,7 +441,7 @@ def f(ctx, op: Operation = Operation.ADD): pass
     #[test]
     fn captures_type_annotations_as_strings() {
         let func = first_func("def f(ctx, name: str = \"x\"): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].type_annotation.as_deref(), Some("str"));
     }
 
@@ -446,7 +453,7 @@ from typing import Literal
 def f(ctx, mode: Literal["a", "b"]): pass
 "#,
         );
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(
             args[0].allowed_values,
             vec!["a".to_string(), "b".to_string()]
@@ -456,7 +463,7 @@ def f(ctx, mode: Literal["a", "b"]): pass
     #[test]
     fn leaves_allowed_values_empty_for_non_literal_types() {
         let func = first_func("def f(ctx, name: str): pass\n");
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert!(args[0].allowed_values.is_empty());
     }
 
@@ -478,7 +485,7 @@ def f(ctx, mode: Mode): pass
         tmp.write_all(src.as_bytes()).unwrap();
         let m = crate::parser::parse_python_file(tmp.path()).unwrap();
         let mut enums = EnumTable::default();
-        enums.merge(EnumTable::from_module(&m));
+        enums.merge(EnumTable::from_module(&m, "tools.test"));
         // Pull out the function manually (skip the enum class above).
         let func = m
             .body
@@ -488,7 +495,7 @@ def f(ctx, mode: Mode): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &enums, &ConstTable::default(), &SourcesImports::default());
+        let args = extract_arguments(&func, &enums, &ConstTable::default(), &SourcesImports::default(), "tools.test");
         assert_eq!(
             args[0].allowed_values,
             vec!["fast".to_string(), "slow".to_string()]
@@ -517,7 +524,7 @@ def f(ctx, *, cpu: str = "1", dispatched: DispatchCommand): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources);
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources, "tools.test");
         assert_eq!(args.len(), 1, "expected `dispatched` to be filtered out, got {args:?}");
         assert_eq!(args[0].name, "cpu");
     }
@@ -542,7 +549,7 @@ def f(ctx, *, name: str = "x", dispatched: DC): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources);
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources, "tools.test");
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].name, "name");
     }
@@ -567,7 +574,7 @@ def f(ctx, *, name: str = "x"): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources);
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources, "tools.test");
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].name, "name");
         // The annotation rendering hasn't lost the type tag.
@@ -593,7 +600,7 @@ def f(ctx, *, name: str = "x", dispatched: toolr.sources.DispatchCommand): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources);
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources, "tools.test");
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].name, "name");
     }
@@ -623,7 +630,7 @@ def f(ctx, *, cpu: str = "1", dispatched: Annotated[DispatchCommand, arg(help="x
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources);
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources, "tools.test");
         assert!(
             args.iter().all(|a| a.name != "dispatched"),
             "expected `dispatched` to be filtered out, got {args:?}"
@@ -650,7 +657,7 @@ def f(ctx, *, cpu: str = "1", dispatched: "DispatchCommand"): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources);
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources, "tools.test");
         assert!(
             args.iter().all(|a| a.name != "dispatched"),
             "expected `dispatched` to be filtered out, got {args:?}"
@@ -678,7 +685,7 @@ def f(ctx, *, cpu: str = "1", dispatched: "DC"): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources);
+        let args = extract_arguments(&func, &EnumTable::default(), &ConstTable::default(), &sources, "tools.test");
         assert!(
             args.iter().all(|a| a.name != "dispatched"),
             "expected `dispatched` to be filtered out, got {args:?}"
@@ -707,7 +714,7 @@ def f(ctx, *, mode: str = DEFAULT_MODE): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &consts, &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &consts, &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].default.as_deref(), Some("fast"));
     }
 
@@ -731,7 +738,7 @@ def f(ctx, *, retries: int = MAX_RETRIES, loud: bool = VERBOSE): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &consts, &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &consts, &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].default.as_deref(), Some("3"));
         assert_eq!(args[1].default.as_deref(), Some("true"));
     }
@@ -756,7 +763,7 @@ def f(ctx, *, path: str = compute_default()): pass
                 _ => None,
             })
             .unwrap();
-        let args = extract_arguments(&func, &EnumTable::default(), &consts, &SourcesImports::default());
+        let args = extract_arguments(&func, &EnumTable::default(), &consts, &SourcesImports::default(), "tools.test");
         assert_eq!(args[0].default.as_deref(), Some("<expr>"));
     }
 }

--- a/crates/toolr-core/src/parser/symbols.rs
+++ b/crates/toolr-core/src/parser/symbols.rs
@@ -454,6 +454,22 @@ class Database(StrEnum):
     }
 
     #[test]
+    fn single_definition_resolves_from_an_unrelated_module() {
+        let src = r#"
+from enum import StrEnum
+
+class Mode(StrEnum):
+    FAST = "fast"
+"#;
+        let table = EnumTable::from_module(&parse(src), "tools.module_a");
+
+        assert_eq!(
+            table.lookup("Mode", "tools.module_b").unwrap(),
+            vec!["fast".to_string()]
+        );
+    }
+
+    #[test]
     fn arg_section_collects_module_bindings() {
         let src = r#"
 LOGGING = arg_section("Logging Options", description="Control verbosity.")

--- a/crates/toolr-core/src/parser/symbols.rs
+++ b/crates/toolr-core/src/parser/symbols.rs
@@ -13,17 +13,32 @@ pub struct EnumMember {
     pub value: String,
 }
 
+/// A class name's enum members plus the dotted module path that
+/// defines it, so that two unrelated classes sharing a bare name
+/// (e.g. `Database` in two different `tools/*.py` files) don't
+/// collide when tables from multiple modules are merged (GH #449).
+#[derive(Debug, Clone)]
+struct EnumDef {
+    module: String,
+    members: Vec<EnumMember>,
+}
+
 /// Mapping of local class name → enum members, for classes that look
 /// like an `Enum` subclass. Tracks both the member name (`ADD`) and
 /// its serialised value (`"add"`) so we can resolve attribute-style
 /// defaults like `Operation.ADD` to the CLI-visible value.
+///
+/// Keyed by bare class name, but each entry carries every module that
+/// defines a class with that name — `resolve_def` picks the one that's
+/// actually in scope for the caller's module rather than whichever
+/// definition happened to be merged in last.
 #[derive(Debug, Default, Clone)]
 pub struct EnumTable {
-    members: HashMap<String, Vec<EnumMember>>,
+    members: HashMap<String, Vec<EnumDef>>,
 }
 
 impl EnumTable {
-    pub fn from_module(module: &ModModule) -> Self {
+    pub fn from_module(module: &ModModule, module_path: &str) -> Self {
         let mut table = EnumTable::default();
         for stmt in &module.body {
             let Stmt::ClassDef(class) = stmt else {
@@ -38,31 +53,54 @@ impl EnumTable {
                 .filter_map(member_value)
                 .collect::<Vec<_>>();
             if !members.is_empty() {
-                table.members.insert(class.name.to_string(), members);
+                table.members.entry(class.name.to_string()).or_default().push(EnumDef {
+                    module: module_path.to_string(),
+                    members,
+                });
             }
         }
         table
     }
 
+    /// Pick the `class` definition that's actually visible from
+    /// `current_module`: a same-module definition always wins. Failing
+    /// that, an unambiguous single cross-module definition (the common
+    /// "enum lives in a shared module, imported elsewhere" case) is
+    /// used. Two or more different-module definitions with no local
+    /// match are genuinely ambiguous — the static parser doesn't track
+    /// which one, if any, was actually imported here — so this returns
+    /// `None` rather than silently picking one, surfacing as an
+    /// unsupported-type error instead of a wrong result.
+    fn resolve_def(&self, class: &str, current_module: &str) -> Option<&[EnumMember]> {
+        let defs = self.members.get(class)?;
+        if let Some(d) = defs.iter().find(|d| d.module == current_module) {
+            return Some(&d.members);
+        }
+        match defs.as_slice() {
+            [only] => Some(&only.members),
+            _ => None,
+        }
+    }
+
     /// List of serialised values for `class`. Used for `allowed_values`.
-    pub fn lookup(&self, class: &str) -> Option<Vec<String>> {
-        self.members
-            .get(class)
+    pub fn lookup(&self, class: &str, current_module: &str) -> Option<Vec<String>> {
+        self.resolve_def(class, current_module)
             .map(|m| m.iter().map(|em| em.value.clone()).collect())
     }
 
     /// Resolve `class.member` to its serialised value. Used when
     /// rendering enum-attribute defaults in `--help`.
-    pub fn lookup_member(&self, class: &str, member: &str) -> Option<&str> {
-        self.members
-            .get(class)?
+    pub fn lookup_member(&self, class: &str, member: &str, current_module: &str) -> Option<&str> {
+        self.resolve_def(class, current_module)?
             .iter()
             .find(|em| em.name == member)
             .map(|em| em.value.as_str())
     }
 
     pub fn merge(&mut self, other: EnumTable) {
-        self.members.extend(other.members);
+        for (name, defs) in other.members {
+            self.members.entry(name).or_default().extend(defs);
+        }
     }
 }
 
@@ -331,8 +369,8 @@ class Mode(StrEnum):
     FAST = "fast"
     SLOW = "slow"
 "#;
-        let table = EnumTable::from_module(&parse(src));
-        let vals = table.lookup("Mode").unwrap();
+        let table = EnumTable::from_module(&parse(src), "tools.example");
+        let vals = table.lookup("Mode", "tools.example").unwrap();
         assert_eq!(vals, vec!["fast".to_string(), "slow".to_string()]);
     }
 
@@ -345,11 +383,14 @@ class Operation(StrEnum):
     ADD = "add"
     SUBTRACT = "subtract"
 "#;
-        let table = EnumTable::from_module(&parse(src));
-        assert_eq!(table.lookup_member("Operation", "ADD"), Some("add"));
-        assert_eq!(table.lookup_member("Operation", "SUBTRACT"), Some("subtract"));
-        assert_eq!(table.lookup_member("Operation", "MISSING"), None);
-        assert_eq!(table.lookup_member("OtherClass", "ADD"), None);
+        let table = EnumTable::from_module(&parse(src), "tools.example");
+        assert_eq!(table.lookup_member("Operation", "ADD", "tools.example"), Some("add"));
+        assert_eq!(
+            table.lookup_member("Operation", "SUBTRACT", "tools.example"),
+            Some("subtract")
+        );
+        assert_eq!(table.lookup_member("Operation", "MISSING", "tools.example"), None);
+        assert_eq!(table.lookup_member("OtherClass", "ADD", "tools.example"), None);
     }
 
     #[test]
@@ -361,10 +402,10 @@ class Code(IntEnum):
     OK = 0
     ERROR = 1
 "#;
-        let table = EnumTable::from_module(&parse(src));
+        let table = EnumTable::from_module(&parse(src), "tools.example");
         // No string value, so we record the member's own name.
-        assert_eq!(table.lookup_member("Code", "OK"), Some("OK"));
-        assert_eq!(table.lookup_member("Code", "ERROR"), Some("ERROR"));
+        assert_eq!(table.lookup_member("Code", "OK", "tools.example"), Some("OK"));
+        assert_eq!(table.lookup_member("Code", "ERROR", "tools.example"), Some("ERROR"));
     }
 
     #[test]
@@ -373,8 +414,43 @@ class Code(IntEnum):
 class Foo:
     X = "x"
 "#;
-        let table = EnumTable::from_module(&parse(src));
-        assert!(table.lookup("Foo").is_none());
+        let table = EnumTable::from_module(&parse(src), "tools.example");
+        assert!(table.lookup("Foo", "tools.example").is_none());
+    }
+
+    #[test]
+    fn colliding_bare_names_resolve_per_module_not_last_merged_wins() {
+        let a = parse(
+            r#"
+from enum import StrEnum
+
+class Database(StrEnum):
+    PRIMARY = "primary"
+"#,
+        );
+        let b = parse(
+            r#"
+from enum import StrEnum
+
+class Database(StrEnum):
+    REPLICA = "replica"
+"#,
+        );
+        let mut table = EnumTable::from_module(&a, "tools.module_a");
+        table.merge(EnumTable::from_module(&b, "tools.module_b"));
+
+        assert_eq!(
+            table.lookup("Database", "tools.module_a").unwrap(),
+            vec!["primary".to_string()]
+        );
+        assert_eq!(
+            table.lookup("Database", "tools.module_b").unwrap(),
+            vec!["replica".to_string()]
+        );
+        // Neither module's definition wins from an unrelated module —
+        // the collision is genuinely ambiguous, so this resolves to
+        // nothing rather than silently picking one (GH #449).
+        assert!(table.lookup("Database", "tools.module_c").is_none());
     }
 
     #[test]

--- a/crates/toolr-core/src/parser/types/mod.rs
+++ b/crates/toolr-core/src/parser/types/mod.rs
@@ -196,6 +196,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn optional_via_bin_or_with_none_first() {
+        let (_, ann) = first_annotation("def f(x: None | int): pass\n");
+        assert_eq!(
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
+            SupportedType::Optional(Box::new(SupportedType::Int))
+        );
+    }
+
+    #[test]
+    fn optional_via_subscript() {
+        let (_, ann) = first_annotation("def f(x: Optional[int]): pass\n");
+        assert_eq!(
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
+            SupportedType::Optional(Box::new(SupportedType::Int))
+        );
+    }
+
     /// Pin every `toolr.types.X` name the rust side knows about.
     ///
     /// The python-side companion lives at `tests/test_types_module.py`

--- a/crates/toolr-core/src/parser/types/mod.rs
+++ b/crates/toolr-core/src/parser/types/mod.rs
@@ -72,22 +72,22 @@ mod tests {
     fn primitives_resolve() {
         let (_, ann) = first_annotation("def f(x: int): pass\n");
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::Int
         );
         let (_, ann) = first_annotation("def f(x: float): pass\n");
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::Float
         );
         let (_, ann) = first_annotation("def f(x: bool): pass\n");
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::Bool
         );
         let (_, ann) = first_annotation("def f(x: str): pass\n");
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::Str
         );
     }
@@ -96,7 +96,7 @@ mod tests {
     fn bare_path_name_is_supported() {
         let (_, ann) = first_annotation("def f(x: Path): pass\n");
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::Path
         );
     }
@@ -105,7 +105,7 @@ mod tests {
     fn pathlib_path_attribute_is_supported() {
         let (_, ann) = first_annotation("def f(x: pathlib.Path): pass\n");
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::Path
         );
     }
@@ -117,7 +117,7 @@ mod tests {
         let (_, ann) = first_annotation(src);
         let imports = TypeImports::from_module(&m);
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &imports, &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &imports, &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::ResolvedPath
         );
     }
@@ -129,7 +129,7 @@ mod tests {
         let (_, ann) = first_annotation(src);
         let imports = TypeImports::from_module(&m);
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &imports, &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &imports, &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::ResolvedPath
         );
     }
@@ -141,7 +141,7 @@ mod tests {
         let (_, ann) = first_annotation(src);
         let imports = TypeImports::from_module(&m);
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &imports, &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &imports, &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::AbsolutePath
         );
     }
@@ -150,7 +150,7 @@ mod tests {
     fn unknown_dotted_name_errors_with_pointer_to_toolr_types() {
         let (_, ann) = first_annotation("def f(x: datetime.datetime): pass\n");
         let err =
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).expect_err("should fail");
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").expect_err("should fail");
         let msg = err.to_string();
         assert!(msg.contains("datetime.datetime"), "msg was: {msg}");
         assert!(msg.contains("toolr.types"), "msg was: {msg}");
@@ -160,7 +160,7 @@ mod tests {
     fn list_of_int_resolves() {
         let (_, ann) = first_annotation("def f(x: list[int]): pass\n");
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::List(Box::new(SupportedType::Int))
         );
     }
@@ -169,7 +169,7 @@ mod tests {
     fn tuple_str_int_resolves_heterogeneous() {
         let (_, ann) = first_annotation("def f(x: tuple[str, int]): pass\n");
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::Tuple(vec![SupportedType::Str, SupportedType::Int])
         );
     }
@@ -180,7 +180,7 @@ mod tests {
             "from typing import Literal\ndef f(x: Literal[\"a\", \"b\"]): pass\n",
         );
         let SupportedType::Literal(values) =
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap()
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap()
         else {
             panic!("expected Literal");
         };
@@ -191,7 +191,7 @@ mod tests {
     fn optional_via_bin_or_with_none() {
         let (_, ann) = first_annotation("def f(x: int | None): pass\n");
         assert_eq!(
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default()).unwrap(),
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap(),
             SupportedType::Optional(Box::new(SupportedType::Int))
         );
     }
@@ -252,7 +252,7 @@ def f(commit_sha: CommitHash): pass
         let (_, ann) = first_annotation(src);
         let aliases = TypeAliasTable::from_module(&m);
         let resolved =
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &aliases).unwrap();
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &aliases, "tools.test").unwrap();
         assert_eq!(
             resolved,
             SupportedType::Optional(Box::new(SupportedType::Str))
@@ -270,7 +270,7 @@ def f(hosts: HostList): pass
         let (_, ann) = first_annotation(src);
         let aliases = TypeAliasTable::from_module(&m);
         let resolved =
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &aliases).unwrap();
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &aliases, "tools.test").unwrap();
         assert_eq!(resolved, SupportedType::List(Box::new(SupportedType::Str)));
     }
 
@@ -286,7 +286,7 @@ def f(x: A): pass
         let (_, ann) = first_annotation(src);
         let aliases = TypeAliasTable::from_module(&m);
         let err =
-            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &aliases)
+            resolve(&ann, &EnumTable::default(), &TypeImports::default(), &aliases, "tools.test")
                 .expect_err("cycle must error");
         let msg = err.to_string();
         assert!(msg.contains("cyclic"), "got: {msg}");
@@ -298,8 +298,8 @@ def f(x: A): pass
         let m = module(src);
         let (_, ann) = first_annotation(src);
         let mut enums = EnumTable::default();
-        enums.merge(EnumTable::from_module(&m));
-        let resolved = resolve(&ann, &enums, &TypeImports::default(), &TypeAliasTable::default()).unwrap();
+        enums.merge(EnumTable::from_module(&m, "tools.test"));
+        let resolved = resolve(&ann, &enums, &TypeImports::default(), &TypeAliasTable::default(), "tools.test").unwrap();
         assert_eq!(
             resolved,
             SupportedType::Enum {
@@ -429,7 +429,7 @@ def f(x: Annotated[bool, arg(help_section=LOGGING)]): pass
         let m = module(src);
         let imports = TypeImports::from_module(&m);
         let resolved =
-            resolve(&ann, &EnumTable::default(), &imports, &TypeAliasTable::default()).unwrap();
+            resolve(&ann, &EnumTable::default(), &imports, &TypeAliasTable::default(), "tools.test").unwrap();
         assert_eq!(resolved, SupportedType::Count);
     }
 }

--- a/crates/toolr-core/src/parser/types/resolve.rs
+++ b/crates/toolr-core/src/parser/types/resolve.rs
@@ -127,7 +127,7 @@ fn resolve_one(
     {
         arg.metadata = md;
     }
-    match resolve(expr, enums, type_imports, aliases) {
+    match resolve(expr, enums, type_imports, aliases, module) {
         Ok(ty) => {
             // Post-resolution kind override: `toolr.types.Count` is the
             // only type that flips the inferred kind, since the type
@@ -188,25 +188,31 @@ fn follow_alias_for_arg_metadata(
     extract_arg_metadata(aliased, sections)
 }
 
-/// Resolve a parameter annotation to a [`SupportedType`].
+/// Resolve a parameter annotation to a [`SupportedType`]. `module` is
+/// the dotted path of the module the annotation was parsed from — it
+/// disambiguates enum classes that share a bare name across unrelated
+/// `tools/*.py` files (see [`EnumTable`]).
 pub fn resolve(
     annotation: &Expr,
     enums: &EnumTable,
     imports: &TypeImports,
     aliases: &TypeAliasTable,
+    module: &str,
 ) -> Result<SupportedType, UnsupportedType> {
-    resolve_inner(annotation, enums, imports, aliases, &mut Vec::new())
+    resolve_inner(annotation, enums, imports, aliases, module, &mut Vec::new())
 }
 
 /// `seen` tracks names currently being expanded to break alias cycles
 /// (`A = B; B = A`). Capped depth gives a second line of defence.
 const MAX_ALIAS_DEPTH: usize = 16;
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_inner(
     annotation: &Expr,
     enums: &EnumTable,
     imports: &TypeImports,
     aliases: &TypeAliasTable,
+    module: &str,
     seen: &mut Vec<String>,
 ) -> Result<SupportedType, UnsupportedType> {
     if seen.len() >= MAX_ALIAS_DEPTH {
@@ -215,7 +221,7 @@ fn resolve_inner(
         ));
     }
     match annotation {
-        Expr::Name(n) => resolve_name(n.id.as_str(), enums, imports, aliases, seen),
+        Expr::Name(n) => resolve_name(n.id.as_str(), enums, imports, aliases, module, seen),
         Expr::Attribute(_) => {
             if let Some(toolr_name) = imports.resolve_attribute(annotation) {
                 return resolve_toolr_types_name(toolr_name);
@@ -229,17 +235,19 @@ fn resolve_inner(
             }
             Err(UnsupportedType::UnknownName(rendered))
         }
-        Expr::Subscript(sub) => resolve_subscript(sub, enums, imports, aliases, seen),
-        Expr::BinOp(op) => resolve_bin_op(op, enums, imports, aliases, seen),
+        Expr::Subscript(sub) => resolve_subscript(sub, enums, imports, aliases, module, seen),
+        Expr::BinOp(op) => resolve_bin_op(op, enums, imports, aliases, module, seen),
         _ => Err(UnsupportedType::UnknownName(annotation_to_label(annotation))),
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_name(
     name: &str,
     enums: &EnumTable,
     imports: &TypeImports,
     aliases: &TypeAliasTable,
+    module: &str,
     seen: &mut Vec<String>,
 ) -> Result<SupportedType, UnsupportedType> {
     if let Some(canonical) = imports.resolve_direct(name) {
@@ -252,7 +260,7 @@ fn resolve_name(
         "bool" => Ok(SupportedType::Bool),
         "Path" => Ok(SupportedType::Path),
         _ => {
-            if let Some(values) = enums.lookup(name) {
+            if let Some(values) = enums.lookup(name, module) {
                 return Ok(SupportedType::Enum {
                     name: name.to_string(),
                     values: values.to_vec(),
@@ -268,7 +276,7 @@ fn resolve_name(
                     )));
                 }
                 seen.push(name.to_string());
-                let result = resolve_inner(aliased, enums, imports, aliases, seen);
+                let result = resolve_inner(aliased, enums, imports, aliases, module, seen);
                 seen.pop();
                 return result;
             }
@@ -294,11 +302,13 @@ pub(super) fn resolve_toolr_types_name(name: &str) -> Result<SupportedType, Unsu
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_subscript(
     sub: &ruff_python_ast::ExprSubscript,
     enums: &EnumTable,
     imports: &TypeImports,
     aliases: &TypeAliasTable,
+    module: &str,
     seen: &mut Vec<String>,
 ) -> Result<SupportedType, UnsupportedType> {
     let head = match sub.value.as_ref() {
@@ -316,7 +326,7 @@ fn resolve_subscript(
             }
         }
         "list" | "List" => {
-            let inner = resolve_inner(sub.slice.as_ref(), enums, imports, aliases, seen)
+            let inner = resolve_inner(sub.slice.as_ref(), enums, imports, aliases, module, seen)
                 .map_err(|e| UnsupportedType::Inner(Box::new(e)))?;
             Ok(SupportedType::List(Box::new(inner)))
         }
@@ -324,14 +334,14 @@ fn resolve_subscript(
             let parts = tuple_element_exprs(sub.slice.as_ref());
             let resolved: Result<Vec<_>, _> = parts
                 .into_iter()
-                .map(|elt| resolve_inner(elt, enums, imports, aliases, seen))
+                .map(|elt| resolve_inner(elt, enums, imports, aliases, module, seen))
                 .collect();
             Ok(SupportedType::Tuple(
                 resolved.map_err(|e| UnsupportedType::Inner(Box::new(e)))?,
             ))
         }
         "Optional" => {
-            let inner = resolve_inner(sub.slice.as_ref(), enums, imports, aliases, seen)
+            let inner = resolve_inner(sub.slice.as_ref(), enums, imports, aliases, module, seen)
                 .map_err(|e| UnsupportedType::Inner(Box::new(e)))?;
             Ok(SupportedType::Optional(Box::new(inner)))
         }
@@ -343,7 +353,7 @@ fn resolve_subscript(
             let first = exprs
                 .first()
                 .ok_or_else(|| UnsupportedType::UnsupportedShape("Annotated[]".into()))?;
-            resolve_inner(first, enums, imports, aliases, seen)
+            resolve_inner(first, enums, imports, aliases, module, seen)
         }
         other => Err(UnsupportedType::UnsupportedShape(other.to_string())),
     }
@@ -354,6 +364,7 @@ fn resolve_bin_op(
     enums: &EnumTable,
     imports: &TypeImports,
     aliases: &TypeAliasTable,
+    module: &str,
     seen: &mut Vec<String>,
 ) -> Result<SupportedType, UnsupportedType> {
     if !matches!(op.op, ruff_python_ast::Operator::BitOr) {
@@ -366,12 +377,12 @@ fn resolve_bin_op(
     let none_rhs = matches!(rhs, Expr::NoneLiteral(_));
     match (none_lhs, none_rhs) {
         (false, true) => {
-            let inner = resolve_inner(lhs, enums, imports, aliases, seen)
+            let inner = resolve_inner(lhs, enums, imports, aliases, module, seen)
                 .map_err(|e| UnsupportedType::Inner(Box::new(e)))?;
             Ok(SupportedType::Optional(Box::new(inner)))
         }
         (true, false) => {
-            let inner = resolve_inner(rhs, enums, imports, aliases, seen)
+            let inner = resolve_inner(rhs, enums, imports, aliases, module, seen)
                 .map_err(|e| UnsupportedType::Inner(Box::new(e)))?;
             Ok(SupportedType::Optional(Box::new(inner)))
         }


### PR DESCRIPTION
## Summary

`toolr project manifest rebuild` resolved an `Enum`'s CLI `possible
values` by its bare class `__name__`, not the module that defines it.
Two unrelated `tools/*.py` modules each declaring a same-named `Enum`
subclass (e.g. `Database`) clobbered each other's manifest entry -
whichever module the builder happened to scan last silently won for
every command referencing that name, including on the modules that
never touched.

`EnumTable` (`crates/toolr-core/src/parser/symbols.rs`) now tracks each
enum definition alongside its owning module path instead of merging
them into one flat bare-name map. Lookups resolve per the caller's own
module:

1. a same-module definition always wins,
2. failing that, an unambiguous single cross-module definition is used
   (the common "enum lives in a shared module, imported elsewhere"
   case),
3. two or more different-module definitions with no local match are
   genuinely ambiguous - the static parser doesn't track which one, if
   any, was actually imported - so this now surfaces as an
   unsupported-type build error instead of silently picking one.

Threaded the current module path through the type resolver
(`parser/types/resolve.rs`) and argument extraction
(`parser/signatures.rs`), and updated both manifest-build passes
(`parser/build.rs`, `build_fragment.rs`) to pass each file's module
path into `EnumTable::from_module`.

## Test plan

- [x] `cargo test -p toolr-core` - new unit test
      (`colliding_bare_names_resolve_per_module_not_last_merged_wins`)
      and end-to-end `build_static_manifest` regression test
      (`colliding_bare_enum_names_across_modules_resolve_independently`)
      reproducing the issue's exact two-module repro
- [x] `cargo test --workspace` - all green
- [x] `prek run --all-files` - clean (fmt, clippy, mypy, skill-refs
      drift gate)

Fixes #449