### PR TITLE
chore(ci): bump pinned mise to v2026.8.10

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -6,4 +6,4 @@
 #
 # Bump `MISE_VERSION` here to upgrade every workflow's mise install in
 # a single edit. Lockstep with `mise.toml`'s tooling pins.
-MISE_VERSION=v2026.5.18
+MISE_VERSION=v2026.8.10


### PR DESCRIPTION
v2026.5.18 has an aqua-backend bin-path bug (fixed in v2026.6.13,
"list_bin_paths no longer caches transient filesystem existence,
fixing missing uv/uvx shims") that this PR's mise.lock churn just
tripped over. Bump past it and pick up ~3 months of fixes; no
breaking change in v2026.5.19..v2026.8.10 touches anything this repo
uses (checked disable_tools, oci push --tool, npm.use_npm_view,
usage_* task vars, RTX_* plugins, vlang versions, the
unix/windows_default_*_shell_args settings, and conf.d dotted
filenames — none appear in mise.toml or .github/).