### PR TITLE
fix(renovate): split toolr-py versioning from mise/gh-actions regex

### DIFF
--- a/docs/installation/mise.md
+++ b/docs/installation/mise.md
@@ -80,6 +80,13 @@ floating major.minor alias (`v0.30`) pointing at the same commit. Without
 the override, Renovate can resolve the shorter alias and propose `0.30`
 instead of `0.30.0`.
 
+If you also dogfood `toolr-py` from PyPI and want one Renovate rule to
+track both together, keep this `versioning` override on the `mise`
+(and `github-actions`) `matchManagers` only — don't apply it to a `pep621`
+rule in the same group. The regex can't parse a `>=`-style range like
+`toolr-py>=0.25.0`, so a `pep621` dependency matched by it stops getting
+updated at all, silently.
+
 ## Project configuration
 
 ### `.mise.toml` (recommended)

--- a/renovate.json5
+++ b/renovate.json5
@@ -109,36 +109,42 @@
 
     // ---- Keep every in-repo pin of our own release in lockstep ----
     {
-      // We dogfood our own releases in three places, and all three should
-      // move together the moment a new version publishes:
-      //   1. `tools/pyproject.toml` / `tools/uv.lock` — the `toolr-py`
-      //      floor driving the dogfood venv (pep621 manager). Bare name
-      //      alone yields no update, hence the `>=` floor; the lock
-      //      silently drifted to 0.20.1 until 0.25.0 broke dispatch.
-      //      `update-lockfile` keeps the floor and bumps only the lock.
-      //   2. `mise.toml` — the `aqua:s0undt3ch/ToolR` pin driving the
-      //      local `toolr` binary used to run repo automation.
-      //   3. Any `uses: s0undt3ch/ToolR@…` pin in `.github/workflows/`,
-      //      if/when a workflow starts using our own GitHub Action.
-      // One groupName across all three managers means one PR, not one
-      // per file. Override the global weekly schedule so the bump lands
-      // on the next Renovate run after a release publishes (not the
-      // following Monday); `at any time` lifts the PR-timing gate,
-      // detection is still bounded by Renovate's own run cadence — repo
-      // config can't make that instant.
-      description: "Track our own toolr / toolr-py release everywhere ASAP",
+      // `tools/pyproject.toml` / `tools/uv.lock` — the `toolr-py` floor
+      // driving the dogfood venv (pep621 manager). Bare name alone yields
+      // no update, hence the `>=` floor; the lock silently drifted to
+      // 0.20.1 until 0.25.0 broke dispatch. `update-lockfile` keeps the
+      // floor and bumps only the lock. Same `groupName` as the rule below
+      // means one PR across both, not one per file. Override the global
+      // weekly schedule so the bump lands on the next Renovate run after
+      // a release publishes (not the following Monday); `at any time`
+      // lifts the PR-timing gate — detection is still bounded by
+      // Renovate's own run cadence, repo config can't make that instant.
+      description: "Track our own toolr-py release in the dogfood venv ASAP",
       groupName: "toolr release",
-      matchManagers: ["pep621", "mise", "github-actions"],
+      matchManagers: ["pep621"],
+      matchFileNames: ["tools/pyproject.toml", "tools/uv.lock"],
+      matchPackageNames: ["toolr-py"],
+      rangeStrategy: "update-lockfile",
+      schedule: ["at any time"],
+      recreateWhen: "always",
+    },
+    {
+      // Same groupName as above keeps this in the same PR as the toolr-py
+      // lock bump — split into its own rule only because the versioning
+      // override below can't apply to the pep621 rule: `tools/pyproject.toml`
+      // carries a `>=0.25.0` range, and the regex versioning scheme can't
+      // parse a `>=` operator, so applying it there silently stops Renovate
+      // from touching that dependency at all (it happened once already).
+      description: "Track our own toolr release in mise / GH Actions ASAP",
+      groupName: "toolr release",
+      matchManagers: ["mise", "github-actions"],
       matchFileNames: [
-        "tools/pyproject.toml",
-        "tools/uv.lock",
         "mise.toml",
         ".github/workflows/**",
         ".github/actions/**",
         "action.yml",
       ],
-      matchPackageNames: ["toolr-py", "aqua:s0undt3ch/ToolR", "s0undt3ch/ToolR"],
-      rangeStrategy: "update-lockfile",
+      matchPackageNames: ["aqua:s0undt3ch/ToolR", "s0undt3ch/ToolR"],
       // GitHub Releases carry both a full `v0.30.0` tag and a floating
       // `v0.30` major.minor alias pointing at the same commit. Without
       // this, Renovate sometimes resolves the shorter alias and proposes


### PR DESCRIPTION
The shared 'toolr release' packageRule applied a strict major.minor.patch
regex versioning to pep621, mise, and github-actions together. That regex
can't parse the '>=0.25.0' range in tools/pyproject.toml, so Renovate
silently stopped bumping toolr-py in tools/uv.lock after the versioning
override landed — mise/action bumps kept working, the pep621 lockfile
bump didn't. Split into two rules under the same groupName: pep621 keeps
default PEP 440 versioning, mise/github-actions keep the regex override.